### PR TITLE
Reject kind 4 character on the C, C++ and WASM backends

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4777,6 +4777,10 @@ RUN(NAME merge_str_01 LABELS gfortran llvm)
 RUN(NAME io_direct_slash LABELS gfortran llvm)
 RUN(NAME achar_kind_01 LABELS gfortran llvm)
 RUN(NAME char4_string_intrinsics_01 LABELS gfortran llvm)
+RUN(NAME char4_string_intrinsics_02 LABELS gfortran llvm)
+# GFortran treats each source byte of a kind 4 literal as one character,
+# LFortran (like LLVM Flang) decodes the UTF-8 source into code points.
+RUN(NAME char4_string_literal_01 LABELS llvm)
 
 #test for coarray
 RUN(NAME coarray_01 LABELS gfortran GFORTRAN_ARGS -fcoarray=single)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4777,6 +4777,8 @@ RUN(NAME merge_str_01 LABELS gfortran llvm)
 RUN(NAME io_direct_slash LABELS gfortran llvm)
 RUN(NAME achar_kind_01 LABELS gfortran llvm)
 RUN(NAME char4_string_intrinsics_01 LABELS gfortran llvm)
+RUN(NAME char4_io_01 LABELS gfortran llvm)
+RUN(NAME char4_io_02 LABELS gfortran llvm)
 RUN(NAME char4_string_intrinsics_02 LABELS gfortran llvm)
 # GFortran treats each source byte of a kind 4 literal as one character,
 # LFortran (like LLVM Flang) decodes the UTF-8 source into code points.

--- a/integration_tests/char4_io_01.f90
+++ b/integration_tests/char4_io_01.f90
@@ -1,0 +1,73 @@
+program char4_io_01
+    implicit none
+    integer, parameter :: ucs4 = selected_char_kind("ISO_10646")
+    ! U+4F60 and U+597D: three UTF-8 bytes each, so a byte oriented write
+    ! would truncate or mangle them.
+    character(kind=ucs4, len=1), parameter :: ni = char(int(z'4F60'), ucs4)
+    character(kind=ucs4, len=1), parameter :: hao = char(int(z'597D'), ucs4)
+    character(kind=ucs4, len=6) :: greeting
+    character(len=80) :: record
+    integer :: u
+
+    greeting = ucs4_"ab" // ni // hao
+
+    ! Write the value out with ENCODING='UTF-8', then read the file back as
+    ! default characters so the exact bytes can be checked.
+    open(newunit=u, file="char4_io_01_data.txt", status="replace", &
+         encoding="UTF-8", action="write")
+    write(u, '(a)') greeting
+    write(u, '("<",a,">")') trim(greeting)
+    write(u, *) greeting
+    close(u)
+
+    open(newunit=u, file="char4_io_01_data.txt", status="old", action="read")
+
+    ! 'a' with no width writes all six characters: a, b, then the two
+    ! ideographs as three bytes each, then two trailing blanks.
+    read(u, '(a)') record
+    call check_utf8(record, 1, "plain a")
+
+    ! trim() drops the two blanks, so only four characters are written.
+    read(u, '(a)') record
+    if (record(1:1) /= "<") error stop 10
+    call check_utf8(record, 2, "trimmed a")
+    if (record(10:10) /= ">") error stop 11
+
+    ! List directed output writes the same bytes.
+    read(u, '(a)') record
+    call check_utf8(record, 1 + count_leading_blanks(record), "list directed")
+
+    close(u, status="delete")
+
+    print *, "ok"
+
+contains
+
+    integer function count_leading_blanks(s) result(n)
+        character(len=*), intent(in) :: s
+        n = 0
+        do while (n < len(s))
+            if (s(n + 1 : n + 1) /= " ") exit
+            n = n + 1
+        end do
+    end function
+
+    ! Checks that `s`, starting at `start`, holds the UTF-8 bytes of
+    ! "ab" // U+4F60 // U+597D.
+    subroutine check_utf8(s, start, what)
+        character(len=*), intent(in) :: s
+        integer, intent(in) :: start
+        character(len=*), intent(in) :: what
+        integer :: expected(8), i, got
+        ! 'a', 'b', E4 BD A0, E5 A5 BD
+        expected = [97, 98, 228, 189, 160, 229, 165, 189]
+        do i = 1, 8
+            got = ichar(s(start + i - 1 : start + i - 1))
+            if (got /= expected(i)) then
+                print *, "byte", i, "of", what, "is", got, "expected", expected(i)
+                error stop 1
+            end if
+        end do
+    end subroutine
+
+end program

--- a/integration_tests/char4_io_02.f90
+++ b/integration_tests/char4_io_02.f90
@@ -1,0 +1,51 @@
+program char4_io_02
+    implicit none
+    integer, parameter :: ucs4 = selected_char_kind("ISO_10646")
+    ! U+5E74, U+6708 and U+65E5: the Japanese year, month and day characters.
+    character(kind=ucs4, len=1), parameter :: nen = char(int(z'5e74'), ucs4)
+    character(kind=ucs4, len=1), parameter :: gatsu = char(int(z'6708'), ucs4)
+    character(kind=ucs4, len=1), parameter :: nichi = char(int(z'65e5'), ucs4)
+    character(kind=ucs4, len=40) :: line
+    character(kind=ucs4, len=:), allocatable :: grown
+    integer :: u
+
+    ! An internal WRITE into a kind 4 variable must store code units, so the
+    ! result can be measured and indexed as characters afterwards.
+    write(line, '(i0,a,i0,a,i0,a)') 2026, nen, 8, gatsu, 24, nichi
+    if (len_trim(line) /= 10) error stop 1
+    if (line(1:4) /= ucs4_"2026") error stop 2
+    if (ichar(line(5:5), kind=4) /= int(z'5e74')) error stop 3
+    if (line(6:6) /= ucs4_"8") error stop 4
+    if (ichar(line(7:7), kind=4) /= int(z'6708')) error stop 5
+    if (line(8:9) /= ucs4_"24") error stop 6
+    if (ichar(line(10:10), kind=4) /= int(z'65e5')) error stop 7
+
+    ! The same for a shorter record: the tail must be blank padded in
+    ! characters, not in bytes.
+    write(line, '(a,a,a)') nen, gatsu, nichi
+    if (len_trim(line) /= 3) error stop 8
+    if (ichar(line(2:2), kind=4) /= int(z'6708')) error stop 9
+
+    grown = repeat(nichi, 3)
+    if (len(grown) /= 3) error stop 10
+
+    ! Round trip through a UTF-8 file: what is written as code units comes
+    ! back as code units.
+    open(newunit=u, file="char4_io_02_data.txt", status="replace", &
+         encoding="UTF-8", action="write")
+    write(u, '(a)') nen // gatsu // nichi
+    close(u)
+
+    line = ucs4_" "
+    open(newunit=u, file="char4_io_02_data.txt", status="old", &
+         encoding="UTF-8", action="read")
+    read(u, '(a)') line
+    close(u, status="delete")
+
+    if (len_trim(line) /= 3) error stop 11
+    if (ichar(line(1:1), kind=4) /= int(z'5e74')) error stop 12
+    if (ichar(line(2:2), kind=4) /= int(z'6708')) error stop 13
+    if (ichar(line(3:3), kind=4) /= int(z'65e5')) error stop 14
+
+    print *, "ok"
+end program

--- a/integration_tests/char4_string_intrinsics_02.f90
+++ b/integration_tests/char4_string_intrinsics_02.f90
@@ -1,0 +1,90 @@
+program char4_string_intrinsics_02
+    implicit none
+    integer, parameter :: ucs4 = selected_char_kind("ISO_10646")
+    ! U+4F60 and U+597D, two CJK ideographs outside the ASCII range
+    character(kind=ucs4, len=1), parameter :: ni = char(int(z'4F60'), ucs4)
+    character(kind=ucs4, len=1), parameter :: hao = char(int(z'597D'), ucs4)
+    character(kind=ucs4, len=6) :: padded
+    character(kind=ucs4, len=4) :: leading
+    character(kind=ucs4, len=3) :: a, b
+    character(kind=ucs4, len=:), allocatable :: joined
+    integer :: code
+
+    ! Give every variable a value before it is used: the kind inquiries below
+    ! do not depend on the values, but their arguments are still evaluated.
+    padded = ni // hao // ucs4_"    "
+    leading = ucs4_"  " // ni // hao
+    a = ni // hao // ucs4_"!"
+    b = ucs4_"abc"
+
+    ! Every character intrinsic must return a result of the same character
+    ! kind as its argument, not the default kind.
+    if (kind(trim(padded)) /= 4) error stop 1
+    if (kind(adjustl(leading)) /= 4) error stop 2
+    if (kind(adjustr(padded)) /= 4) error stop 3
+    if (kind(repeat(a, 2)) /= 4) error stop 4
+    if (kind(a // b) /= 4) error stop 5
+    if (kind(new_line(a)) /= 4) error stop 6
+    if (kind(char(65, ucs4)) /= 4) error stop 7
+    if (kind(achar(65, ucs4)) /= 4) error stop 8
+
+    ! char() with a non-constant code point and a constant kind must still
+    ! build a four byte character.
+    code = int(z'4F60')
+    if (ichar(char(code, ucs4), kind=4) /= int(z'4F60')) error stop 9
+    if (ichar(achar(code, ucs4), kind=4) /= int(z'4F60')) error stop 10
+
+    ! trim/adjustl/adjustr must count and compare whole characters, so a
+    ! trailing blank of kind 4 is one character wide, not one byte.
+    if (len_trim(padded) /= 2) error stop 11
+    if (len(trim(padded)) /= 2) error stop 12
+    if (trim(padded) /= ni // hao) error stop 13
+
+    if (len_trim(adjustl(leading)) /= 2) error stop 14
+    if (adjustl(leading) /= ni // hao // ucs4_"  ") error stop 15
+    if (adjustr(ni // hao // ucs4_"  ") /= ucs4_"  " // ni // hao) error stop 16
+
+    ! Concatenation of two run time values keeps the kind and the length.
+    joined = a // b
+    if (len(joined) /= 6) error stop 17
+    if (kind(joined) /= 4) error stop 18
+    if (ichar(joined(1:1), kind=4) /= int(z'4F60')) error stop 19
+    if (ichar(joined(2:2), kind=4) /= int(z'597D')) error stop 20
+    if (joined(4:6) /= ucs4_"abc") error stop 21
+
+    if (repeat(ni, 3) /= ni // ni // ni) error stop 22
+    if (len(repeat(ni, 3)) /= 3) error stop 23
+
+    ! index/scan/verify report character positions, not byte offsets.
+    if (index(padded, hao) /= 2) error stop 24
+    if (scan(padded, hao) /= 2) error stop 25
+    if (verify(padded, ni // hao // ucs4_" ") /= 0) error stop 26
+    if (index(padded, ni // hao) /= 1) error stop 27
+
+    call check_folded()
+
+    print *, "ok"
+
+contains
+
+    ! The same properties, but computed at compile time: constant folding must
+    ! use the same character counts as the generated code.
+    subroutine check_folded()
+        character(kind=ucs4, len=6), parameter :: cpadded = ni // hao // ucs4_"    "
+        character(kind=ucs4, len=4), parameter :: clead = ucs4_"  " // ni // hao
+        if (len(cpadded) /= 6) error stop 31
+        if (len_trim(cpadded) /= 2) error stop 32
+        if (len(trim(cpadded)) /= 2) error stop 33
+        if (trim(cpadded) /= ni // hao) error stop 34
+        if (ichar(ni, kind=4) /= int(z'4F60')) error stop 35
+        if (len(ni // hao) /= 2) error stop 36
+        if (len_trim(adjustl(clead)) /= 2) error stop 37
+        if (adjustl(clead) /= ni // hao // ucs4_"  ") error stop 38
+        if (adjustr(cpadded) /= ucs4_"    " // ni // hao) error stop 39
+        if (len(repeat(ni, 3)) /= 3) error stop 40
+        if (index(cpadded, hao) /= 2) error stop 41
+        if (scan(cpadded, hao) /= 2) error stop 42
+        if (verify(cpadded, ni // hao // ucs4_" ") /= 0) error stop 43
+    end subroutine
+
+end program

--- a/integration_tests/char4_string_literal_01.f90
+++ b/integration_tests/char4_string_literal_01.f90
@@ -1,0 +1,21 @@
+program char4_string_literal_01
+    implicit none
+    integer, parameter :: ucs4 = selected_char_kind("ISO_10646")
+    ! A kind 4 literal written directly in the (UTF-8) source is decoded into
+    ! code points, so its length is a count of characters. This matches LLVM
+    ! Flang; GFortran instead treats each source byte as one character, so this
+    ! test is not run against GFortran.
+    character(kind=ucs4, len=*), parameter :: greeting = ucs4_"你好"
+    character(kind=ucs4, len=:), allocatable :: copy
+
+    if (len(greeting) /= 2) error stop 1
+    if (ichar(greeting(1:1), kind=4) /= int(z'4F60')) error stop 2
+    if (ichar(greeting(2:2), kind=4) /= int(z'597D')) error stop 3
+    if (greeting /= char(int(z'4F60'), ucs4) // char(int(z'597D'), ucs4)) error stop 4
+
+    copy = greeting
+    if (len(copy) /= 2) error stop 5
+    if (len_trim(greeting // ucs4_"  ") /= 2) error stop 6
+
+    print *, "ok"
+end program

--- a/integration_tests/print_12.f90
+++ b/integration_tests/print_12.f90
@@ -3,10 +3,34 @@ program print_12
     implicit none
 
     integer, parameter :: ucs4 = selected_char_kind('ISO_10646')
+    character(kind=ucs4, len=:), allocatable :: greeting
+    character(len=80) :: record
+    integer :: u, i
+    ! "Hello = Ni Hao = " followed by the UTF-8 bytes of U+4F60 and U+597D
+    integer, parameter :: tail(6) = [228, 189, 160, 229, 165, 189]
 
     if (ucs4 /= 4) error stop
 
-    open(output_unit, encoding='UTF-8')
-    print *, ucs4_'Hello = Ni Hao = ' // &
+    greeting = ucs4_'Hello = Ni Hao = ' // &
          char(int(z'4F60'), ucs4) // char(int(z'597D'), ucs4)
+    if (len(greeting) /= 19) error stop 1
+
+    open(output_unit, encoding='UTF-8')
+    print *, greeting
+
+    ! Write the same value to a file and read it back as default characters,
+    ! so the bytes that reach the stream can be checked.
+    open(newunit=u, file='print_12_data.txt', status='replace', &
+         encoding='UTF-8', action='write')
+    write(u, '(a)') greeting
+    close(u)
+
+    open(newunit=u, file='print_12_data.txt', status='old', action='read')
+    read(u, '(a)') record
+    close(u, status='delete')
+
+    if (record(1:17) /= 'Hello = Ni Hao = ') error stop 2
+    do i = 1, 6
+        if (ichar(record(17 + i : 17 + i)) /= tail(i)) error stop 3
+    end do
 end program print_12

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -918,6 +918,18 @@ inline static void set_intrinsic_return_kind(Allocator& al, const Location& loc,
     }
 }
 
+inline static std::string cmpop_to_str(ASR::cmpopType op) {
+    switch (op) {
+        case (ASR::cmpopType::Eq): return "==";
+        case (ASR::cmpopType::NotEq): return "/=";
+        case (ASR::cmpopType::Lt): return "<";
+        case (ASR::cmpopType::LtE): return "<=";
+        case (ASR::cmpopType::Gt): return ">";
+        case (ASR::cmpopType::GtE): return ">=";
+        default: return "";
+    }
+}
+
 inline static void visit_Compare(Allocator &al, const AST::Compare_t &x,
                                    ASR::expr_t *&left, ASR::expr_t *&right,
                                    ASR::asr_t *&asr, std::string& intrinsic_op_name,
@@ -1072,6 +1084,20 @@ inline static void visit_Compare(Allocator &al, const AST::Compare_t &x,
     }
 
     if( overloaded == nullptr ) {
+        if (ASRUtils::is_character(*left_type2) && ASRUtils::is_character(*right_type2)) {
+            int64_t left_kind = ASRUtils::extract_kind_from_ttype_t(left_type2);
+            int64_t right_kind = ASRUtils::extract_kind_from_ttype_t(right_type2);
+            if (left_kind != right_kind) {
+                diag.add(diag::Diagnostic(
+                    "operands of comparison operator '" + cmpop_to_str(asr_op) +
+                    "' must be character with the same kind, found character(" +
+                    std::to_string(left_kind) + ") and character(" +
+                    std::to_string(right_kind) + ")",
+                    Level::Error, Stage::Semantic, {
+                    diag::Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
+            }
+        }
         if (!ASRUtils::check_equal_type(ASRUtils::expr_type(left),
                                     ASRUtils::expr_type(right), left, right)) {
             diag.add(diag::Diagnostic(
@@ -19541,6 +19567,16 @@ public:
 
         if( ASR::is_a<ASR::String_t>(*left_type) &&
             ASR::is_a<ASR::String_t>(*right_type) ) { // CreateIntrinisc `stringConcat`
+            int64_t left_kind = ASR::down_cast<ASR::String_t>(left_type)->m_kind;
+            int64_t right_kind = ASR::down_cast<ASR::String_t>(right_type)->m_kind;
+            if (left_kind != right_kind) {
+                diag.add(Diagnostic(
+                    "operands of // must be character with the same kind, "
+                    "found character(" + std::to_string(left_kind) + ") and character("
+                    + std::to_string(right_kind) + ")",
+                    Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+                throw SemanticAbort();
+            }
             Vec<ASR::expr_t*> v; v.reserve(al, 1);
             v.push_back(al, left);
             v.push_back(al, right);
@@ -19767,6 +19803,12 @@ public:
                     throw SemanticAbort();
                 }
             }
+        }
+        if (!ASRUtils::is_supported_character_kind(kind)) {
+            diag.add(Diagnostic("kind " + std::to_string(kind) +
+                " is not supported for character, only 1 and 4 are",
+                Level::Error, Stage::Semantic, {Label("", {x.base.base.loc})}));
+            throw SemanticAbort();
         }
         if (kind > 1) {
             s_len = (int)utf8_codepoint_count(x.m_s);
@@ -20928,6 +20970,14 @@ public:
                 this->visit_expr(*kind_item->m_value);
                 ASR::expr_t* kind_expr = ASRUtils::EXPR(tmp);
                 str->m_kind = ASRUtils::extract_kind<SemanticAbort>(kind_expr, kind_item->loc, diag);
+                if (!ASRUtils::is_supported_character_kind(str->m_kind)) {
+                    diag.add(diag::Diagnostic(
+                        "kind " + std::to_string(str->m_kind) +
+                        " is not supported for character, only 1 and 4 are",
+                        Level::Error, Stage::Semantic, {
+                        diag::Label("", {kind_item->loc})}));
+                    throw SemanticAbort();
+                }
                 str->m_physical_type = ASR::DescriptorString;
             }
         } else {

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -422,11 +422,15 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
         value = ASRUtils::EXPR(ASR::make_StringConstant_t(al, x.base.base.loc, x.m_s, x.m_type));
     }
 
+    // Substring bounds are character positions. For kind > 1 the value holds
+    // UTF-8, so one character can span several bytes and the value has to be
+    // sliced character by character.
     void visit_StringSection(const ASR::StringSection_t &x) {
         this->visit_expr(*x.m_arg);
-        char* str_val = ASR::down_cast<ASR::StringConstant_t>(value)->m_s;
-        std::string str(str_val);
-        int start = 1, end = (int)str.size();
+        ASR::StringConstant_t* str_const = ASR::down_cast<ASR::StringConstant_t>(value);
+        std::vector<std::string> characters = ASRUtils::string_value_characters(
+            str_const->m_s, ASRUtils::extract_kind_from_ttype_t(str_const->m_type));
+        int start = 1, end = (int)characters.size();
         if (x.m_start) {
             this->visit_expr(*x.m_start);
             start = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
@@ -435,18 +439,22 @@ class ImpliedDoLoopValuesVisitor : public ASR::BaseWalkVisitor<ImpliedDoLoopValu
             this->visit_expr(*x.m_end);
             end = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
         }
-        int len = end - start + 1;
-        std::string result = len > 0 ? str.substr(start - 1, len) : "";
+        std::string result;
+        for (int i = start; i <= end && i <= (int)characters.size(); i++) {
+            result += characters[i - 1];
+        }
         value = ASRUtils::EXPR(ASR::make_StringConstant_t(al, x.base.base.loc,
             s2c(al, result), x.m_type));
     }
 
     void visit_StringItem(const ASR::StringItem_t &x) {
         this->visit_expr(*x.m_arg);
-        char* str_val = ASR::down_cast<ASR::StringConstant_t>(value)->m_s;
+        ASR::StringConstant_t* str_const = ASR::down_cast<ASR::StringConstant_t>(value);
+        std::vector<std::string> characters = ASRUtils::string_value_characters(
+            str_const->m_s, ASRUtils::extract_kind_from_ttype_t(str_const->m_type));
         this->visit_expr(*x.m_idx);
         int idx = ASR::down_cast<ASR::IntegerConstant_t>(value)->m_n;
-        std::string result(1, str_val[idx - 1]);
+        std::string result = characters[idx - 1];
         value = ASRUtils::EXPR(ASR::make_StringConstant_t(al, x.base.base.loc,
             s2c(al, result), x.m_type));
     }
@@ -10910,8 +10918,17 @@ public:
                     if( end == -1 && !flag ) {
                         end = str_length;
                     } else {
+                        // Substring bounds are character positions. For kind > 1
+                        // the value holds UTF-8, so slice whole characters.
+                        std::vector<std::string> characters =
+                            ASRUtils::string_value_characters(m_str->m_s, s_type->m_kind);
+                        // An initializer shorter than the declared length is
+                        // blank padded, so the value has `str_length` characters.
+                        characters.resize(str_length, " ");
+                        int64_t sliced_len = 0;
                         for( int i = start - 1; i < end; i += step ) {
-                            sliced_str.push_back(m_str->m_s[i]);
+                            sliced_str += characters[i];
+                            sliced_len++;
                         }
                         Str l_str;
                         l_str.from_str(al, sliced_str);
@@ -10919,7 +10936,7 @@ public:
                             ASRUtils::TYPE(ASR::make_String_t(al, loc, ASRUtils::extract_kind_from_ttype_t(root_v_type), 
                                 ASRUtils::EXPR(
                                     ASR::make_IntegerConstant_t(
-                                        al, loc, sliced_str.size(),
+                                        al, loc, sliced_len,
                                         ASRUtils::TYPE(ASR::make_Integer_t(al, loc, compiler_options.po.default_integer_kind))
                                     )
                                 ),
@@ -19700,6 +19717,9 @@ public:
     void visit_String(const AST::String_t &x) {
         int s_len = strlen(x.m_s);
         int kind = 1;
+        // `s_len` is fixed up below once `kind` is known: a kind > 1 literal
+        // holds UTF-8 in ASR, so its Fortran length is the number of code
+        // points, not the number of bytes.
         if (x.m_kind) {
             kind = std::atoi(x.m_kind);
             if (kind == 0) {
@@ -19747,6 +19767,9 @@ public:
                     throw SemanticAbort();
                 }
             }
+        }
+        if (kind > 1) {
+            s_len = (int)utf8_codepoint_count(x.m_s);
         }
         ASR::ttype_t *type = ASRUtils::TYPE(ASR::make_String_t(al, x.base.base.loc, kind, 
             ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, x.base.base.loc, s_len,

--- a/src/libasr/asr_builder.h
+++ b/src/libasr/asr_builder.h
@@ -376,8 +376,17 @@ class ASRBuilder {
         return EXPR(ASR::make_StringSection_t(al, loc, s, start, end, i32(1), string_type, nullptr));
     }
 
+    // A single character of `x` has the same character kind as `x` itself.
     inline ASR::expr_t* StringItem(ASR::expr_t* x, ASR::expr_t* idx) {
-        return EXPR(ASR::make_StringItem_t(al, loc, x, idx, character(1), nullptr));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x));
+        return EXPR(ASR::make_StringItem_t(al, loc, x, idx,
+            String(i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind), nullptr));
+    }
+
+    // A blank of the given character kind, for padding and trimming.
+    inline ASR::expr_t* StringBlank(int char_kind) {
+        return StringConstant(" ",
+            String(i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind));
     }
 
     inline ASR::expr_t* StringConstant(std::string s, ASR::ttype_t* type) {

--- a/src/libasr/asr_text.cpp
+++ b/src/libasr/asr_text.cpp
@@ -19,51 +19,11 @@
 #include <libasr/asr_text_parser.h>
 #include <libasr/asr_text_visitor.h>
 #include <libasr/asr_utils.h>
+#include <libasr/string_utils.h>
 
 namespace LCompilers {
 
 namespace {
-
-// Returns true if `value` is well-formed UTF-8: the encoding the text format
-// is defined in. Overlong forms, surrogates and out-of-range code points are
-// rejected, so a value that survives this check can be written as a string.
-bool is_valid_utf8(const char *value, size_t size) {
-    size_t i = 0;
-    while (i < size) {
-        const unsigned char c = static_cast<unsigned char>(value[i]);
-        size_t length;
-        uint32_t code_point;
-        if (c < 0x80) {
-            i++;
-            continue;
-        } else if ((c & 0xe0) == 0xc0) {
-            length = 2;
-            code_point = c & 0x1f;
-        } else if ((c & 0xf0) == 0xe0) {
-            length = 3;
-            code_point = c & 0x0f;
-        } else if ((c & 0xf8) == 0xf0) {
-            length = 4;
-            code_point = c & 0x07;
-        } else {
-            return false;
-        }
-        if (i + length > size) return false;
-        for (size_t k = 1; k < length; k++) {
-            const unsigned char cont =
-                static_cast<unsigned char>(value[i + k]);
-            if ((cont & 0xc0) != 0x80) return false;
-            code_point = (code_point << 6) | (cont & 0x3f);
-        }
-        if (length == 2 && code_point < 0x80) return false;
-        if (length == 3 && code_point < 0x800) return false;
-        if (length == 4 && code_point < 0x10000) return false;
-        if (code_point > 0x10ffff) return false;
-        if (code_point >= 0xd800 && code_point <= 0xdfff) return false;
-        i += length;
-    }
-    return true;
-}
 
 std::string byte_hex(const uint8_t *bytes, size_t size) {
     static const char digits[] = "0123456789abcdef";
@@ -129,7 +89,7 @@ class ASRTextWriter
     // byte into a two byte character. Such values are written as #asr/bytes
     // instead, which keeps the document valid UTF-8 and byte exact.
     void write_escaped_string(const char *value, size_t size) {
-        if (!is_valid_utf8(value, size)) {
+        if (!LCompilers::is_valid_utf8(value, size)) {
             write_bytes(value, size);
             return;
         }

--- a/src/libasr/asr_text_parser.cpp
+++ b/src/libasr/asr_text_parser.cpp
@@ -8,6 +8,7 @@
 #include <set>
 
 #include <libasr/asr_text_parser.h>
+#include <libasr/string_utils.h>
 
 namespace LCompilers::ASRText {
 
@@ -49,59 +50,6 @@ bool is_token_terminator(unsigned char c) {
 
 bool is_ascii_digit(unsigned char c) {
     return c >= '0' && c <= '9';
-}
-
-// Appends the UTF-8 encoding of a BMP code point that is not a surrogate.
-void append_utf8(std::string &out, uint32_t cp) {
-    if (cp <= 0x7F) {
-        out += static_cast<char>(cp);
-    } else if (cp <= 0x7FF) {
-        out += static_cast<char>(0xC0 | (cp >> 6));
-        out += static_cast<char>(0x80 | (cp & 0x3F));
-    } else {
-        out += static_cast<char>(0xE0 | (cp >> 12));
-        out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
-        out += static_cast<char>(0x80 | (cp & 0x3F));
-    }
-}
-
-bool is_well_formed_utf8(const std::string &text) {
-    size_t i = 0;
-    const size_t size = text.size();
-    while (i < size) {
-        const unsigned char c = static_cast<unsigned char>(text[i]);
-        size_t length;
-        uint32_t code_point;
-        if (c < 0x80) {
-            i++;
-            continue;
-        } else if ((c & 0xe0) == 0xc0) {
-            length = 2;
-            code_point = c & 0x1f;
-        } else if ((c & 0xf0) == 0xe0) {
-            length = 3;
-            code_point = c & 0x0f;
-        } else if ((c & 0xf8) == 0xf0) {
-            length = 4;
-            code_point = c & 0x07;
-        } else {
-            return false;
-        }
-        if (i + length > size) return false;
-        for (size_t k = 1; k < length; k++) {
-            const unsigned char cont =
-                static_cast<unsigned char>(text[i + k]);
-            if ((cont & 0xc0) != 0x80) return false;
-            code_point = (code_point << 6) | (cont & 0x3f);
-        }
-        if (length == 2 && code_point < 0x80) return false;
-        if (length == 3 && code_point < 0x800) return false;
-        if (length == 4 && code_point < 0x10000) return false;
-        if (code_point > 0x10ffff) return false;
-        if (code_point >= 0xd800 && code_point <= 0xdfff) return false;
-        i += length;
-    }
-    return true;
 }
 
 bool hex_digit_value(char c, int &value) {
@@ -498,7 +446,7 @@ private:
                                     span_loc(esc_start, pos - 1),
                                     "surrogate escapes are not valid UTF-8");
                         }
-                        append_utf8(buffer, cp);
+                        utf8_encode_codepoint(buffer, cp);
                         break;
                     }
                     default:
@@ -512,7 +460,7 @@ private:
             }
         }
         Location loc = span_loc(start, pos - 1);
-        if (!is_well_formed_utf8(buffer)) {
+        if (!is_valid_utf8(buffer)) {
             return fail("string literal is not well-formed UTF-8",
                     loc, "invalid UTF-8 in this string");
         }

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3149,6 +3149,13 @@ static inline int64_t string_first_code_point(ASR::StringConstant_t* s) {
     return (int64_t)code_points[0];
 }
 
+// The character kinds the compiler supports: 1 (one byte per character,
+// ASCII / the default kind) and 4 (four bytes per character, ISO 10646 /
+// UCS-4). This matches GFortran; LLVM Flang additionally supports 2 (UCS-2).
+static inline bool is_supported_character_kind(int64_t kind) {
+    return kind == 1 || kind == 4;
+}
+
 static inline bool is_complex(ASR::ttype_t &x) {
     return ASR::is_a<ASR::Complex_t>(
         *type_get_past_array(

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -3121,6 +3121,34 @@ static inline bool is_character(ASR::ttype_t &x) {
                 type_get_past_pointer(&x))));
 }
 
+// The Fortran characters of a compile time string value: one entry per
+// character. A kind 1 value stores one byte per character, while a kind > 1
+// value stores UTF-8 in `StringConstant::m_s`, so one entry can span several
+// bytes.
+static inline std::vector<std::string> string_value_characters(
+        const char* s, int64_t kind) {
+    std::string str(s);
+    if (kind == 1) {
+        std::vector<std::string> characters;
+        characters.reserve(str.size());
+        for (char c : str) characters.push_back(std::string(1, c));
+        return characters;
+    }
+    return utf8_split(str);
+}
+
+// The Unicode code point of the first character of a compile time string
+// value, i.e. the result of ICHAR/IACHAR applied to it. A kind 1 value yields
+// the byte, a kind > 1 value the code point its UTF-8 encodes.
+static inline int64_t string_first_code_point(ASR::StringConstant_t* s) {
+    int64_t kind = extract_kind_from_ttype_t(s->m_type);
+    if (s->m_s[0] == '\0') return 0;
+    if (kind == 1) return (int64_t)(unsigned char)s->m_s[0];
+    std::vector<uint32_t> code_points = utf8_decode(std::string(s->m_s));
+    LCOMPILERS_ASSERT(code_points.size() >= 1);
+    return (int64_t)code_points[0];
+}
+
 static inline bool is_complex(ASR::ttype_t &x) {
     return ASR::is_a<ASR::Complex_t>(
         *type_get_past_array(

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -2937,6 +2937,9 @@ public:
     }
 
     void visit_String(const String_t &x){
+/*Check the character kind*/
+        require(ASRUtils::is_supported_character_kind(x.m_kind),
+            "String kind must be 1 or 4, found " + std::to_string(x.m_kind));
 /*General Check on the length*/ 
         if(x.m_len){
             require(ASR::is_a<ASR::Integer_t>(*ASRUtils::type_get_past_pointer(

--- a/src/libasr/codegen/asr_to_c.cpp
+++ b/src/libasr/codegen/asr_to_c.cpp
@@ -430,6 +430,16 @@ public:
                 convert_variable_decl_util(v, is_array, declare_as_constant, use_ref, dummy,
                     force_declare, force_declare_name, n_dims, m_dims, v_m_type, dims, sub);
             } else if (ASRUtils::is_character(*v_m_type)) {
+                // The C backend represents a character value as a byte string,
+                // so it can only carry kind 1. A kind 4 value is four byte code
+                // units, which `char *`, `strlen` and `strcmp` would all read
+                // as bytes.
+                int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(v_m_type);
+                if (char_kind != 1) {
+                    throw CodeGenError("character(kind=" + std::to_string(char_kind) +
+                        ") is not supported by the C backend, only kind 1 is",
+                        v.base.base.loc);
+                }
                 bool is_fixed_size = true;
                 dims = convert_dims_c(n_dims, m_dims, v_m_type, is_fixed_size);
                 sub = format_type_c(dims, "char *", v.m_name, use_ref, dummy);

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -289,6 +289,13 @@ public:
                 dims = convert_dims(n_dims, m_dims, size);
                 sub = format_type(dims, "bool", v.m_name, use_ref, dummy);
             } else if (ASRUtils::is_character(*v.m_type)) {
+                // std::string is a byte string, so it can only carry kind 1.
+                int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(v.m_type);
+                if (char_kind != 1) {
+                    throw CodeGenError("character(kind=" + std::to_string(char_kind) +
+                        ") is not supported by the C++ backend, only kind 1 is",
+                        v.base.base.loc);
+                }
                 size_t size;
                 extract_dimensions(v.m_type)
                 dims = convert_dims(n_dims, m_dims, size);

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -18990,16 +18990,25 @@ public:
         constexpr int32_t kInt64 = 3;
         constexpr int32_t kFloat = 4;
         constexpr int32_t kDouble = 5;
+        constexpr int32_t kWideChar = 8;
 
         // Scalar arg: prepend is_descriptor_array=0 before type_code
         llvm::Value* is_descriptor_array_false = llvm::ConstantInt::get(context, llvm::APInt(32, 0));
         if (ASR::is_a<ASR::String_t>(*val_type)) {
+            // A destination of character kind > 1 uses its own type code and
+            // carries the kind, so the runtime knows the field has to be
+            // decoded into code units.
+            int64_t char_kind = ASR::down_cast<ASR::String_t>(val_type)->m_kind;
             args.push_back(is_descriptor_array_false);
-            args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32, kChar)));
+            args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32,
+                char_kind > 1 ? kWideChar : kChar)));
             auto [str_data, str_len] = llvm_utils->get_string_length_data(
                 ASRUtils::get_string_type(val_type), elem_ptr, true);
             args.push_back(str_data);
             args.push_back(str_len);
+            if (char_kind > 1) {
+                args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32, char_kind)));
+            }
         } else if (ASR::is_a<ASR::Logical_t>(*val_type)) {
             args.push_back(is_descriptor_array_false);
             args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32, kLogical)));
@@ -21028,7 +21037,8 @@ public:
                     end_data = LCompilers::create_global_string_ptr(context, *module, *builder, "\n");
                     end_len = llvm::ConstantInt::get(context, llvm::APInt(32, 1));
                 }
-                printf(context, *module, *builder, { fmt_ptr, str_data, str_len, end_data, end_len });
+                llvm::Value* str_kind = llvm::ConstantInt::get(context, llvm::APInt(32, 1));
+                printf(context, *module, *builder, { fmt_ptr, str_data, str_len, str_kind, end_data, end_len });
             } else if (x.n_values == 1){
                 handle_print(x.m_values[0], x.m_end);
             } else {
@@ -21058,6 +21068,7 @@ public:
             args_type.push_back(llvm::Type::getInt8Ty(context)); // is_allocatable
             args_type.push_back(llvm::Type::getInt8Ty(context)); // is_deferred
             args_type.push_back(llvm::Type::getInt8Ty(context)); // is_array_unit
+            args_type.push_back(llvm::Type::getInt32Ty(context)); // char_kind
             args_type.push_back(llvm::Type::getInt64Ty(context)); // array_size
             args_type.push_back(llvm::Type::getInt64Ty(context)->getPointerTo()); //len
             args_type.push_back(llvm::Type::getInt32Ty(context)->getPointerTo()); //iostat
@@ -21432,14 +21443,25 @@ public:
                 }
                 continue;
             }
+            ASR::ttype_t *t = ASRUtils::extract_type(ASRUtils::expr_type(m_values[i]));
+            bool value_is_wide_char = x.m_is_formatted && ASRUtils::is_character(*t) &&
+                ASRUtils::extract_kind_from_ttype_t(t) > 1;
             compute_fmt_specifier_and_arg(fmt, args, m_values[i],
                 x.base.base.loc); // return of visited expression `m_values[i]` stored in `tmp`
+            if (value_is_wide_char) {
+                // `%S` takes (data, character count, character kind): the
+                // runtime transcodes the code units to UTF-8 on the way out.
+                fmt.back() = "%S";
+            }
 
             // Push the length of the string to args
-            ASR::ttype_t *t = ASRUtils::extract_type(ASRUtils::expr_type(m_values[i]));
             if (x.m_is_formatted && ASRUtils::is_character(*t)) {
                 llvm::Value *str_len = llvm_utils->get_string_length(ASRUtils::get_string_type(t), tmp);
                 args.push_back(str_len);
+                if (value_is_wide_char) {
+                    args.push_back(llvm::ConstantInt::get(context, llvm::APInt(32,
+                        ASRUtils::extract_kind_from_ttype_t(t))));
+                }
             }
         }
         if (!x.m_is_formatted) {  // give -1 argument for end of arguments
@@ -21474,9 +21496,15 @@ public:
                 ASRUtils::is_deferredLength_string(ASRUtils::expr_type(x.m_unit))));
             llvm::Value* is_array_unit = llvm::ConstantInt::get(context, llvm::APInt(8,
                 is_string_array_unit));
+            // The internal file's character kind: the formatted record is
+            // produced as UTF-8 bytes, so a kind 4 target needs it decoded
+            // back into code units.
+            llvm::Value* char_kind = llvm::ConstantInt::get(context, llvm::APInt(32,
+                ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(x.m_unit))));
             printf_args.push_back(is_allocatable);
             printf_args.push_back(is_deferred);
             printf_args.push_back(is_array_unit);
+            printf_args.push_back(char_kind);
             printf_args.push_back(string_array_size);
             printf_args.push_back(string_len);
         }
@@ -21519,7 +21547,7 @@ public:
         ( ) --> Struct
         I   --> Integer
         R   --> Real
-        S-PhysicalType-len? --> Character [S-DESC-10, S-CCHAR-1, S-DESC]
+        S-PhysicalType-K<kind>-len? --> Character [S-DESC-K1-10, S-CCHAR-K1-1, S-DESC-K4]
         L   --> Logical
         { } --> Struct for COMPLEX
         The serialization corresponds to how these arguments are represented in LLVM backend;
@@ -21546,6 +21574,10 @@ public:
             if(str_type->m_physical_type == ASR::DescriptorString) res += "DESC";
             else if(str_type->m_physical_type == ASR::CChar) res +="CCHAR";
             else throw LCompilersException("Unhandled string physical type");
+            // The character kind tells the runtime how many bytes one character
+            // occupies, so that it can transcode a kind 4 value to UTF-8 and
+            // count field widths in characters rather than bytes.
+            res += "-K" + std::to_string(str_type->m_kind);
             int len;
             if(ASRUtils::extract_value(str_type->m_len, len)){res += "-" + std::to_string(len);}
         } else if (ASR::is_a<ASR::Complex_t>(*type)){
@@ -21753,11 +21785,17 @@ public:
         }
 
         std::string fmt_str;
+        // The character kind of the value being written. `main_len` counts
+        // characters, so the runtime needs the kind to know how many bytes
+        // that is and whether to transcode to UTF-8 on the way out.
+        llvm::Value* main_kind = llvm::ConstantInt::get(context, llvm::APInt(32, 1));
 
         if (ASRUtils::is_character(*t)) {
             // --- String path ---
             std::tie(main_data, main_len) = get_string_data_and_length(arg);
             main_len = builder->CreateTrunc(main_len, llvm::Type::getInt32Ty(context));
+            main_kind = llvm::ConstantInt::get(context, llvm::APInt(32,
+                ASRUtils::extract_kind_from_ttype_t(ASRUtils::extract_type(t))));
             fmt_str = "%s";
         } else {
             // --- Non-string path ---
@@ -21780,7 +21818,7 @@ public:
         }
         fmt_str += "%s";
         llvm::Value* fmt_ptr = LCompilers::create_global_string_ptr(context, *module, *builder, fmt_str);
-        printf(context, *module, *builder, { fmt_ptr, main_data, main_len, end_data, end_len });
+        printf(context, *module, *builder, { fmt_ptr, main_data, main_len, main_kind, end_data, end_len });
         llvm_utils->stringFormat_return.free();
     }
 

--- a/src/libasr/codegen/asr_to_wasm.cpp
+++ b/src/libasr/codegen/asr_to_wasm.cpp
@@ -944,7 +944,9 @@ class ASRToWASMVisitor : public ASR::BaseVisitor<ASRToWASMVisitor> {
                         type_vec.push_back(i32);
                     } else {
                         throw CodeGenError(
-                            "Strings of kind 1 only supported");
+                            "character(kind=" + std::to_string(v_int->m_kind) +
+                            ") is not supported by the WASM backend, only kind 1 is",
+                            v->base.base.loc);
                     }
                 }
             } else if (ASRUtils::is_complex(*ttype)) {

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2,6 +2,7 @@
 #include <libasr/codegen/llvm_utils.h>
 #include <libasr/codegen/llvm_array_utils.h>
 #include <libasr/asr_utils.h>
+#include <libasr/string_utils.h>
 #include <libasr/codegen/llvm_compat.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -2901,49 +2902,6 @@ namespace LCompilers {
             throw LCompilersException("Unhandled case");
         }
     }
-    /*
-     * Decodes a UTF-8 encoded string into a sequence of Unicode codepoints,
-     * then serializes each codepoint into `kind`-width little-endian bytes.
-     *   kind=2 -> 2 bytes per codepoint (UCS-2 / UTF-16 code unit)
-     *   kind=4 -> 4 bytes per codepoint (UCS-4 / UTF-32)
-     */
-    static std::vector<uint8_t> utf8_to_unicode_bytes(const std::string& str, int kind) {
-        std::vector<uint32_t> codepoints;
-        size_t i = 0;
-        while (i < str.length()) {
-            uint32_t codepoint = 0;
-            unsigned char c = str[i];
-            if (c <= 0x7F) {
-                codepoint = c;
-                i += 1;
-            } else if ((c & 0xE0) == 0xC0) {
-                LCOMPILERS_ASSERT(i + 1 < str.length());
-                codepoint = ((c & 0x1F) << 6) | (str[i + 1] & 0x3F);
-                i += 2;
-            } else if ((c & 0xF0) == 0xE0) {
-                LCOMPILERS_ASSERT(i + 2 < str.length());
-                codepoint = ((c & 0x0F) << 12) | ((str[i + 1] & 0x3F) << 6) | (str[i + 2] & 0x3F);
-                i += 3;
-            } else if ((c & 0xF8) == 0xF0) {
-                LCOMPILERS_ASSERT(i + 3 < str.length());
-                codepoint = ((c & 0x07) << 18) | ((str[i + 1] & 0x3F) << 12) | ((str[i + 2] & 0x3F) << 6) | (str[i + 3] & 0x3F);
-                i += 4;
-            } else {
-                LCOMPILERS_ASSERT(false); // Invalid UTF-8 lead byte
-            }
-            codepoints.push_back(codepoint);
-        }
-        // Serialize codepoints into kind-width little-endian bytes
-        std::vector<uint8_t> bytes(codepoints.size() * kind);
-        for (size_t idx = 0; idx < codepoints.size(); ++idx) {
-            uint32_t cp = codepoints[idx];
-            for (int b = 0; b < kind; ++b) {
-                bytes[idx * kind + b] = (cp >> (8 * b)) & 0xFF;
-            }
-        }
-        return bytes;
-    }
-
     llvm::Value* LLVMUtils::declare_global_string(
         ASR::String_t* str, std::string initial_data, bool is_const, std::string name,
         llvm::GlobalValue::LinkageTypes linkage,
@@ -2990,7 +2948,7 @@ namespace LCompilers {
                         initial_data_padded.resize(len, ' ');
                         const_data_as_array = llvm::ConstantDataArray::getString(context, initial_data_padded, false);
                     } else if (kind == 2 || kind == 4) {
-                        std::vector<uint8_t> bytes = utf8_to_unicode_bytes(initial_data_padded, kind);
+                        std::vector<uint8_t> bytes = LCompilers::utf8_to_unicode_bytes(initial_data_padded, kind);
                         size_t orig_count = bytes.size() / kind;
                         bytes.resize(len * kind, 0x00);
                         // Pad remaining slots with space character (0x20)

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -113,6 +113,7 @@ class ASRToLLVMVisitor;
                     llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(context)),  // format
                     llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(context)),  // str
                     llvm::Type::getInt32Ty(context),                               // str_len
+                    llvm::Type::getInt32Ty(context),                               // str_kind
                     llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(context)),  // end
                     llvm::Type::getInt32Ty(context)                                // end_len
                 },

--- a/src/libasr/intrinsic_func_registry_util_gen.py
+++ b/src/libasr/intrinsic_func_registry_util_gen.py
@@ -729,7 +729,8 @@ intrinsic_funcs_args = {
     "NewLine": [
         {
             "args": [("char",)],
-            "return": "character(1)"
+            "return": "character(1)",
+            "char_kind_from_arg": 0
         }
     ],
     "Range": [
@@ -938,7 +939,8 @@ intrinsic_funcs_args = {
         {
             "args": [("char",)],
             "return" : "allocatable_deferred_string()",
-            "allow_polymorphic_arg": [0]
+            "allow_polymorphic_arg": [0],
+            "char_kind_from_arg": 0
         }
     ],
 }
@@ -1166,6 +1168,14 @@ def add_create_func_return_src(func_name):
         ret_type = "type_"
     kind_arg = arg_infos[0].get("kind_arg", False)
     src += indent * 2 + f"ASR::ttype_t *return_type = {ret_type};\n"
+    char_kind_from_arg = arg_infos[0].get("char_kind_from_arg", None)
+    if char_kind_from_arg is not None:
+        # The result is a character of the same kind as the argument, not of
+        # the default kind.
+        src += indent * 2 + f"if (is_character(*ASRUtils::expr_type(args[{char_kind_from_arg}]))) {{\n"
+        src += indent * 3 +     "set_kind_to_ttype_t(ASRUtils::extract_type(return_type),\n"
+        src += indent * 4 +         f"ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[{char_kind_from_arg}])));\n"
+        src += indent * 2 + "}\n"
     if kind_arg:
         src += indent * 2 + "if ( args[1] != nullptr ) {\n"
         src += indent * 3 +     "int kind = -1;\n"

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -1179,8 +1179,12 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
         ASR::stmt_t* create_do_loop_concat_idl(ASR::ImpliedDoLoop_t* x) {
             const Location& loc = x->base.base.loc;
 
+            // The accumulator holds the loop's own values, so it takes their
+            // character kind rather than assuming the default.
+            int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(
+                ASRUtils::extract_type(ASRUtils::expr_type(x->m_values[0])));
             ASR::ttype_t* str_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
-                ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr,
+                ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr,
                     ASR::string_length_kindType::DeferredLength,
                     ASR::string_physical_typeType::DescriptorString))));
 
@@ -1201,7 +1205,7 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             // __lf_accum = ""
             ASR::expr_t* empty_str = ASRUtils::EXPR(ASR::make_StringConstant_t(
                 al, loc, s2c(al, ""),
-                ASRUtils::TYPE(ASR::make_String_t(al, loc, 1,
+                ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind,
                     ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 0,
                         ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
                     ASR::string_length_kindType::ExpressionLength,

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5743,9 +5743,10 @@ namespace BitSize {
 namespace NewLine {
 
     static ASR::expr_t *eval_NewLine(Allocator &al, const Location &loc,
-            ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &/*args*/, diag::Diagnostics& /*diag*/) {
+            ASR::ttype_t* t1, Vec<ASR::expr_t*> &/*args*/, diag::Diagnostics& /*diag*/) {
         char* new_line_str = (char*)"\n";
-        return make_ConstantWithType(make_StringConstant_t, new_line_str, ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, 
+        return make_ConstantWithType(make_StringConstant_t, new_line_str, ASRUtils::TYPE(ASR::make_String_t(al, loc,
+            ASRUtils::extract_kind_from_ttype_t(t1),
             ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1,
                 ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
             ASR::string_length_kindType::ExpressionLength,
@@ -5758,24 +5759,31 @@ namespace Adjustl {
 
     static ASR::expr_t *eval_Adjustl(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        size_t len = std::strlen(str);
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(arg->m_type);
+        std::vector<std::string> characters =
+            ASRUtils::string_value_characters(arg->m_s, char_kind);
         size_t first_non_space = 0;
-        while (first_non_space < len && std::isspace(str[first_non_space])) {
+        while (first_non_space < characters.size() &&
+                characters[first_non_space] == " ") {
             first_non_space++;
         }
-        std::string res(len, ' ');
-        char* result = s2c(al, res);
-        std::strncpy(result, str + first_non_space, len - first_non_space);
-        return make_ConstantWithType(make_StringConstant_t, result, t1, loc);
+        std::string res;
+        for (size_t i = first_non_space; i < characters.size(); i++) {
+            res += characters[i];
+        }
+        res.append(first_non_space, ' ');
+        return make_ConstantWithType(make_StringConstant_t, s2c(al, res), t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_Adjustl(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_adjustl_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
-        return_type = TYPE(ASR::make_String_t(al, loc, 1, EXPR(ASR::make_StringLen_t(al, loc, args[0], int32, nullptr)),
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_adjustl_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        return_type = TYPE(ASR::make_String_t(al, loc, char_kind, EXPR(ASR::make_StringLen_t(al, loc, args[0], int32, nullptr)),
             ASR::string_length_kindType::ExpressionLength,
             ASR::string_physical_typeType::DescriptorString));
         auto result = declare("result", return_type, ReturnVar);
@@ -5802,12 +5810,12 @@ namespace Adjustl {
                 end if
             end function
         */
-        body.push_back(al, b.Assignment(result, b.StringConstant(" ", character(1))));
+        body.push_back(al, b.Assignment(result, b.StringBlank(char_kind)));
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.While(b.LtE(itr, b.StringLen(args[0])), {
             b.If(b.Eq(ASRUtils::EXPR(ASR::make_Ichar_t(al, loc,
                 ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-                ASRUtils::TYPE(ASR::make_String_t(al, loc, 1,  nullptr, 
+                ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind,  nullptr, 
                     ASR::string_length_kindType::AssumedLength,
                     ASR::string_physical_typeType::DescriptorString)), nullptr)), int32, nullptr)),
                 b.Ichar(" ", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, 
@@ -5829,7 +5837,7 @@ namespace Adjustl {
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, f_sym);
-        return_type = TYPE(ASR::make_String_t(al, loc, 1, EXPR(ASR::make_StringLen_t(al, loc, new_args[0].m_value, int32, nullptr)),
+        return_type = TYPE(ASR::make_String_t(al, loc, char_kind, EXPR(ASR::make_StringLen_t(al, loc, new_args[0].m_value, int32, nullptr)),
             ASR::string_length_kindType::ExpressionLength,
             ASR::string_physical_typeType::DescriptorString));
         return b.Call(f_sym, new_args, return_type, nullptr);
@@ -5841,31 +5849,31 @@ namespace Adjustr {
 
     static ASR::expr_t *eval_Adjustr(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        size_t len = std::strlen(str);
-        int last_non_space = len - 1;
-        while (last_non_space >= 0 && std::isspace(str[last_non_space])) {
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(arg->m_type);
+        std::vector<std::string> characters =
+            ASRUtils::string_value_characters(arg->m_s, char_kind);
+        int last_non_space = (int)characters.size() - 1;
+        while (last_non_space >= 0 && characters[last_non_space] == " ") {
             last_non_space--;
         }
-        std::string res(len, ' ');
-        char* result = s2c(al, res);
-        if (last_non_space != -1) {
-            int tmp = len - 1 - last_non_space;
-            for (int i = 0; i <= last_non_space; i++) {
-                result[i + tmp] = str[i];
-            }
+        std::string res(characters.size() - (last_non_space + 1), ' ');
+        for (int i = 0; i <= last_non_space; i++) {
+            res += characters[i];
         }
-        return make_ConstantWithType(make_StringConstant_t, result, t1, loc);
+        return make_ConstantWithType(make_StringConstant_t, s2c(al, res), t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_Adjustr(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_adjustr_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1,
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_adjustr_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind,
             nullptr, ASR::string_length_kindType::AssumedLength,
              ASR::string_physical_typeType::DescriptorString)));
-        return_type = TYPE(ASR::make_String_t(al, loc, 1, 
+        return_type = TYPE(ASR::make_String_t(al, loc, char_kind, 
             EXPR(ASR::make_StringLen_t(al, loc, args[0], int32, nullptr)),
                 ASR::string_length_kindType::ExpressionLength,
                 ASR::string_physical_typeType::DescriptorString));
@@ -5894,12 +5902,12 @@ namespace Adjustr {
             end function
         */
 
-        body.push_back(al, b.Assignment(result, b.StringConstant(" ", character(1))));
+        body.push_back(al, b.Assignment(result, b.StringBlank(char_kind)));
         body.push_back(al, b.Assignment(itr, b.StringLen(args[0])));
         body.push_back(al, b.While(b.GtE(itr, b.i32(1)), {
             b.If(b.Eq(ASRUtils::EXPR(ASR::make_Ichar_t(al, loc,
                 ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-                ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr,
+                ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr,
                     ASR::string_length_kindType::AssumedLength,
                     ASR::string_physical_typeType::DescriptorString)), nullptr)), int32, nullptr)),
                 b.Ichar(" ", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, 
@@ -5922,7 +5930,7 @@ namespace Adjustr {
         ASR::symbol_t *f_sym = make_ASR_Function_t(fn_name, fn_symtab, dep, args,
             body, result, ASR::abiType::Source, ASR::deftypeType::Implementation, nullptr);
         scope->add_symbol(fn_name, f_sym);
-        return_type = TYPE(ASR::make_String_t(al, loc, 1, EXPR(ASR::make_StringLen_t(al, loc, new_args[0].m_value, int32, nullptr)),
+        return_type = TYPE(ASR::make_String_t(al, loc, char_kind, EXPR(ASR::make_StringLen_t(al, loc, new_args[0].m_value, int32, nullptr)),
             ASR::string_length_kindType::ExpressionLength,
             ASR::string_physical_typeType::DescriptorString));
         return b.Call(f_sym, new_args, return_type, nullptr);
@@ -5970,8 +5978,8 @@ namespace StringConcat {
         extract_value_(s1_value, s1_char);
 
         // For kind=1, logical length == physical byte length (safe for null bytes).
-        // For kind>1, logical length != physical bytes (UTF-8 multi-byte encoding),
-        // so we must use strlen to get the actual byte count.
+        // For kind>1, m_s holds UTF-8 while m_len counts characters, so the
+        // number of bytes to copy is strlen, not m_len.
         int64_t s0_len, s1_len;
         extract_value_(expr_value(s0_type->m_len), s0_len);
         extract_value_(expr_value(s1_type->m_len), s1_len);
@@ -5996,6 +6004,9 @@ namespace StringConcat {
 
         ASR::expr_t* value {};
         ASR::ttype_t* return_type {};
+        // Both operands are guaranteed to have the same character kind by the
+        // frontend, and the result carries that kind through.
+        int char_kind = get_string_type(args[0])->m_kind;
         if(all_args_evaluated(m_args)){
             // When args have compile-time values, evaluate and get length from value types
             ASRBuilder b(al, loc);
@@ -6010,13 +6021,11 @@ namespace StringConcat {
                 int64_t s0_len, s1_len;
                 extract_value(expr_value(s0_type->m_len), s0_len);
                 extract_value(expr_value(s1_type->m_len), s1_len);
-                // For kind>1, logical length != physical bytes (UTF-8 encoding),
-                // so use strlen. For kind=1, logical == physical (null-safe).
-                char* s0_char {}; extract_value_(s0_value, s0_char);
-                char* s1_char {}; extract_value_(s1_value, s1_char);
-                int64_t phys_s0 = (s0_type->m_kind > 1 && s0_char) ? (int64_t)strlen(s0_char) : s0_len;
-                int64_t phys_s1 = (s1_type->m_kind > 1 && s1_char) ? (int64_t)strlen(s1_char) : s1_len;
-                return_type = b.String(b.i64(phys_s0 + phys_s1), ASR::ExpressionLength);
+                // Lengths are character counts, so they add directly. For
+                // kind > 1 the number of *bytes* to copy differs, and
+                // eval_StringConcat works that out from the values themselves.
+                return_type = b.String(b.i64(s0_len + s1_len), ASR::ExpressionLength,
+                    ASR::DescriptorString, char_kind);
                 value = eval_StringConcat(al, loc, return_type, args, diag);
             } else {
                 // Array parameter: evaluate element-by-element into an ArrayConstant.
@@ -6080,12 +6089,14 @@ namespace StringConcat {
                     Vec<ASR::expr_t*> elem_args; elem_args.reserve(al, 2);
                     elem_args.push_back(al, arg0_is_array ? left_elem : right_elem);
                     elem_args.push_back(al, arg0_is_array ? right_elem : left_elem);
-                    ASR::ttype_t* res_type = b.String(b.i64(result_elem_len), ASR::ExpressionLength);
+                    ASR::ttype_t* res_type = b.String(b.i64(result_elem_len), ASR::ExpressionLength,
+                        ASR::DescriptorString, char_kind);
                     ASR::StringConstant_t* res_i = ASR::down_cast<ASR::StringConstant_t>(
                         eval_StringConcat(al, loc, res_type, elem_args, diag));
                     memcpy(result_buf + i * result_elem_len, res_i->m_s, result_elem_len);
                 }
-                return_type = b.String(b.i64(result_elem_len), ASR::ExpressionLength);
+                return_type = b.String(b.i64(result_elem_len), ASR::ExpressionLength,
+                    ASR::DescriptorString, char_kind);
                 ASR::Array_t* arr_t = ASR::down_cast<ASR::Array_t>(
                     ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(arr_arg)));
                 ASR::ttype_t* result_arr_type = ASRUtils::TYPE(ASR::make_Array_t(
@@ -6103,9 +6114,11 @@ namespace StringConcat {
                 int64_t s1_len, s2_len;
                 extract_value(s1->m_len, s1_len);
                 extract_value(s2->m_len, s2_len);
-                return_type = b.String(b.i64(s1_len + s2_len), ASR::ExpressionLength);
+                return_type = b.String(b.i64(s1_len + s2_len), ASR::ExpressionLength,
+                    ASR::DescriptorString, char_kind);
             } else {
-                return_type = b.allocatable(b.String(nullptr, ASR::DeferredLength));
+                return_type = b.allocatable(b.String(nullptr, ASR::DeferredLength,
+                    ASR::DescriptorString, char_kind));
             }
         }
 
@@ -6162,7 +6175,9 @@ namespace StringConcat {
     inline ASR::expr_t* instantiate_StringConcat(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t* /*return_type*/,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/){
-        char intrinsic_fn_name[] = "_lcompilers_stringconcat";
+        int char_kind = ASR::down_cast<ASR::String_t>(
+            ASRUtils::extract_type(arg_types[0]))->m_kind;
+        std::string intrinsic_fn_name = "_lcompilers_stringconcat_" + std::to_string(char_kind);
         declare_basic_variables(intrinsic_fn_name)
 
         // Compute argument lengths safely, avoiding circular references for
@@ -6185,14 +6200,14 @@ namespace StringConcat {
         }
 
         /* Function signature: (s1, s2, s1_len, s2_len) -> concat_result */
-        fill_func_arg("s1", b.String(nullptr, ASR::AssumedLength))
-        fill_func_arg("s2", b.String(nullptr, ASR::AssumedLength))
+        fill_func_arg("s1", b.String(nullptr, ASR::AssumedLength, ASR::DescriptorString, char_kind))
+        fill_func_arg("s2", b.String(nullptr, ASR::AssumedLength, ASR::DescriptorString, char_kind))
         fill_func_arg("s1_len", int32)
         fill_func_arg("s2_len", int32)
 
         ASR::expr_t* ret_var = declare(
             "concat_result",
-            b.allocatable(b.String(nullptr, ASR::DeferredLength)),
+            b.allocatable(b.String(nullptr, ASR::DeferredLength, ASR::DescriptorString, char_kind)),
             ReturnVar);
 
         body.push_back(al, b.Allocate(ret_var, nullptr, 0, b.Add(args[2], args[3])));
@@ -6219,10 +6234,12 @@ namespace StringLenTrim {
 
     static ASR::expr_t *eval_StringLenTrim(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        size_t len = std::strlen(str);
-        for (int i = len - 1; i >= 0; i--) {
-            if (!std::isspace(str[i])) {
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(arg->m_type);
+        std::vector<std::string> characters =
+            ASRUtils::string_value_characters(arg->m_s, char_kind);
+        for (int i = (int)characters.size() - 1; i >= 0; i--) {
+            if (characters[i] != " ") {
                 return make_ConstantWithType(make_IntegerConstant_t, i + 1, t1, loc);
             }
         }
@@ -6252,7 +6269,7 @@ namespace StringLenTrim {
 
         body.push_back(al, b.Assignment(result, b.i2i_t(b.StringLen(args[0]), return_type)));
         body.push_back(al, b.If(b.NotEq(result, b.i_t(0, return_type)), {
-            b.While(b.Eq(b.StringItem(args[0], result), b.StringConstant(" ", character(1))), {
+            b.While(b.Eq(b.StringItem(args[0], result), b.StringBlank(char_kind)), {
                 b.Assignment(result, b.Sub(result, b.i_t(1, return_type))),
                 b.If(b.Eq(result, b.i_t(0, return_type)), {
                     b.Exit()
@@ -6275,22 +6292,19 @@ namespace StringTrim {
 
     static ASR::expr_t *eval_StringTrim(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        // Trim trailing spaces (in place)
-        size_t len = strlen(str);
-        if (len > 0) {
-            char* endptr = str + len - 1;
-            while (endptr >= str && std::isspace(*endptr)) {
-                *endptr = '\0';
-                --endptr;
-            }
-        }
-
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
         int char_kind = ASRUtils::extract_kind_from_ttype_t(t1);
+        std::vector<std::string> characters =
+            ASRUtils::string_value_characters(arg->m_s, char_kind);
+        size_t trimmed = characters.size();
+        while (trimmed > 0 && characters[trimmed - 1] == " ") trimmed--;
+        std::string res;
+        for (size_t i = 0; i < trimmed; i++) res += characters[i];
+
         ASR::ttype_t* str_type = ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind,
-            make_ConstantWithType(make_IntegerConstant_t, strlen(str), int32, loc), 
+            make_ConstantWithType(make_IntegerConstant_t, trimmed, int32, loc), 
             ASR::ExpressionLength, ASR::string_physical_typeType::DescriptorString));
-        return make_ConstantWithType(make_StringConstant_t, str, str_type, loc);
+        return make_ConstantWithType(make_StringConstant_t, s2c(al, res), str_type, loc);
     }
 
     static inline ASR::expr_t* instantiate_StringTrim(Allocator &al, const Location &loc,
@@ -6329,10 +6343,8 @@ namespace Ichar {
 
     static ASR::expr_t *eval_Ichar(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        LCOMPILERS_ASSERT(str[0] == '\0' || std::strlen(str) == 1);
-        char first_char = str[0];
-        int result = (int)first_char;
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t result = string_first_code_point(arg);
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
     }
 
@@ -6401,11 +6413,15 @@ namespace Char {
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
 
-        declare_basic_variables("_lcompilers_char_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(return_type);
+        declare_basic_variables("_lcompilers_char_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
 
         /* Declare Arguments + Return Variable */
         fill_func_arg("i", arg_types[0]);
-        auto result = declare("result", character(1), ReturnVar);
+        auto result = declare("result",
+            b.String(b.i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind),
+            ReturnVar);
 
         /* Body */
         /*
@@ -6466,7 +6482,9 @@ namespace Achar {
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
 
-        declare_basic_variables("_lcompilers_achar_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(return_type);
+        declare_basic_variables("_lcompilers_achar_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
 
         ASR::expr_t* result;
         ASR::ttype_t* call_return_type = return_type;
@@ -6476,10 +6494,13 @@ namespace Achar {
 
             ASR::expr_t* n = b.ArraySize(args[0], b.i32(1), int32);
             ASR::ttype_t* result_str_type = b.String(n,
-                ASR::string_length_kindType::ExpressionLength);
+                ASR::string_length_kindType::ExpressionLength,
+                ASR::DescriptorString, char_kind);
             result = declare("result", result_str_type, ReturnVar);
             auto j = declare("j", int32, Local);
-            auto tmp_char = declare("tmp_char", character(1), Local);
+            auto tmp_char = declare("tmp_char",
+                b.String(b.i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind),
+                Local);
 
             body.push_back(al, b.DoLoop(j, b.i32(1), n, {
                 b.Assignment(tmp_char, b.BitCast(
@@ -6490,10 +6511,13 @@ namespace Achar {
             ASR::expr_t* n_caller = b.ArraySize(
                 new_args[0].m_value, b.i32(1), int32);
             call_return_type = b.String(n_caller,
-                ASR::string_length_kindType::ExpressionLength);
+                ASR::string_length_kindType::ExpressionLength,
+                ASR::DescriptorString, char_kind);
         } else {
             fill_func_arg("i", arg_types[0]);
-            result = declare("result", character(1), ReturnVar);
+            result = declare("result",
+                b.String(b.i32(1), ASR::ExpressionLength, ASR::DescriptorString, char_kind),
+                ReturnVar);
             body.push_back(al, b.Assignment(result, b.BitCast(args[0], result)));
         }
 
@@ -6510,10 +6534,8 @@ namespace Iachar {
 
     static ASR::expr_t *eval_Iachar(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* str = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        LCOMPILERS_ASSERT(str[0] == '\0' || std::strlen(str) == 1);
-        unsigned char first_char = (unsigned char)str[0];
-        int result = (int)first_char;
+        ASR::StringConstant_t* arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        int64_t result = string_first_code_point(arg);
         return make_ConstantWithType(make_IntegerConstant_t, result, t1, loc);
     }
 
@@ -6521,14 +6543,16 @@ namespace Iachar {
     static inline ASR::expr_t* instantiate_Iachar(Allocator &al, const Location &loc,
         SymbolTable *scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
         Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_iachar_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_iachar_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
         auto result = declare("result", return_type, ReturnVar);
         auto itr = declare("i", int32, Local);
         body.push_back(al, b.Assignment(itr, b.i32(1)));
         body.push_back(al, b.Assignment(result, b.i2i_t(
             ASRUtils::EXPR(ASR::make_Iachar_t(al, loc, ASRUtils::EXPR(ASR::make_StringItem_t(al, loc, args[0], itr,
-            ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr,
+            ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr,
                 ASR::string_length_kindType::AssumedLength,
                 ASR::string_physical_typeType::DescriptorString)),
             nullptr)), int32, nullptr)), return_type)));
@@ -6680,14 +6704,14 @@ namespace Repeat {
         ASRUtils::ASRBuilder b(al, loc);
         char* str = ASR::down_cast<ASR::StringConstant_t>(expr_value(args[0]))->m_s;
         int64_t n = ASR::down_cast<ASR::IntegerConstant_t>(expr_value(args[1]))->m_n;
-        size_t len = std::strlen(str);
-        size_t new_len = len*n;
-        char* result = new char[new_len+1];
-        for (size_t i=0; i<new_len; i++) {
-            result[i] = str[i%len];
-        }
-        result[new_len] = '\0';
         int char_kind = ASRUtils::extract_kind_from_ttype_t(ASRUtils::expr_type(args[0]));
+        // The result length is a character count, so repeat whole characters
+        // rather than bytes.
+        size_t len = ASRUtils::string_value_characters(str, char_kind).size();
+        size_t new_len = len*n;
+        std::string repeated;
+        for (int64_t i = 0; i < n; i++) repeated += str;
+        char* result = s2c(al, repeated);
         ASR::ttype_t *return_type = b.String(
             ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, new_len,
                 ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)))),
@@ -6814,21 +6838,32 @@ namespace StringContainsSet {
 
     static ASR::expr_t *eval_StringContainsSet(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* set = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
+        ASR::StringConstant_t* string_arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        ASR::StringConstant_t* set_arg = ASR::down_cast<ASR::StringConstant_t>(args[1]);
         bool back = ASR::down_cast<ASR::LogicalConstant_t>(args[2])->m_value;
-        size_t len = std::strlen(string);
+        // Positions count characters, so for kind > 1 walk code points rather
+        // than the bytes of the UTF-8 encoding.
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(string_arg->m_type);
+        std::vector<std::string> string =
+            ASRUtils::string_value_characters(string_arg->m_s, char_kind);
+        std::vector<std::string> set =
+            ASRUtils::string_value_characters(set_arg->m_s, char_kind);
+        size_t len = string.size();
         int64_t result = 0;
+        // VERIFY reports the first character that is *not* in the set.
+        auto is_match = [&](size_t idx) {
+            return std::find(set.begin(), set.end(), string[idx]) == set.end();
+        };
         if (back) {
             for (size_t i=0; i<len; i++) {
-                if (std::strchr(set, string[len-i-1]) == nullptr) {
+                if (is_match(len-i-1)) {
                     result = len-i;
                     break;
                 }
             }
         } else {
             for (size_t i=0; i<len; i++) {
-                if (std::strchr(set, string[i]) == nullptr) {
+                if (is_match(i)) {
                     result = i+1;
                     break;
                 }
@@ -6840,9 +6875,11 @@ namespace StringContainsSet {
     static inline ASR::expr_t* instantiate_StringContainsSet(Allocator &al, const Location &loc,
             SymbolTable* scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
             Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_verify_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
-        fill_func_arg("set", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_verify_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        fill_func_arg("set", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
         fill_func_arg("back", ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
         fill_func_arg("kind", int32);
         auto result = declare(fn_name, return_type, ReturnVar);
@@ -6945,21 +6982,32 @@ namespace StringFindSet {
 
     static ASR::expr_t *eval_StringFindSet(Allocator &al, const Location &loc,
             ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* set = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
+        ASR::StringConstant_t* string_arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        ASR::StringConstant_t* set_arg = ASR::down_cast<ASR::StringConstant_t>(args[1]);
         bool back = ASR::down_cast<ASR::LogicalConstant_t>(args[2])->m_value;
-        size_t len = std::strlen(string);
+        // Positions count characters, so for kind > 1 walk code points rather
+        // than the bytes of the UTF-8 encoding.
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(string_arg->m_type);
+        std::vector<std::string> string =
+            ASRUtils::string_value_characters(string_arg->m_s, char_kind);
+        std::vector<std::string> set =
+            ASRUtils::string_value_characters(set_arg->m_s, char_kind);
+        size_t len = string.size();
         int64_t result = 0;
+        // SCAN reports the first character that is in the set.
+        auto is_match = [&](size_t idx) {
+            return std::find(set.begin(), set.end(), string[idx]) != set.end();
+        };
         if (back) {
             for (size_t i=0; i<len; i++) {
-                if (std::strchr(set, string[len-i-1]) != nullptr) {
+                if (is_match(len-i-1)) {
                     result = len-i;
                     break;
                 }
             }
         } else {
             for (size_t i=0; i<len; i++) {
-                if (std::strchr(set, string[i]) != nullptr) {
+                if (is_match(i)) {
                     result = i+1;
                     break;
                 }
@@ -6971,9 +7019,11 @@ namespace StringFindSet {
     static inline ASR::expr_t* instantiate_StringFindSet(Allocator &al, const Location &loc,
             SymbolTable* scope, Vec<ASR::ttype_t*>& arg_types, ASR::ttype_t *return_type,
             Vec<ASR::call_arg_t>& new_args, int64_t /*overload_id*/, int /*index_kind*/) {
-        declare_basic_variables("_lcompilers_scan_" + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
-        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
-        fill_func_arg("set", ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        int char_kind = ASRUtils::extract_kind_from_ttype_t(arg_types[0]);
+        declare_basic_variables("_lcompilers_scan_" + std::to_string(char_kind) + "_"
+            + type_to_str_python_expr(arg_types[0], new_args[0].m_value));
+        fill_func_arg("str", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
+        fill_func_arg("set", ASRUtils::TYPE(ASR::make_String_t(al, loc, char_kind, nullptr, ASR::string_length_kindType::AssumedLength, ASR::string_physical_typeType::DescriptorString)));
         fill_func_arg("back", ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4)));
         fill_func_arg("kind", int32);
         auto result = declare(fn_name, return_type, ReturnVar);
@@ -7067,22 +7117,37 @@ namespace SubstrIndex {
 
     static ASR::expr_t *eval_SubstrIndex(Allocator &al, const Location &loc,
             ASR::ttype_t* /*t1*/, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* substring = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
+        ASR::StringConstant_t* string_arg = ASR::down_cast<ASR::StringConstant_t>(args[0]);
+        ASR::StringConstant_t* substring_arg = ASR::down_cast<ASR::StringConstant_t>(args[1]);
         bool back = ASR::down_cast<ASR::LogicalConstant_t>(args[2])->m_value;
         int64_t kind = ASR::down_cast<ASR::IntegerConstant_t>(args[3])->m_n;
-        size_t len = std::strlen(string);
+        // INDEX counts characters, so walk the values character by character
+        // rather than byte by byte: for kind > 1 one character can span
+        // several UTF-8 bytes.
+        int64_t char_kind = ASRUtils::extract_kind_from_ttype_t(string_arg->m_type);
+        std::vector<std::string> string =
+            ASRUtils::string_value_characters(string_arg->m_s, char_kind);
+        std::vector<std::string> substring =
+            ASRUtils::string_value_characters(substring_arg->m_s, char_kind);
+        size_t len = string.size();
         int64_t result = 0;
+        auto matches_at = [&](size_t start) {
+            if (start + substring.size() > string.size()) return false;
+            for (size_t k = 0; k < substring.size(); k++) {
+                if (string[start + k] != substring[k]) return false;
+            }
+            return true;
+        };
         if (back) {
             for (size_t i=0; i<len; i++) {
-                if (std::strncmp(string+len-i-1, substring, std::strlen(substring)) == 0) {
+                if (matches_at(len-i-1)) {
                     result = len-i;
                     break;
                 }
             }
         } else {
             for (size_t i=0; i<len; i++) {
-                if (std::strncmp(string+i, substring, std::strlen(substring)) == 0) {
+                if (matches_at(i)) {
                     result = i+1;
                     break;
                 }

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -5948,6 +5948,9 @@ namespace StringConcat {
             require_impl(   is_character(*arg0) && is_character(*arg1),
                             "Unexpected arg types. StringConcat expects (char, char)",
                             loc, diag);
+            require_impl(   extract_kind_from_ttype_t(arg0) == extract_kind_from_ttype_t(arg1),
+                            "StringConcat expects both operands to have the same character kind",
+                            loc, diag);
         } else {
             require_impl(   false,
                             "Unexpected number of args, StringConcat takes 2 arguments, found "+ std::to_string(n_args),

--- a/src/libasr/pass/nested_vars.cpp
+++ b/src/libasr/pass/nested_vars.cpp
@@ -688,7 +688,7 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                         var_type = 
                             ASRUtils::TYPE(
                                 ASR::make_Pointer_t(al, str->base.base.loc,
-                                    ASRUtils::TYPE(ASR::make_String_t(al, str->base.base.loc, 1,
+                                    ASRUtils::TYPE(ASR::make_String_t(al, str->base.base.loc, str->m_kind,
                                         nullptr, ASR::DeferredLength, ASR::DescriptorString))));
                     }
                 } else if(ASRUtils::is_array_of_strings(var_type)){ // e.g -> `character(len=foo()) :: str(10)`
@@ -711,7 +711,7 @@ class ReplaceNestedVisitor: public ASR::CallReplacerOnExpressionsVisitor<Replace
                             pending_length_ctx_sym = ASR::down_cast<ASR::Var_t>(len_expr_var)->m_v;
                         }
                         // Create a new ASR::String node, To avoid using the original one.
-                        array_t->m_type = ASRUtils::TYPE(ASR::make_String_t(al, string_t->base.base.loc, 1,
+                        array_t->m_type = ASRUtils::TYPE(ASR::make_String_t(al, string_t->base.base.loc, string_t->m_kind,
                                             nullptr, ASR::DeferredLength, ASR::DescriptorString));
                     }
                 }

--- a/src/libasr/pass/select_case.cpp
+++ b/src/libasr/pass/select_case.cpp
@@ -153,7 +153,8 @@ Vec<ASR::stmt_t*> replace_selectcase(Allocator &al, const ASR::Select_t &select_
         ASR::ttype_t* a_type = ASRUtils::expr_type(a);
         if (ASRUtils::is_character(*a_type)) {
             a_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
-                ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr,
+                ASRUtils::TYPE(ASR::make_String_t(al, loc,
+                    ASRUtils::extract_kind_from_ttype_t(a_type), nullptr,
                     ASR::string_length_kindType::DeferredLength,
                     ASR::string_physical_typeType::DescriptorString))));
         }
@@ -250,7 +251,8 @@ Vec<ASR::stmt_t*> replace_selectcase_with_fall_through(
         ASR::ttype_t* a_type = ASRUtils::expr_type(a);
         if (ASRUtils::is_character(*a_type)) {
             a_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc,
-                ASRUtils::TYPE(ASR::make_String_t(al, loc, 1, nullptr,
+                ASRUtils::TYPE(ASR::make_String_t(al, loc,
+                    ASRUtils::extract_kind_from_ttype_t(a_type), nullptr,
                     ASR::string_length_kindType::DeferredLength,
                     ASR::string_physical_typeType::DescriptorString))));
         }

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -614,11 +614,120 @@ LFORTRAN_API int _lfortran_random_int(int lower, int upper)
     return randint;
 }
 
-LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_t str_len, const fchar* end, uint32_t end_len)
+// Appends the UTF-8 encoding of one code point to `out`, returning how many
+// bytes it wrote. `out` must have room for 4 bytes.
+static int utf8_encode_code_point(char* out, uint32_t cp)
+{
+    if (cp <= 0x7f) {
+        out[0] = (char)cp;
+        return 1;
+    } else if (cp <= 0x7ff) {
+        out[0] = (char)(0xc0 | (cp >> 6));
+        out[1] = (char)(0x80 | (cp & 0x3f));
+        return 2;
+    } else if (cp <= 0xffff) {
+        out[0] = (char)(0xe0 | (cp >> 12));
+        out[1] = (char)(0x80 | ((cp >> 6) & 0x3f));
+        out[2] = (char)(0x80 | (cp & 0x3f));
+        return 3;
+    }
+    out[0] = (char)(0xf0 | (cp >> 18));
+    out[1] = (char)(0x80 | ((cp >> 12) & 0x3f));
+    out[2] = (char)(0x80 | ((cp >> 6) & 0x3f));
+    out[3] = (char)(0x80 | (cp & 0x3f));
+    return 4;
+}
+
+// Number of bytes the UTF-8 sequence starting with `c` occupies, or 0 if `c`
+// is not a lead byte.
+static int utf8_sequence_length(unsigned char c)
+{
+    if (c < 0x80) return 1;
+    if ((c & 0xe0) == 0xc0) return 2;
+    if ((c & 0xf0) == 0xe0) return 3;
+    if ((c & 0xf8) == 0xf0) return 4;
+    return 0;
+}
+
+/*
+ * A character value of kind > 1 is held in memory as `count` little-endian
+ * code units of `kind` bytes each (kind 4 is UCS-4). Files and the terminal
+ * are byte streams, so such a value is written out as UTF-8. This matches LLVM
+ * Flang, which transcodes kind 4 output regardless of the unit's ENCODING=.
+ *
+ * Returns a newly allocated buffer and stores its length in `*out_len`. The
+ * caller frees it with internal_free.
+ */
+char* _lfortran_unicode_to_utf8(const char* data, int64_t count, int32_t kind,
+        int64_t* out_len)
+{
+    char* out = (char*)internal_malloc((size_t)(count * 4 + 1));
+    int64_t pos = 0;
+    for (int64_t i = 0; i < count; i++) {
+        uint32_t cp = 0;
+        for (int32_t b = 0; b < kind; b++) {
+            cp |= ((uint32_t)(unsigned char)data[i * kind + b]) << (8 * b);
+        }
+        pos += utf8_encode_code_point(out + pos, cp);
+    }
+    out[pos] = '\0';
+    *out_len = pos;
+    return out;
+}
+
+/*
+ * The inverse: decodes at most `count` characters of UTF-8 from `data` into
+ * `kind`-wide little-endian code units written to `dest`, blank padding any
+ * remaining characters. Returns the number of characters decoded.
+ */
+int64_t _lfortran_utf8_to_unicode(const char* data, int64_t data_len,
+        char* dest, int64_t count, int32_t kind)
+{
+    int64_t i = 0, written = 0;
+    while (i < data_len && written < count) {
+        int length = utf8_sequence_length((unsigned char)data[i]);
+        uint32_t cp;
+        if (length == 0 || i + length > data_len) {
+            // Not well-formed; pass the byte through so we always make progress
+            cp = (unsigned char)data[i];
+            length = 1;
+        } else if (length == 1) {
+            cp = (unsigned char)data[i];
+        } else {
+            static const uint32_t lead_mask[5] = {0, 0, 0x1f, 0x0f, 0x07};
+            cp = (unsigned char)data[i] & lead_mask[length];
+            for (int k = 1; k < length; k++) {
+                cp = (cp << 6) | ((unsigned char)data[i + k] & 0x3f);
+            }
+        }
+        for (int32_t b = 0; b < kind; b++) {
+            dest[written * kind + b] = (char)((cp >> (8 * b)) & 0xff);
+        }
+        written++;
+        i += length;
+    }
+    for (int64_t j = written; j < count; j++) {
+        dest[j * kind] = ' ';
+        for (int32_t b = 1; b < kind; b++) dest[j * kind + b] = 0;
+    }
+    return written;
+}
+
+LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_t str_len, int32_t str_kind, const fchar* end, uint32_t end_len)
 {
     if (str == NULL) {
         str = (fchar*)" "; // dummy output
         str_len = 1; // length of dummy output
+        str_kind = 1;
+    }
+    // `str_len` counts characters. A kind > 1 value is code units in memory and
+    // is written out as UTF-8.
+    char* encoded = NULL;
+    if (str_kind > 1) {
+        int64_t encoded_len;
+        encoded = _lfortran_unicode_to_utf8((const char*)str, str_len, str_kind, &encoded_len);
+        str = (const fchar*)encoded;
+        str_len = (uint32_t)encoded_len;
     }
     // Detect "\b" to raise error (only if still null-terminated)
     if (str_len > 0 && ((char*)str)[0] == '\b') {
@@ -633,6 +742,7 @@ LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_
     fwrite((char*)str, sizeof(char), str_len, stdout);
     fwrite((char*)end, sizeof(char), end_len, stdout);
     fflush(stdout);
+    internal_free(encoded);
 }
 
 char* substring(const char* str, int start, int end) {
@@ -2421,6 +2531,7 @@ typedef struct serialization_info{
         void* current_arg; // holds pointer to the arg being printed (Scalar or Vector) 
         bool is_complex;
         int64_t current_string_len; // Holds string length 'If Exist'
+        int32_t current_string_kind; // Bytes per character of the string arg
     } current_arg_info;
     struct runtime_sizes_lengths{ // Passed array sizes or string legnths.
         int64_t* ptr;
@@ -2439,6 +2550,22 @@ int64_t transform_string_size_into_int(struct serialization_info* s_info){
         array_size = array_size * 10 + (s_info->serialization_string[s_info->current_stop++] - '0');
     }
     return array_size;
+}
+
+// Reads the `-K<kind>` part that follows the string physical type. The kind is
+// the number of bytes one character occupies: 1 for ASCII/default, 4 for
+// ISO 10646 (UCS-4).
+void set_string_kind(Serialization_Info* s_info){
+    if(s_info->serialization_string[s_info->current_stop] != '-' ||
+       s_info->serialization_string[s_info->current_stop + 1] != 'K') {
+        fprintf(stderr, "RunTime - compiler internal error"
+            " : Missing character kind in string serialization --> %s\n",
+                s_info->serialization_string);
+        exit(1);
+    }
+    s_info->current_stop += 2;
+    s_info->current_arg_info.current_string_kind =
+        (int32_t)transform_string_size_into_int(s_info);
 }
 
 // Sets `current_string_length` either from the serialization string or passed run-time length
@@ -2641,6 +2768,7 @@ void set_current_PrimitiveType(Serialization_Info* s_info){
     }
     case 'S':{
         Primitive_Types str_phys_type = get_string_primitive_type(s_info);
+        set_string_kind(s_info);
         set_string_length(s_info);
         *PrimitiveType = str_phys_type;
         break;
@@ -2954,6 +3082,17 @@ int64_t print_into_string(Serialization_Info* s_info,  char* result){
             char* char_ptr = *(char**)arg;
                 if(char_ptr == NULL){
                     sprintf(result, "%s", " ");
+                } else if(s_info->current_arg_info.current_string_kind > 1){
+                    // A kind > 1 value is code units in memory; write it out
+                    // as UTF-8.
+                    int64_t encoded_len;
+                    char* encoded = _lfortran_unicode_to_utf8(char_ptr,
+                        s_info->current_arg_info.current_string_len,
+                        s_info->current_arg_info.current_string_kind, &encoded_len);
+                    memcpy(result, encoded, encoded_len);
+                    *(result + encoded_len) = '\0';
+                    internal_free(encoded);
+                    return encoded_len;
                 } else {
                     memcpy(result,
                         char_ptr,
@@ -3049,7 +3188,9 @@ void default_formatting(lfortran_allocator_t* al, char** result, int64_t *result
         int size_to_allocate;
         if(curr_is_char &&
             *(char**)s_info->current_arg_info.current_arg != NULL){
+            // A kind > 1 character can take up to 4 bytes once encoded as UTF-8.
             size_to_allocate = (s_info->current_arg_info.current_string_len
+                                    * (s_info->current_arg_info.current_string_kind > 1 ? 4 : 1)
                                  + default_spacing_len + 1) * sizeof(char);
         } else {
             size_to_allocate = (60 + default_spacing_len) * sizeof(char);
@@ -3143,6 +3284,7 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(lfortran_allocator_t* al, c
     s_info.current_arg_info.args = &args;
     s_info.current_element_type = NONE_TYPE;
     s_info.current_arg_info.is_complex = false;
+    s_info.current_arg_info.current_string_kind = 1;
     s_info.array_sizes.current_index = 0;
     s_info.string_lengths.current_index = 0;
     s_info.just_peeked = false;
@@ -3514,26 +3656,49 @@ LFORTRAN_API char* _lcompilers_string_format_fortran(lfortran_allocator_t* al, c
                     }
                     char* arg = *(char**)s_info.current_arg_info.current_arg;
                     if (arg == NULL) continue;
+                    // `current_string_len` counts characters. A kind 1 value is
+                    // already a byte string; a kind > 1 value is transcoded to
+                    // UTF-8 here, and the field width below stays a character
+                    // count, as the standard requires.
+                    int32_t char_kind = s_info.current_arg_info.current_string_kind;
+                    int64_t src_len = s_info.current_arg_info.current_string_len;
+                    char* encoded = NULL;
+                    int64_t arg_bytes = src_len;
+                    if (char_kind > 1) {
+                        encoded = _lfortran_unicode_to_utf8(arg, src_len, char_kind, &arg_bytes);
+                        arg = encoded;
+                    }
                     if (strlen(value) == 1) {
                         // Simple 'A' format - use full string length, preserve embedded nulls
-                        result = write_to_result_at_pos(al, result, &result_extent, result_len, arg, s_info.current_arg_info.current_string_len);
-                        result_len += s_info.current_arg_info.current_string_len;
+                        result = write_to_result_at_pos(al, result, &result_extent, result_len, arg, arg_bytes);
+                        result_len += arg_bytes;
                     } else {
                         // 'Aw' format with width: right-justify if width > len, truncate leading part if width < len.
                         int64_t width = atoi(value + 1);
-                        if (width <= 0) continue;
-                        int64_t src_len = s_info.current_arg_info.current_string_len;
-                        int64_t copy_len = (width < src_len) ? width : src_len;
+                        if (width <= 0) { internal_free(encoded); continue; }
+                        int64_t copy_chars = (width < src_len) ? width : src_len;
                         int64_t pad_len = (width > src_len) ? (width - src_len) : 0;
-                        char *field = (char*)internal_malloc((size_t)width);
+                        // Truncation is by characters, so re-encode just the
+                        // part that is kept.
+                        int64_t copy_bytes = copy_chars;
+                        char* truncated = NULL;
+                        if (char_kind > 1) {
+                            truncated = _lfortran_unicode_to_utf8(
+                                *(char**)s_info.current_arg_info.current_arg,
+                                copy_chars, char_kind, &copy_bytes);
+                        }
+                        int64_t field_len = pad_len + copy_bytes;
+                        char *field = (char*)internal_malloc((size_t)field_len);
                         if (pad_len > 0) {
                             memset(field, ' ', (size_t)pad_len);
                         }
-                        memcpy(field + pad_len, arg, (size_t)copy_len);
-                        result = write_to_result_at_pos(al, result, &result_extent, result_len, field, width);
-                        result_len += width;
+                        memcpy(field + pad_len, truncated ? truncated : arg, (size_t)copy_bytes);
+                        result = write_to_result_at_pos(al, result, &result_extent, result_len, field, field_len);
+                        result_len += field_len;
                         internal_free(field);
+                        internal_free(truncated);
                     }
+                    internal_free(encoded);
                 } else if (tolower(value[0]) == 'i') {
                     // Integer Editing ( I[w[.m]] )
                     char* temp_buf = (char*)internal_malloc(1); temp_buf[0] = '\0';
@@ -10349,6 +10514,7 @@ typedef struct {
     long record_length;     // length of current record in characters
     int access_id;          // 0=sequential, 1=stream, 2=direct
     int32_t record_len;     // record length for direct access
+    int encoding_mode;      // 0=unknown, 1=UTF-8, 2=default
 } InputSource;
 
 // Shared buffer parsing functions for formatted reads
@@ -10542,6 +10708,24 @@ static void parse_logical_from_buffer(char* buffer, int field_len,
     }
 }
 
+// A destination of character kind > 1 holds `kind`-wide code units. With
+// ENCODING='UTF-8' the field is decoded from UTF-8; otherwise each byte of the
+// field is one character, as both GFortran and LLVM Flang do.
+static void parse_wide_character_from_buffer(char* buffer, int field_len,
+        char* str_data, int64_t str_len, int32_t char_kind, int encoding_mode)
+{
+    if (encoding_mode == 1) {
+        _lfortran_utf8_to_unicode(buffer, field_len, str_data, str_len, char_kind);
+        return;
+    }
+    for (int64_t i = 0; i < str_len; i++) {
+        uint32_t cp = (i < field_len) ? (uint32_t)(unsigned char)buffer[i] : (uint32_t)' ';
+        for (int32_t b = 0; b < char_kind; b++) {
+            str_data[i * char_kind + b] = (char)((cp >> (8 * b)) & 0xff);
+        }
+    }
+}
+
 static void parse_character_from_buffer(char* buffer, int field_len,
         char* str_data, int64_t str_len, int width)
 {
@@ -10714,9 +10898,14 @@ static bool handle_read_A(InputSource *inputSource, va_list *args, int width, bo
     // TODO: Add support for read into descriptor-arrays for character reads
     (void)is_descriptor_array;
     int32_t type_code = va_arg(*args, int32_t);
-    (void)type_code;
     char** str_data_ptr = va_arg(*args, char**);
     int64_t str_len = va_arg(*args, int64_t);
+    // Type code 8 marks a destination of character kind > 1; it carries the
+    // kind after the length.
+    int32_t char_kind = 1;
+    if (type_code == 8) {
+        char_kind = va_arg(*args, int32_t);
+    }
     (*arg_idx)++;
 
     char* str_data = str_data_ptr ? *str_data_ptr : NULL;
@@ -10735,7 +10924,12 @@ static bool handle_read_A(InputSource *inputSource, va_list *args, int width, bo
         return false;
     }
 
-    parse_character_from_buffer(buffer, field_len, str_data, str_len, read_width);
+    if (char_kind > 1) {
+        parse_wide_character_from_buffer(buffer, field_len, str_data, str_len,
+            char_kind, inputSource->encoding_mode);
+    } else {
+        parse_character_from_buffer(buffer, field_len, str_data, str_len, read_width);
+    }
 
     internal_free(buffer);
     return true;
@@ -11374,16 +11568,19 @@ LFORTRAN_API void _lfortran_formatted_read(
     int pad_mode;
     inputSource.access_id = 0;
     inputSource.record_len = 0;
+    inputSource.encoding_mode = 0;
 
     if (unit_num != -1) {
         int access_id = 0;
         int32_t unit_recl = 0;
         bool read_access = true;
+        int encoding_mode = 0;
         inputSource.inputMethod = INPUT_FILE;
         inputSource.file = get_file_pointer_from_unit(unit_num, &unit_file_bin,
-            &access_id, &read_access, NULL, NULL, &blank_zero, &unit_recl, NULL, NULL, NULL, NULL, &pad_mode);
+            &access_id, &read_access, NULL, NULL, &blank_zero, &unit_recl, NULL, NULL, &encoding_mode, NULL, &pad_mode);
         inputSource.access_id = access_id;
         inputSource.record_len = unit_recl;
+        inputSource.encoding_mode = encoding_mode;
         if (!inputSource.file) {
             if (iostat) { *iostat = 1; return; }
             printf("No file found with given unit\n");
@@ -12068,6 +12265,14 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
         va_start(args, format_len);
         char* str = va_arg(args, char*);
         int64_t str_len = va_arg(args, int64_t);
+        // `%S` marks a value of character kind > 1: it carries a kind after the
+        // length, and its code units are written out as UTF-8.
+        char* wide_encoded = NULL;
+        if (format_data[1] == 'S') {
+            int32_t str_kind = va_arg(args, int32_t);
+            wide_encoded = _lfortran_unicode_to_utf8(str, str_len, str_kind, &str_len);
+            str = wide_encoded;
+        }
 
         // Detect "\b" to raise error
         if(str_len > 0 && str[0] == '\b'){
@@ -12090,7 +12295,7 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
 
         char* end = NULL;
         int64_t end_len = 0;
-        if(strcmp(format_data, "%s%s") == 0){
+        if(strcmp(format_data + 2, "%s") == 0){
             end = va_arg(args, char*);
             end_len = va_arg(args, int64_t);
         } else if (strcmp(format_data, "%s") != 0){
@@ -12164,6 +12369,7 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
 
 
         if(iostat != NULL) *iostat = 0;
+        internal_free(wide_encoded);
         va_end(args);
     }
     // Only truncate actual files, not stdout/stderr
@@ -12175,7 +12381,7 @@ LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const 
 }
 
 LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_holder, bool is_allocatable, bool is_deferred,
-    bool is_array_unit, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
+    bool is_array_unit, int32_t char_kind, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
     int64_t format_len, ...) {
     va_list args;
     va_start(args, format_len);
@@ -12234,11 +12440,17 @@ LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_ho
                 while (end < str_len && str[end] != '\n') {
                     end++;
                 }
-                _lfortran_copy_str_and_pad(
-                    (*str_holder) + rec * (*len),
-                    *len,
-                    str + start,
-                    end - start, 1);
+                if (char_kind > 1) {
+                    // The record is UTF-8; the target holds code units.
+                    _lfortran_utf8_to_unicode(str + start, end - start,
+                        (*str_holder) + rec * (*len) * char_kind, *len, char_kind);
+                } else {
+                    _lfortran_copy_str_and_pad(
+                        (*str_holder) + rec * (*len),
+                        *len,
+                        str + start,
+                        end - start, 1);
+                }
                 rec++;
                 if (end >= str_len) {
                     break;
@@ -12248,9 +12460,25 @@ LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_ho
 
             // Remaining records (beyond the output list) are left
             // unchanged, per the Fortran standard.
+        } else if (char_kind > 1) {
+            _lfortran_utf8_to_unicode(str, str_len, *str_holder, *len, char_kind);
         } else {
             _lfortran_copy_str_and_pad(*str_holder, *len, str, str_len, 1);
         }
+    } else if (char_kind > 1) {
+        // A deferred length kind 4 target takes one character per code point
+        // of the record.
+        int64_t char_count = 0;
+        for (int64_t i = 0; i < str_len; ) {
+            int seq = utf8_sequence_length((unsigned char)str[i]);
+            i += (seq == 0 || i + seq > str_len) ? 1 : seq;
+            char_count++;
+        }
+        char* decoded = (char*)internal_malloc((size_t)(char_count * char_kind + 1));
+        _lfortran_utf8_to_unicode(str, str_len, decoded, char_count, char_kind);
+        _lfortran_strcpy_alloc(al, str_holder, len, is_allocatable, is_deferred,
+            decoded, char_count, char_kind);
+        internal_free(decoded);
     } else {
         _lfortran_strcpy_alloc(al, str_holder, len, is_allocatable, is_deferred, str, str_len, 1);
     }

--- a/src/libasr/runtime/lfortran_intrinsics.h
+++ b/src/libasr/runtime/lfortran_intrinsics.h
@@ -108,7 +108,7 @@ LFORTRAN_API int _lfortran_init_random_seed(unsigned seed);
 LFORTRAN_API double _lfortran_random();
 LFORTRAN_API int _lfortran_randrange(int lower, int upper);
 LFORTRAN_API int _lfortran_random_int(int lower, int upper);
-LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_t str_len, const fchar* end, uint32_t end_len);
+LFORTRAN_API void _lfortran_printf(const char* format, const fchar* str, uint32_t str_len, int32_t str_kind, const fchar* end, uint32_t end_len);
 LFORTRAN_API char* _lcompilers_snprintf_alloc(lfortran_allocator_t* al, const char* format, ...);
 LFORTRAN_API void _lcompilers_print_error(const char* format, ...);
 LFORTRAN_API void _lfortran_complex_add_32(struct _lfortran_complex_32* a,
@@ -355,7 +355,7 @@ LFORTRAN_API void _lfortran_read_array_complex_double(struct _lfortran_complex_6
 LFORTRAN_API void _lfortran_read_array_char(char *p, int64_t length, int array_size, int32_t unit_num, int32_t *iostat);
 LFORTRAN_API void _lfortran_read_char(char **p, int64_t p_len, int32_t unit_num, int32_t *iostat);
 LFORTRAN_API void _lfortran_string_write(lfortran_allocator_t* al, char **str_holder, bool is_allocatable, bool is_deferred,
-        bool is_array_unit, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
+        bool is_array_unit, int32_t char_kind, int64_t array_size, int64_t* len, int32_t* iostat, const char* format,
         int64_t format_len, ...);
 LFORTRAN_API void _lfortran_file_write(int32_t unit_num, int32_t* iostat, const char* format_data, int64_t format_len, ...);
 LFORTRAN_API void _lfortran_set_child_io(int32_t unit_num, int32_t is_child);

--- a/src/libasr/string_utils.cpp
+++ b/src/libasr/string_utils.cpp
@@ -302,4 +302,156 @@ void rtrim(std::string& str) {
     str.erase(std::find_if_not(str.rbegin(), str.rend(), ::isspace).base(), str.end());
 }
 
+// UTF-8 helpers ------------------------------------------------------------
+
+namespace {
+
+// Length in bytes of the UTF-8 sequence a lead byte starts, or 0 if `c` is not
+// a valid lead byte.
+size_t utf8_sequence_length(unsigned char c) {
+    if (c < 0x80) return 1;
+    if ((c & 0xe0) == 0xc0) return 2;
+    if ((c & 0xf0) == 0xe0) return 3;
+    if ((c & 0xf8) == 0xf0) return 4;
+    return 0;
+}
+
+// The code point bits a lead byte contributes.
+uint32_t utf8_lead_bits(unsigned char c, size_t length) {
+    switch (length) {
+        case 1: return c;
+        case 2: return c & 0x1f;
+        case 3: return c & 0x0f;
+        default: return c & 0x07;
+    }
+}
+
+} // anonymous namespace
+
+bool is_valid_utf8(const char *value, size_t size) {
+    size_t i = 0;
+    while (i < size) {
+        const unsigned char c = static_cast<unsigned char>(value[i]);
+        const size_t length = utf8_sequence_length(c);
+        if (length == 0) return false;
+        if (length == 1) {
+            i++;
+            continue;
+        }
+        if (i + length > size) return false;
+        uint32_t code_point = utf8_lead_bits(c, length);
+        for (size_t k = 1; k < length; k++) {
+            const unsigned char cont =
+                static_cast<unsigned char>(value[i + k]);
+            if ((cont & 0xc0) != 0x80) return false;
+            code_point = (code_point << 6) | (cont & 0x3f);
+        }
+        if (length == 2 && code_point < 0x80) return false;
+        if (length == 3 && code_point < 0x800) return false;
+        if (length == 4 && code_point < 0x10000) return false;
+        if (code_point > 0x10ffff) return false;
+        if (code_point >= 0xd800 && code_point <= 0xdfff) return false;
+        i += length;
+    }
+    return true;
+}
+
+bool is_valid_utf8(const std::string &value) {
+    return is_valid_utf8(value.data(), value.size());
+}
+
+std::vector<uint32_t> utf8_decode(const std::string &s) {
+    std::vector<uint32_t> code_points;
+    size_t i = 0;
+    while (i < s.size()) {
+        const unsigned char c = static_cast<unsigned char>(s[i]);
+        size_t length = utf8_sequence_length(c);
+        if (length == 0 || i + length > s.size()) {
+            // Not well-formed: pass the byte through so callers that did not
+            // validate still make progress instead of running off the end.
+            code_points.push_back(c);
+            i++;
+            continue;
+        }
+        uint32_t code_point = utf8_lead_bits(c, length);
+        for (size_t k = 1; k < length; k++) {
+            code_point = (code_point << 6) |
+                (static_cast<unsigned char>(s[i + k]) & 0x3f);
+        }
+        code_points.push_back(code_point);
+        i += length;
+    }
+    return code_points;
+}
+
+size_t utf8_codepoint_count(const std::string &s) {
+    size_t count = 0;
+    size_t i = 0;
+    while (i < s.size()) {
+        const size_t length =
+            utf8_sequence_length(static_cast<unsigned char>(s[i]));
+        i += (length == 0 || i + length > s.size()) ? 1 : length;
+        count++;
+    }
+    return count;
+}
+
+size_t utf8_codepoint_count(const char *s) {
+    return utf8_codepoint_count(std::string(s));
+}
+
+void utf8_encode_codepoint(std::string &out, uint32_t code_point) {
+    if (code_point <= 0x7f) {
+        out += static_cast<char>(code_point);
+    } else if (code_point <= 0x7ff) {
+        out += static_cast<char>(0xc0 | (code_point >> 6));
+        out += static_cast<char>(0x80 | (code_point & 0x3f));
+    } else if (code_point <= 0xffff) {
+        out += static_cast<char>(0xe0 | (code_point >> 12));
+        out += static_cast<char>(0x80 | ((code_point >> 6) & 0x3f));
+        out += static_cast<char>(0x80 | (code_point & 0x3f));
+    } else {
+        out += static_cast<char>(0xf0 | (code_point >> 18));
+        out += static_cast<char>(0x80 | ((code_point >> 12) & 0x3f));
+        out += static_cast<char>(0x80 | ((code_point >> 6) & 0x3f));
+        out += static_cast<char>(0x80 | (code_point & 0x3f));
+    }
+}
+
+std::vector<uint8_t> utf8_to_unicode_bytes(const std::string &s, int kind) {
+    std::vector<uint32_t> code_points = utf8_decode(s);
+    std::vector<uint8_t> bytes(code_points.size() * kind);
+    for (size_t idx = 0; idx < code_points.size(); idx++) {
+        const uint32_t cp = code_points[idx];
+        for (int b = 0; b < kind; b++) {
+            bytes[idx * kind + b] = (cp >> (8 * b)) & 0xff;
+        }
+    }
+    return bytes;
+}
+
+std::vector<std::string> utf8_split(const std::string &s) {
+    std::vector<std::string> characters;
+    size_t i = 0;
+    while (i < s.size()) {
+        size_t length = utf8_sequence_length(static_cast<unsigned char>(s[i]));
+        if (length == 0 || i + length > s.size()) length = 1;
+        characters.push_back(s.substr(i, length));
+        i += length;
+    }
+    return characters;
+}
+
+std::string unicode_bytes_to_utf8(const uint8_t *bytes, size_t count, int kind) {
+    std::string out;
+    for (size_t idx = 0; idx < count; idx++) {
+        uint32_t cp = 0;
+        for (int b = 0; b < kind; b++) {
+            cp |= static_cast<uint32_t>(bytes[idx * kind + b]) << (8 * b);
+        }
+        utf8_encode_codepoint(out, cp);
+    }
+    return out;
+}
+
 } // namespace LCompilers

--- a/src/libasr/string_utils.h
+++ b/src/libasr/string_utils.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <cctype>
 
 #include <libasr/alloc.h>
@@ -53,6 +54,44 @@ char* str_unescape_fortran(Allocator &al, LCompilers::Str &s, char ch);
 
 bool str_compare(const unsigned char *pos, std::string s);
 void rtrim(std::string& str);
+
+// UTF-8 helpers ------------------------------------------------------------
+//
+// A CHARACTER value of kind > 1 is stored in ASR as UTF-8 in
+// `StringConstant::m_s` (a `char*` cannot carry the embedded null bytes that
+// raw UCS-4 would produce), while its ASR length is a count of characters.
+// These helpers convert between the two.
+
+// Returns true if `value` is well-formed UTF-8. Overlong forms, surrogates and
+// out-of-range code points are rejected.
+bool is_valid_utf8(const char *value, size_t size);
+bool is_valid_utf8(const std::string &value);
+
+// Decodes well-formed UTF-8 into code points. The input must already have
+// passed `is_valid_utf8`.
+std::vector<uint32_t> utf8_decode(const std::string &s);
+
+// Number of Unicode code points in `s`, i.e. the Fortran length of the value
+// `s` encodes. Malformed trailing bytes count as one character each, so this
+// never reads past the end of `s`.
+size_t utf8_codepoint_count(const std::string &s);
+size_t utf8_codepoint_count(const char *s);
+
+// Appends the UTF-8 encoding of a single code point to `out`.
+void utf8_encode_codepoint(std::string &out, uint32_t code_point);
+
+// Decodes UTF-8 and serialises each code point as `kind` little-endian bytes:
+// kind 2 gives UCS-2, kind 4 gives UCS-4. This is the in-memory form the
+// backends use.
+std::vector<uint8_t> utf8_to_unicode_bytes(const std::string &s, int kind);
+
+// The inverse of `utf8_to_unicode_bytes`: reads `count` code points of `kind`
+// little-endian bytes each and returns their UTF-8 encoding.
+std::string unicode_bytes_to_utf8(const uint8_t *bytes, size_t count, int kind);
+
+// Splits UTF-8 into one string per code point. Malformed trailing bytes are
+// returned as single byte entries rather than dropped.
+std::vector<std::string> utf8_split(const std::string &s);
 
 } // namespace LCompilers
 

--- a/tests/errors/char4_backend_c.f90
+++ b/tests/errors/char4_backend_c.f90
@@ -1,0 +1,8 @@
+program char4_backend_c
+! The C, C++ and WASM backends represent a character value as a byte string,
+! so they cannot carry the four byte code units of ISO 10646. They must say so
+! rather than silently emitting a byte string.
+character(kind=4, len=3) :: wide
+wide = 4_"abc"
+print *, len(wide)
+end program

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -966,6 +966,40 @@ program continue_compilation_1
         values = [(real(r_idx), r_idx = 1, 3)]  ! {Error} The implied do loop variable 'r_idx' must be a scalar integer, not real(4)
         print *, values(1)
     end subroutine
+
+    subroutine character_kind_mixing_concat()
+        implicit none
+        character(kind=4, len=3) :: wide
+        character(len=3) :: narrow
+        wide = 4_"abc"
+        narrow = "xyz"
+        print *, wide // narrow  ! {Error} operands of // must be character with the same kind, found character(4) and character(1)
+    end subroutine
+
+    subroutine character_kind_mixing_compare()
+        implicit none
+        character(kind=4, len=3) :: wide
+        character(len=3) :: narrow
+        wide = 4_"abc"
+        narrow = "xyz"
+        if (wide == narrow) print *, "eq"  ! {Error} operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
+    end subroutine
+
+    subroutine character_literal_kind_not_supported()
+        implicit none
+        character(len=4) :: s
+        s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+    end subroutine
+
+    ! Keep the unsupported character kind declarations last: a rejected
+    ! declaration makes the symbol table visitor skip the program units that
+    ! follow it, which would hide the errors expected above.
+    subroutine character_kind_not_supported()
+        implicit none
+        character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
+        character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+        character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
+    end subroutine
 end program
 
 ! A syntax error inside a module makes the parser skip the erroneous

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "84a3b6397734cd4055d21571c3d7b837479ef9b1ec58586c59a46ee1",
+    "infile_hash": "225aedafcfbdd579cc77da7548f73331b6b9411119af8b5db5b1df07",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "76a6b2de5561abe4df3a75104301de648e3e07007d977c9759a59ff3",
+    "stderr_hash": "21c248cf709e49318348b5fa37b69129e90c49925faa086b22c099fb",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -11,10 +11,10 @@ syntax error: implicit statement must appear before declaration and executable s
     |         ^^^^^^^^^^^^^^ 
 
 syntax error: Token 'foo' (of type 'identifier') is unexpected here
-   --> tests/errors/continue_compilation_1.f90:978:7
-    |
-978 |       foo    end type t_recovery
-    |       ^^^ 
+    --> tests/errors/continue_compilation_1.f90:1012:7
+     |
+1012 |       foo    end type t_recovery
+     |       ^^^ 
 
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
   --> tests/errors/continue_compilation_1.f90:53:5 - 57:24
@@ -544,6 +544,24 @@ semantic error: equivalence between a common block variable and this array eleme
 949 |         equivalence (first, alias(1))  ! {Error} equivalence between a common block variable and this array element is not implemented
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
 
+semantic error: kind 2 is not supported for character, only 1 and 4 are
+   --> tests/errors/continue_compilation_1.f90:999:19
+    |
+999 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
+    |                   ^^^^^^ 
+
+semantic error: kind 3 is not supported for character, only 1 and 4 are
+    --> tests/errors/continue_compilation_1.f90:1000:19
+     |
+1000 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+     |                   ^^^^^^ 
+
+semantic error: kind 8 is not supported for character, only 1 and 4 are
+    --> tests/errors/continue_compilation_1.f90:1001:19
+     |
+1001 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
+     |                   ^^^^^^ 
+
 semantic error: Symbol 'undeclared_proc' not declared
    --> tests/errors/continue_compilation_1.f90:640:9
     |
@@ -551,10 +569,10 @@ semantic error: Symbol 'undeclared_proc' not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Derived type 't_recovery' not declared
-   --> tests/errors/continue_compilation_1.f90:981:7
-    |
-981 |       class(t_recovery), intent(in) :: self
-    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+    --> tests/errors/continue_compilation_1.f90:1015:7
+     |
+1015 |       class(t_recovery), intent(in) :: self
+     |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Symbol 'bad_op' not declared
  --> tests/errors/continue_compilation_1.f90:1:2
@@ -1883,3 +1901,21 @@ semantic error: The implied do loop variable 'r_idx' must be a scalar integer, n
     |
 966 |         values = [(real(r_idx), r_idx = 1, 3)]  ! {Error} The implied do loop variable 'r_idx' must be a scalar integer, not real(4)
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: operands of // must be character with the same kind, found character(4) and character(1)
+   --> tests/errors/continue_compilation_1.f90:976:18
+    |
+976 |         print *, wide // narrow  ! {Error} operands of // must be character with the same kind, found character(4) and character(1)
+    |                  ^^^^^^^^^^^^^^ 
+
+semantic error: operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
+   --> tests/errors/continue_compilation_1.f90:985:13
+    |
+985 |         if (wide == narrow) print *, "eq"  ! {Error} operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
+    |             ^^^^^^^^^^^^^^ 
+
+semantic error: kind 3 is not supported for character, only 1 and 4 are
+   --> tests/errors/continue_compilation_1.f90:991:13
+    |
+991 |         s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+    |             ^^^^^^^ 

--- a/tests/reference/c-char4_backend_c-3d5d281.json
+++ b/tests/reference/c-char4_backend_c-3d5d281.json
@@ -1,0 +1,13 @@
+{
+    "basename": "c-char4_backend_c-3d5d281",
+    "cmd": "lfortran --no-color --show-c {infile}",
+    "infile": "tests/errors/char4_backend_c.f90",
+    "infile_hash": "3ece0042443ce9e62eb377b1cb078e9bcad1f840bdf28371e7053f99",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "c-char4_backend_c-3d5d281.stderr",
+    "stderr_hash": "10dd09cf88a06c98a95c4aa66cf4aed263d4f6bdc55c3d66018cb966",
+    "returncode": 1
+}

--- a/tests/reference/c-char4_backend_c-3d5d281.stderr
+++ b/tests/reference/c-char4_backend_c-3d5d281.stderr
@@ -1,0 +1,5 @@
+code generation error: character(kind=4) is not supported by the C backend, only kind 1 is
+ --> tests/errors/char4_backend_c.f90:5:29
+  |
+5 | character(kind=4, len=3) :: wide
+  |                             ^^^^ 

--- a/tests/reference/cpp-char4_backend_c-fc84d5e.json
+++ b/tests/reference/cpp-char4_backend_c-fc84d5e.json
@@ -1,0 +1,13 @@
+{
+    "basename": "cpp-char4_backend_c-fc84d5e",
+    "cmd": "lfortran --no-color --show-cpp {infile}",
+    "infile": "tests/errors/char4_backend_c.f90",
+    "infile_hash": "3ece0042443ce9e62eb377b1cb078e9bcad1f840bdf28371e7053f99",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "cpp-char4_backend_c-fc84d5e.stderr",
+    "stderr_hash": "ea559e568f1d9d6315e9889e69f1f8a338382440381348cabaf418b2",
+    "returncode": 1
+}

--- a/tests/reference/cpp-char4_backend_c-fc84d5e.stderr
+++ b/tests/reference/cpp-char4_backend_c-fc84d5e.stderr
@@ -1,0 +1,5 @@
+code generation error: character(kind=4) is not supported by the C++ backend, only kind 1 is
+ --> tests/errors/char4_backend_c.f90:5:29
+  |
+5 | character(kind=4, len=3) :: wide
+  |                             ^^^^ 

--- a/tests/reference/llvm-allocate_03-495d621.json
+++ b/tests/reference/llvm-allocate_03-495d621.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-allocate_03-495d621.stdout",
-    "stdout_hash": "934b2bee5ecc9890b46ec3aff03c112054d106bdfdbeefab8b96c5c2",
+    "stdout_hash": "a4f07cfd9ad7c71486868ce37e97dee76803dc208f087091ae92d879",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-allocate_03-495d621.stdout
+++ b/tests/reference/llvm-allocate_03-495d621.stdout
@@ -973,7 +973,7 @@ ifcont39:                                         ; preds = %ifcont37
   %437 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %438 = load i64, i64* %437, align 8
   %439 = trunc i64 %438 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @215, i32 0, i32 0), i8* %436, i32 %439, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @198, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @215, i32 0, i32 0), i8* %436, i32 %439, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @198, i32 0, i32 0), i32 1)
   %440 = icmp eq i8* %431, null
   br i1 %440, label %free_done, label %free_nonnull
 
@@ -1584,7 +1584,7 @@ ifcont6:                                          ; preds = %ifcont4
   %135 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %136 = load i64, i64* %135, align 8
   %137 = trunc i64 %136 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %134, i32 %137, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %134, i32 %137, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
   %138 = icmp eq i8* %129, null
   br i1 %138, label %free_done, label %free_nonnull
 
@@ -2023,7 +2023,7 @@ ifcont30:                                         ; preds = %ifcont28
   %400 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc31, i32 0, i32 1
   %401 = load i64, i64* %400, align 8
   %402 = trunc i64 %401 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @73, i32 0, i32 0), i8* %399, i32 %402, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @73, i32 0, i32 0), i8* %399, i32 %402, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1)
   %403 = icmp eq i8* %394, null
   br i1 %403, label %free_done33, label %free_nonnull32
 
@@ -2758,7 +2758,7 @@ ifcont23:                                         ; preds = %ifcont21
   %162 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %163 = load i64, i64* %162, align 8
   %164 = trunc i64 %163 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @127, i32 0, i32 0), i8* %161, i32 %164, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @127, i32 0, i32 0), i8* %161, i32 %164, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @110, i32 0, i32 0), i32 1)
   %165 = icmp eq i8* %156, null
   br i1 %165, label %free_done, label %free_nonnull
 
@@ -3205,7 +3205,7 @@ declare i8* @_lfortran_malloc_alloc(i8*, i64)
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-array_bound_1-6741f43.json
+++ b/tests/reference/llvm-array_bound_1-6741f43.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-array_bound_1-6741f43.stdout",
-    "stdout_hash": "68867feda0934cf6db70b84ef1c11f045219d92ff9d08aa3d1b270cf",
+    "stdout_hash": "3552ea89dcd9469162b89c4a251d15d3c93c06a00cd83535f194d294",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-array_bound_1-6741f43.stdout
+++ b/tests/reference/llvm-array_bound_1-6741f43.stdout
@@ -63,7 +63,7 @@ define i32 @main(i32 %0, i8** %1) {
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %14 = load i64, i64* %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %12, i32 %15, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %16 = icmp eq i8* %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
@@ -90,7 +90,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %27 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %28 = load i64, i64* %27, align 8
   %29 = trunc i64 %28 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %26, i32 %29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %26, i32 %29, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %30 = icmp eq i8* %21, null
   br i1 %30, label %free_done3, label %free_nonnull2
 
@@ -119,7 +119,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %43 = load i64, i64* %42, align 8
   %44 = trunc i64 %43 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %41, i32 %44, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %45 = icmp eq i8* %36, null
   br i1 %45, label %free_done6, label %free_nonnull5
 
@@ -148,7 +148,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %57 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %58 = load i64, i64* %57, align 8
   %59 = trunc i64 %58 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %56, i32 %59, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %56, i32 %59, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %60 = icmp eq i8* %51, null
   br i1 %60, label %free_done9, label %free_nonnull8
 
@@ -173,7 +173,7 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %71 = load i64, i64* %70, align 8
   %72 = trunc i64 %71 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %69, i32 %72, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %69, i32 %72, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %73 = icmp eq i8* %64, null
   br i1 %73, label %free_done12, label %free_nonnull11
 
@@ -198,7 +198,7 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %83 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   %84 = load i64, i64* %83, align 8
   %85 = trunc i64 %84 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %82, i32 %85, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %82, i32 %85, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %86 = icmp eq i8* %77, null
   br i1 %86, label %free_done15, label %free_nonnull14
 
@@ -221,7 +221,7 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %95 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   %96 = load i64, i64* %95, align 8
   %97 = trunc i64 %96 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %94, i32 %97, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %94, i32 %97, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %98 = icmp eq i8* %89, null
   br i1 %98, label %free_done18, label %free_nonnull17
 
@@ -244,7 +244,7 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   %107 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
   %108 = load i64, i64* %107, align 8
   %109 = trunc i64 %108 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %106, i32 %109, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %106, i32 %109, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %110 = icmp eq i8* %101, null
   br i1 %110, label %free_done21, label %free_nonnull20
 
@@ -269,7 +269,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-arrays_101-8ed52ae.json
+++ b/tests/reference/llvm-arrays_101-8ed52ae.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-arrays_101-8ed52ae.stdout",
-    "stdout_hash": "3d53bfb5fed0d2173e9785f585739f0dfa7fe8386a1dbfb4a227178f",
+    "stdout_hash": "d0d6d25166c3b830b6477d44b058f4bf396d91a32d2f8ecde66164f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-arrays_101-8ed52ae.stdout
+++ b/tests/reference/llvm-arrays_101-8ed52ae.stdout
@@ -521,7 +521,7 @@ else51:                                           ; preds = %loop.end49
 
 ifcont52:                                         ; preds = %else51, %then50
   %181 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %181, i32 2, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %181, i32 2, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %ifcont52
@@ -567,7 +567,7 @@ declare void @llvm.stackrestore(i8*) #0
 ; Function Attrs: nounwind readnone speculatable willreturn
 declare float @llvm.fabs.f32(float) #1
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 attributes #0 = { nounwind }
 attributes #1 = { nounwind readnone speculatable willreturn }

--- a/tests/reference/llvm-associate_02-558b0e6.json
+++ b/tests/reference/llvm-associate_02-558b0e6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_02-558b0e6.stdout",
-    "stdout_hash": "d30aa37d429a25d27a0a4772161e32cd7d77f86dc4c1cc5f7c3d74ce",
+    "stdout_hash": "8d0cca576cfafce987d677c57df9f14b37151e34c737fd9cac5731d2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_02-558b0e6.stdout
+++ b/tests/reference/llvm-associate_02-558b0e6.stdout
@@ -72,7 +72,7 @@ define i32 @main(i32 %0, i8** %1) {
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %14 = load i64, i64* %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %12, i32 %15, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %16 = icmp eq i8* %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
@@ -93,7 +93,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %25 = load i64, i64* %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
   br i1 %27, label %free_done3, label %free_nonnull2
 
@@ -123,7 +123,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %44 = load i64, i64* %43, align 8
   %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %42, i32 %45, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %46 = icmp eq i8* %37, null
   br i1 %46, label %free_done6, label %free_nonnull5
 
@@ -144,7 +144,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %55 = load i64, i64* %54, align 8
   %56 = trunc i64 %55 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %57 = icmp eq i8* %48, null
   br i1 %57, label %free_done9, label %free_nonnull8
 
@@ -167,7 +167,7 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %67 = load i64, i64* %66, align 8
   %68 = trunc i64 %67 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %65, i32 %68, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %65, i32 %68, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %69 = icmp eq i8* %60, null
   br i1 %69, label %free_done12, label %free_nonnull11
 
@@ -188,7 +188,7 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   %78 = load i64, i64* %77, align 8
   %79 = trunc i64 %78 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %80 = icmp eq i8* %71, null
   br i1 %80, label %free_done15, label %free_nonnull14
 
@@ -224,7 +224,7 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %102 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   %103 = load i64, i64* %102, align 8
   %104 = trunc i64 %103 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %101, i32 %104, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %101, i32 %104, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %105 = icmp eq i8* %96, null
   br i1 %105, label %free_done18, label %free_nonnull17
 
@@ -245,7 +245,7 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   %113 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
   %114 = load i64, i64* %113, align 8
   %115 = trunc i64 %114 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %112, i32 %115, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %112, i32 %115, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %116 = icmp eq i8* %107, null
   br i1 %116, label %free_done21, label %free_nonnull20
 
@@ -270,7 +270,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-associate_03-68dfbc7.json
+++ b/tests/reference/llvm-associate_03-68dfbc7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_03-68dfbc7.stdout",
-    "stdout_hash": "380481401a2ff635fc6249287ed6082e86892b6feee99b7da4fe9c19",
+    "stdout_hash": "8aceddb595b64b274d288810f512d1609bbaafa7d404e958906a1e1b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_03-68dfbc7.stdout
+++ b/tests/reference/llvm-associate_03-68dfbc7.stdout
@@ -37,7 +37,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -73,7 +73,7 @@ ifcont:                                           ; preds = %else, %then
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %26 = load i64, i64* %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %28 = icmp eq i8* %19, null
   br i1 %28, label %free_done3, label %free_nonnull2
 
@@ -116,7 +116,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-associate_04-97f4e70.json
+++ b/tests/reference/llvm-associate_04-97f4e70.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-associate_04-97f4e70.stdout",
-    "stdout_hash": "29e561c66bb1202d565380fe6249881fc42703c0dc90d7c6e147c74c",
+    "stdout_hash": "6d8370391d6a9e0d64e5f5e829b7943f7141d4204b64a89b35195f2c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-associate_04-97f4e70.stdout
+++ b/tests/reference/llvm-associate_04-97f4e70.stdout
@@ -88,7 +88,7 @@ associate_block_start:                            ; preds = %.entry
   %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %29 = load i64, i64* %28, align 8
   %30 = trunc i64 %29 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %27, i32 %30, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %31 = icmp eq i8* %22, null
   br i1 %31, label %free_done, label %free_nonnull
 
@@ -121,7 +121,7 @@ FINALIZE_SYMTABLE_associate_block:                ; preds = %associate_block_end
   %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %44 = load i64, i64* %43, align 8
   %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %42, i32 %45, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %46 = icmp eq i8* %37, null
   br i1 %46, label %free_done3, label %free_nonnull2
 
@@ -168,7 +168,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.json
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_complex_dp-8ead434.stdout",
-    "stdout_hash": "9463fa88fb15879cfe8f677d825e6bd47eea351555b3b01a7e112904",
+    "stdout_hash": "5cfe9d1fb86dad2e54cd1fd1287d6bfdd3a2719c908d2695bb5ea4d8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
+++ b/tests/reference/llvm-bin_op_complex_dp-8ead434.stdout
@@ -35,7 +35,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -60,7 +60,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.json
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bin_op_real_dp-224f1cf.stdout",
-    "stdout_hash": "625b88edc6e0fccc466cc14993612bc977bfde820d4030b93fef9795",
+    "stdout_hash": "f30edf6e39fe9c1eba2077ac56073d50c28b57996c5a85d57ef82c72",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
+++ b/tests/reference/llvm-bin_op_real_dp-224f1cf.stdout
@@ -33,7 +33,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -58,7 +58,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-bindc3-d064ff7.json
+++ b/tests/reference/llvm-bindc3-d064ff7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bindc3-d064ff7.stdout",
-    "stdout_hash": "b1921503d30e4aa1baee1b5c9136ac723db34167790af4b84fccd2ca",
+    "stdout_hash": "270a840f9afb6a421ad2aca429416cd94185ebf94fe5342abef7f1ca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bindc3-d064ff7.stdout
+++ b/tests/reference/llvm-bindc3-d064ff7.stdout
@@ -54,7 +54,7 @@ define i32 @main(i32 %0, i8** %1) {
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %22 = load i64, i64* %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 %23, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %24 = icmp eq i8* %15, null
   br i1 %24, label %free_done, label %free_nonnull
 
@@ -89,7 +89,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %42 = load i64, i64* %41, align 8
   %43 = trunc i64 %42 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %40, i32 %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %40, i32 %43, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %44 = icmp eq i8* %35, null
   br i1 %44, label %free_done6, label %free_nonnull5
 
@@ -114,7 +114,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-binop_03-d0adef1.json
+++ b/tests/reference/llvm-binop_03-d0adef1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-binop_03-d0adef1.stdout",
-    "stdout_hash": "f3e3083a1639935d2ac46adc550ed153fa34df4a6741292b3024a999",
+    "stdout_hash": "d690a187acdca047222ad196804d125ddeee53daf56160f3caa92093",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-binop_03-d0adef1.stdout
+++ b/tests/reference/llvm-binop_03-d0adef1.stdout
@@ -40,7 +40,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %14 = icmp eq i8* %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
@@ -79,7 +79,7 @@ ifcont:                                           ; preds = %else, %then
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
   %26 = load i64, i64* %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %24, i32 %27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %28 = icmp eq i8* %19, null
   br i1 %28, label %free_done4, label %free_nonnull3
 
@@ -120,7 +120,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-bits_02-925bde2.json
+++ b/tests/reference/llvm-bits_02-925bde2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-bits_02-925bde2.stdout",
-    "stdout_hash": "0493419a432257b0ee42df53b0d406a7960b36f2306a5e49db58e867",
+    "stdout_hash": "51ad91d054eb8114c564c7c50629eef12c89415f9f34290355cdff0c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-bits_02-925bde2.stdout
+++ b/tests/reference/llvm-bits_02-925bde2.stdout
@@ -41,7 +41,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %14 = icmp eq i8* %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
@@ -64,7 +64,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %24 = load i64, i64* %23, align 8
   %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %26 = icmp eq i8* %17, null
   br i1 %26, label %free_done3, label %free_nonnull2
 
@@ -87,7 +87,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %36 = load i64, i64* %35, align 8
   %37 = trunc i64 %36 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %34, i32 %37, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %38 = icmp eq i8* %29, null
   br i1 %38, label %free_done6, label %free_nonnull5
 
@@ -112,7 +112,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-boz_01-def9db5.json
+++ b/tests/reference/llvm-boz_01-def9db5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-boz_01-def9db5.stdout",
-    "stdout_hash": "9e8eab443e96e050b2a4030243f2e595b91aa47fb05dbee5516a6e75",
+    "stdout_hash": "bc0c3827e5e4a229541da163abede894dbacbfc606ad3cf366f95596",
     "stderr": "llvm-boz_01-def9db5.stderr",
     "stderr_hash": "2c1014e4f04672dfbcc83dde266587a98d7dc9651f6401dcaab51839",
     "returncode": 0

--- a/tests/reference/llvm-boz_01-def9db5.stdout
+++ b/tests/reference/llvm-boz_01-def9db5.stdout
@@ -135,7 +135,7 @@ ifcont15:                                         ; preds = %else14, %then13
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %24 = load i64, i64* %23, align 8
   %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %22, i32 %25, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %26 = icmp eq i8* %17, null
   br i1 %26, label %free_done, label %free_nonnull
 
@@ -166,6 +166,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-call_subroutine_without_type_01-1c100d1.stdout",
-    "stdout_hash": "6f8caa387b9640d465862c6d6a05d8ee04a8b8239c1e36df5f17f333",
+    "stdout_hash": "825b4e5c738aec53608a8176f361786816b6cc53c032ac8fcf3fd701",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
+++ b/tests/reference/llvm-call_subroutine_without_type_01-1c100d1.stdout
@@ -8,7 +8,7 @@ target datalayout = "..."
 
 @__module___lcompilers_created__nested_context__module_call_subroutine_without_type_01__get_i__self = global %module_call_subroutine_without_type_01.mytype.3_class* null
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-4,R4\00", align 1
+@serialization_info = private unnamed_addr constant [15 x i8] c"S-DESC-K1-4,R4\00", align 1
 @string_const_data = private constant [4 x i8] c"r = "
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -82,7 +82,7 @@ define void @get_i.__module_module_call_subroutine_without_type_01_get_r() {
   %6 = load float, float* %5, align 4
   %7 = alloca float, align 4
   store float %6, float* %7, align 4
-  %8 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %7)
+  %8 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %7)
   %9 = load i64, i64* %1, align 8
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %8, i8** %10, align 8
@@ -93,7 +93,7 @@ define void @get_i.__module_module_call_subroutine_without_type_01_get_r() {
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %15 = load i64, i64* %14, align 8
   %16 = trunc i64 %15 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %13, i32 %16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %13, i32 %16, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %17 = icmp eq i8* %8, null
   br i1 %17, label %free_done, label %free_nonnull
 
@@ -133,7 +133,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-callback_01-facbb46.json
+++ b/tests/reference/llvm-callback_01-facbb46.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_01-facbb46.stdout",
-    "stdout_hash": "f313ecad99265bb798aeff16da0f56728d812c9781680fe5db4db752",
+    "stdout_hash": "f9a71ba44a6a0e97d252eb9771c2d417c9d0ef6a508fa5a4a47da0c4",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_01-facbb46.stdout
+++ b/tests/reference/llvm-callback_01-facbb46.stdout
@@ -50,7 +50,7 @@ define void @__module_callback_01_foo(float* %c, float* %d) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -88,7 +88,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-callback_02-41bc7d7.json
+++ b/tests/reference/llvm-callback_02-41bc7d7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_02-41bc7d7.stdout",
-    "stdout_hash": "0c801165daab85dfb27beaf23cf5ec7f5d3f78c06b310cab4d40d0fc",
+    "stdout_hash": "86753360750608b8b37aa5291fd795fd6b5b49d9cf9b1ace6cdd95ff",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_02-41bc7d7.stdout
+++ b/tests/reference/llvm-callback_02-41bc7d7.stdout
@@ -34,7 +34,7 @@ define void @__module_callback_02_cb(float* %res, float* %a, float* %b, void (fl
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -56,7 +56,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %20 = load i64, i64* %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %22 = icmp eq i8* %13, null
   br i1 %22, label %free_done3, label %free_nonnull2
 
@@ -83,7 +83,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %36 = load i64, i64* %35, align 8
   %37 = trunc i64 %36 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %34, i32 %37, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %38 = icmp eq i8* %29, null
   br i1 %38, label %free_done6, label %free_nonnull5
 
@@ -137,7 +137,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-callback_03-0f44942.json
+++ b/tests/reference/llvm-callback_03-0f44942.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_03-0f44942.stdout",
-    "stdout_hash": "7d301935924f6c0036ca38da126606bdcfeb8bfee9e7fc9154d2071d",
+    "stdout_hash": "ff919349518d643bb621494b238911aaa5b81609c2f50e28f2f2c3be",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_03-0f44942.stdout
+++ b/tests/reference/llvm-callback_03-0f44942.stdout
@@ -53,7 +53,7 @@ define void @__module_callback_03_foo1(float* %c, float* %d) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -106,7 +106,7 @@ define void @__module_callback_03_foo2(float* %c, float* %d) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -144,7 +144,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-callback_04-0d9515f.json
+++ b/tests/reference/llvm-callback_04-0d9515f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_04-0d9515f.stdout",
-    "stdout_hash": "0b214109a977c8a38d7875c8f1051da6ce31a4c00642c9689baad53e",
+    "stdout_hash": "5fd7f947a180398d8ed8e0435b8b744c0c01ca59f33fc1e7db65b142",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_04-0d9515f.stdout
+++ b/tests/reference/llvm-callback_04-0d9515f.stdout
@@ -16,7 +16,7 @@ target datalayout = "..."
 define void @__module_dr_fortran_cb_print_dr() {
 .entry:
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 4, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -43,7 +43,7 @@ declare void @title_or_name()
 define void @__module_dr_fortran_cb_print_fortran() {
 .entry:
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -53,7 +53,7 @@ FINALIZE_SYMTABLE_print_fortran:                  ; preds = %return
   ret void
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-callback_05-c86f2cc.json
+++ b/tests/reference/llvm-callback_05-c86f2cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-callback_05-c86f2cc.stdout",
-    "stdout_hash": "6901359fc4953c3e632e54a96cacf3729526f6438020af2eaa4e5057",
+    "stdout_hash": "c481c8840cb191c0d15699e332a3daf912734d5b102a3f9555788ffd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-callback_05-c86f2cc.stdout
+++ b/tests/reference/llvm-callback_05-c86f2cc.stdout
@@ -37,7 +37,7 @@ define void @px_call1.__module_callback_05_printx(i32* %x) {
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -87,7 +87,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-case_01-09dad75.json
+++ b/tests/reference/llvm-case_01-09dad75.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_01-09dad75.stdout",
-    "stdout_hash": "611707f103a6b5fa9c7976c067bf0ea70c20155407837ad317b428e0",
+    "stdout_hash": "5203b6e4d036e1fc0d6f90881ea36f38b9a278d4a6302f133c76cdeb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_01-09dad75.stdout
+++ b/tests/reference/llvm-case_01-09dad75.stdout
@@ -47,7 +47,7 @@ define i32 @main(i32 %0, i8** %1) {
 then:                                             ; preds = %.entry
   store i64 10, i64* %out, align 8
   %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %4, i32 1, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %ifcont9
 
 else:                                             ; preds = %.entry
@@ -58,7 +58,7 @@ else:                                             ; preds = %.entry
 then1:                                            ; preds = %else
   store i64 20, i64* %out, align 8
   %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 1, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %ifcont8
 
 else2:                                            ; preds = %else
@@ -69,7 +69,7 @@ else2:                                            ; preds = %else
 then3:                                            ; preds = %else2
   store i64 30, i64* %out, align 8
   %10 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %10, i32 1, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %ifcont7
 
 else4:                                            ; preds = %else2
@@ -80,7 +80,7 @@ else4:                                            ; preds = %else2
 then5:                                            ; preds = %else4
   store i64 40, i64* %out, align 8
   %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %13, i32 1, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   br label %ifcont
 
 else6:                                            ; preds = %else4
@@ -117,7 +117,7 @@ ifcont12:                                         ; preds = %else11, %then10
 then13:                                           ; preds = %ifcont12
   store i64 11, i64* %out, align 8
   %18 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %18, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %18, i32 1, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   br label %ifcont18
 
 else14:                                           ; preds = %ifcont12
@@ -134,7 +134,7 @@ else14:                                           ; preds = %ifcont12
 then15:                                           ; preds = %else14
   store i64 22, i64* %out, align 8
   %27 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %27, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %27, i32 5, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   br label %ifcont17
 
 else16:                                           ; preds = %else14
@@ -170,7 +170,7 @@ FINALIZE_SYMTABLE_case_01:                        ; preds = %return
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-case_02-a38c2d8.json
+++ b/tests/reference/llvm-case_02-a38c2d8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_02-a38c2d8.stdout",
-    "stdout_hash": "aadaa25a27aa91b452cc8e12e3b5e58d09276a1b849ce815db2e16e2",
+    "stdout_hash": "6f99e6b8c5b105b376c1196c49f27af07932508ac9cdcc704bfe6691",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_02-a38c2d8.stdout
+++ b/tests/reference/llvm-case_02-a38c2d8.stdout
@@ -33,7 +33,7 @@ target datalayout = "..."
 @string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.11, i32 0, i32 0), i64 13 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
+@serialization_info = private unnamed_addr constant [16 x i8] c"S-DESC-K1-15,I4\00", align 1
 @string_const_data.13 = private constant [15 x i8] c"Your marks are "
 @string_const.14 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.13, i32 0, i32 0), i64 15 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -69,7 +69,7 @@ target datalayout = "..."
 @string_const.28 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.27, i32 0, i32 0), i64 13 }>
 @31 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @32 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.29 = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
+@serialization_info.29 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-15,I4\00", align 1
 @string_const_data.30 = private constant [15 x i8] c"Your marks are "
 @string_const.31 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.30, i32 0, i32 0), i64 15 }>
 @33 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -102,7 +102,7 @@ target datalayout = "..."
 @string_const.45 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.44, i32 0, i32 0), i64 13 }>
 @47 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @48 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.46 = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
+@serialization_info.46 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-15,I4\00", align 1
 @string_const_data.47 = private constant [15 x i8] c"Your marks are "
 @string_const.48 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.47, i32 0, i32 0), i64 15 }>
 @49 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -127,7 +127,7 @@ define i32 @main(i32 %0, i8** %1) {
 then:                                             ; preds = %.entry
   store i32 0, i32* %out, align 4
   %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %ifcont15
 
 else:                                             ; preds = %.entry
@@ -141,7 +141,7 @@ else:                                             ; preds = %.entry
 then1:                                            ; preds = %else
   store i32 1, i32* %out, align 4
   %14 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %14, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %14, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %ifcont14
 
 else2:                                            ; preds = %else
@@ -155,7 +155,7 @@ else2:                                            ; preds = %else
 then3:                                            ; preds = %else2
   store i32 2, i32* %out, align 4
   %20 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %20, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %20, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %ifcont13
 
 else4:                                            ; preds = %else2
@@ -169,7 +169,7 @@ else4:                                            ; preds = %else2
 then5:                                            ; preds = %else4
   store i32 3, i32* %out, align 4
   %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %26, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %26, i32 8, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   br label %ifcont12
 
 else6:                                            ; preds = %else4
@@ -183,7 +183,7 @@ else6:                                            ; preds = %else4
 then7:                                            ; preds = %else6
   store i32 4, i32* %out, align 4
   %32 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %32, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %32, i32 11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   br label %ifcont11
 
 else8:                                            ; preds = %else6
@@ -194,13 +194,13 @@ else8:                                            ; preds = %else6
 then9:                                            ; preds = %else8
   store i32 5, i32* %out, align 4
   %35 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %35, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %35, i32 17, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   br label %ifcont
 
 else10:                                           ; preds = %else8
   store i32 6, i32* %out, align 4
   %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %36, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %36, i32 13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else10, %then9
@@ -220,7 +220,7 @@ ifcont14:                                         ; preds = %ifcont13, %then1
 
 ifcont15:                                         ; preds = %ifcont14, %then
   %37 = alloca i64, align 8
-  %38 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %37, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.14, i32* %marks)
+  %38 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info, i32 0, i32 0), i64* %37, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.14, i32* %marks)
   %39 = load i64, i64* %37, align 8
   %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %38, i8** %40, align 8
@@ -231,7 +231,7 @@ ifcont15:                                         ; preds = %ifcont14, %then
   %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %45 = load i64, i64* %44, align 8
   %46 = trunc i64 %45 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %43, i32 %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %43, i32 %46, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %47 = icmp eq i8* %38, null
   br i1 %47, label %free_done, label %free_nonnull
 
@@ -263,7 +263,7 @@ ifcont18:                                         ; preds = %else17, %then16
 
 then19:                                           ; preds = %ifcont18
   %55 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %55, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %55, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
   br label %ifcont36
 
 else20:                                           ; preds = %ifcont18
@@ -276,7 +276,7 @@ else20:                                           ; preds = %ifcont18
 
 then21:                                           ; preds = %else20
   %61 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.18, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %61, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %61, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
   br label %ifcont35
 
 else22:                                           ; preds = %else20
@@ -289,7 +289,7 @@ else22:                                           ; preds = %else20
 
 then23:                                           ; preds = %else22
   %67 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.20, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %67, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %67, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
   br label %ifcont34
 
 else24:                                           ; preds = %else22
@@ -302,7 +302,7 @@ else24:                                           ; preds = %else22
 
 then25:                                           ; preds = %else24
   %73 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.22, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %73, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %73, i32 8, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
   br label %ifcont33
 
 else26:                                           ; preds = %else24
@@ -315,7 +315,7 @@ else26:                                           ; preds = %else24
 
 then27:                                           ; preds = %else26
   %79 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.24, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %79, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %79, i32 11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
   br label %ifcont32
 
 else28:                                           ; preds = %else26
@@ -325,12 +325,12 @@ else28:                                           ; preds = %else26
 
 then29:                                           ; preds = %else28
   %82 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.26, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %82, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %82, i32 17, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
   br label %ifcont31
 
 else30:                                           ; preds = %else28
   %83 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.28, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %83, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %83, i32 13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
   br label %ifcont31
 
 ifcont31:                                         ; preds = %else30, %then29
@@ -350,7 +350,7 @@ ifcont35:                                         ; preds = %ifcont34, %then21
 
 ifcont36:                                         ; preds = %ifcont35, %then19
   %84 = alloca i64, align 8
-  %85 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.29, i32 0, i32 0), i64* %84, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.31, i32* %marks)
+  %85 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.29, i32 0, i32 0), i64* %84, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.31, i32* %marks)
   %86 = load i64, i64* %84, align 8
   %87 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 0
   store i8* %85, i8** %87, align 8
@@ -361,7 +361,7 @@ ifcont36:                                         ; preds = %ifcont35, %then19
   %91 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc37, i32 0, i32 1
   %92 = load i64, i64* %91, align 8
   %93 = trunc i64 %92 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* %90, i32 %93, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* %90, i32 %93, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0), i32 1)
   %94 = icmp eq i8* %85, null
   br i1 %94, label %free_done39, label %free_nonnull38
 
@@ -379,7 +379,7 @@ free_done39:                                      ; preds = %free_nonnull38, %if
 
 then40:                                           ; preds = %free_done39
   %100 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.33, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %100, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %100, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
   br label %ifcont57
 
 else41:                                           ; preds = %free_done39
@@ -392,7 +392,7 @@ else41:                                           ; preds = %free_done39
 
 then42:                                           ; preds = %else41
   %106 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.35, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %106, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %106, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
   br label %ifcont56
 
 else43:                                           ; preds = %else41
@@ -405,7 +405,7 @@ else43:                                           ; preds = %else41
 
 then44:                                           ; preds = %else43
   %112 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.37, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %112, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %112, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
   br label %ifcont55
 
 else45:                                           ; preds = %else43
@@ -418,7 +418,7 @@ else45:                                           ; preds = %else43
 
 then46:                                           ; preds = %else45
   %118 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.39, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* %118, i32 8, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* %118, i32 8, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0), i32 1)
   br label %ifcont54
 
 else47:                                           ; preds = %else45
@@ -431,7 +431,7 @@ else47:                                           ; preds = %else45
 
 then48:                                           ; preds = %else47
   %124 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.41, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %124, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %124, i32 11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
   br label %ifcont53
 
 else49:                                           ; preds = %else47
@@ -441,12 +441,12 @@ else49:                                           ; preds = %else47
 
 then50:                                           ; preds = %else49
   %127 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.43, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %127, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %127, i32 17, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
   br label %ifcont52
 
 else51:                                           ; preds = %else49
   %128 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.45, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* %128, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* %128, i32 13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0), i32 1)
   br label %ifcont52
 
 ifcont52:                                         ; preds = %else51, %then50
@@ -466,7 +466,7 @@ ifcont56:                                         ; preds = %ifcont55, %then42
 
 ifcont57:                                         ; preds = %ifcont56, %then40
   %129 = alloca i64, align 8
-  %130 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.46, i32 0, i32 0), i64* %129, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.48, i32* %marks)
+  %130 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.46, i32 0, i32 0), i64* %129, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.48, i32* %marks)
   %131 = load i64, i64* %129, align 8
   %132 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 0
   store i8* %130, i8** %132, align 8
@@ -477,7 +477,7 @@ ifcont57:                                         ; preds = %ifcont56, %then40
   %136 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc58, i32 0, i32 1
   %137 = load i64, i64* %136, align 8
   %138 = trunc i64 %137 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %135, i32 %138, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %135, i32 %138, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 1)
   %139 = icmp eq i8* %130, null
   br i1 %139, label %free_done60, label %free_nonnull59
 
@@ -498,7 +498,7 @@ FINALIZE_SYMTABLE_case_02:                        ; preds = %return
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 

--- a/tests/reference/llvm-case_03-c3a5078.json
+++ b/tests/reference/llvm-case_03-c3a5078.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-case_03-c3a5078.stdout",
-    "stdout_hash": "7be68fac3906f3700b0f4511e9e251bf898da3384a2450631cd04b51",
+    "stdout_hash": "f8b75b0bfbfd576caadd0b8c7fa3874e25241eee58a3870a2e679048",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-case_03-c3a5078.stdout
+++ b/tests/reference/llvm-case_03-c3a5078.stdout
@@ -17,7 +17,7 @@ target datalayout = "..."
 @string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.3, i32 0, i32 0), i64 13 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
+@serialization_info = private unnamed_addr constant [16 x i8] c"S-DESC-K1-15,I4\00", align 1
 @string_const_data.5 = private constant [15 x i8] c"Your marks are "
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.5, i32 0, i32 0), i64 15 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -34,7 +34,7 @@ target datalayout = "..."
 @string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([13 x i8], [13 x i8]* @string_const_data.11, i32 0, i32 0), i64 13 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.13 = private unnamed_addr constant [13 x i8] c"S-DESC-15,I4\00", align 1
+@serialization_info.13 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-15,I4\00", align 1
 @string_const_data.14 = private constant [15 x i8] c"Your marks are "
 @string_const.15 = private global %string_descriptor <{ i8* getelementptr inbounds ([15 x i8], [15 x i8]* @string_const_data.14, i32 0, i32 0), i64 15 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -57,7 +57,7 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   %5 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %5, i32 5, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %ifcont3
 
 else:                                             ; preds = %.entry
@@ -67,12 +67,12 @@ else:                                             ; preds = %.entry
 
 then1:                                            ; preds = %else
   %8 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %8, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %8, i32 7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %ifcont
 
 else2:                                            ; preds = %else
   %9 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %9, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %9, i32 13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else2, %then1
@@ -80,7 +80,7 @@ ifcont:                                           ; preds = %else2, %then1
 
 ifcont3:                                          ; preds = %ifcont, %then
   %10 = alloca i64, align 8
-  %11 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %10, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %marks)
+  %11 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info, i32 0, i32 0), i64* %10, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %marks)
   %12 = load i64, i64* %10, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
@@ -91,7 +91,7 @@ ifcont3:                                          ; preds = %ifcont, %then
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %18 = load i64, i64* %17, align 8
   %19 = trunc i64 %18 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %16, i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %16, i32 %19, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %20 = icmp eq i8* %11, null
   br i1 %20, label %free_done, label %free_nonnull
 
@@ -107,7 +107,7 @@ free_done:                                        ; preds = %free_nonnull, %ifco
 
 then4:                                            ; preds = %free_done
   %23 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %23, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %23, i32 5, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   br label %ifcont9
 
 else5:                                            ; preds = %free_done
@@ -120,12 +120,12 @@ else5:                                            ; preds = %free_done
 
 then6:                                            ; preds = %else5
   %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %29, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %29, i32 7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   br label %ifcont8
 
 else7:                                            ; preds = %else5
   %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %30, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %30, i32 13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   br label %ifcont8
 
 ifcont8:                                          ; preds = %else7, %then6
@@ -133,7 +133,7 @@ ifcont8:                                          ; preds = %else7, %then6
 
 ifcont9:                                          ; preds = %ifcont8, %then4
   %31 = alloca i64, align 8
-  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %31, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %marks)
+  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.13, i32 0, i32 0), i64* %31, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %marks)
   %33 = load i64, i64* %31, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %32, i8** %34, align 8
@@ -144,7 +144,7 @@ ifcont9:                                          ; preds = %ifcont8, %then4
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %39 = load i64, i64* %38, align 8
   %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %37, i32 %40, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %41 = icmp eq i8* %32, null
   br i1 %41, label %free_done12, label %free_nonnull11
 
@@ -165,7 +165,7 @@ FINALIZE_SYMTABLE_case03:                         ; preds = %return
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 

--- a/tests/reference/llvm-class_01-82031c0.json
+++ b/tests/reference/llvm-class_01-82031c0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_01-82031c0.stdout",
-    "stdout_hash": "b78533f938453da6836df7277c749551768ce05840ff655f9197f4a9",
+    "stdout_hash": "1dc0d3d436f7e5875af9c8635d302fb741900a388cda52b8d3a196d2",
     "stderr": "llvm-class_01-82031c0.stderr",
     "stderr_hash": "83b7bc133c115994c08e9afc99edb6e1e19ce354b399bf4374f7b855",
     "returncode": 0

--- a/tests/reference/llvm-class_01-82031c0.stdout
+++ b/tests/reference/llvm-class_01-82031c0.stdout
@@ -11,7 +11,7 @@ target datalayout = "..."
 @_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
 @_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle1_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle1_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_3_of_class_circle1_for_UPoly to i8*), i8* bitcast (float (%class_circle1.circle.3_class*)* @__module_class_circle1_circle_area to i8*), i8* bitcast (void (%class_circle1.circle.3_class*)* @__module_class_circle1_circle_print to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-12,R4,S-DESC-8,R4\00", align 1
+@serialization_info = private unnamed_addr constant [31 x i8] c"S-DESC-K1-12,R4,S-DESC-K1-8,R4\00", align 1
 @string_const_data = private constant [12 x i8] c"Circle: r = "
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data, i32 0, i32 0), i64 12 }>
 @string_const_data.1 = private constant [8 x i8] c" area = "
@@ -57,7 +57,7 @@ define void @__module_class_circle1_circle_print(%class_circle1.circle.3_class* 
   %10 = load float, float* %9, align 4
   %11 = alloca float, align 4
   store float %10, float* %11, align 4
-  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %11, %string_descriptor* @string_const.2, float* %area)
+  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([31 x i8], [31 x i8]* @serialization_info, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %11, %string_descriptor* @string_const.2, float* %area)
   %13 = load i64, i64* %6, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %12, i8** %14, align 8
@@ -68,7 +68,7 @@ define void @__module_class_circle1_circle_print(%class_circle1.circle.3_class* 
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %19 = load i64, i64* %18, align 8
   %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %21 = icmp eq i8* %12, null
   br i1 %21, label %free_done, label %free_nonnull
 
@@ -141,7 +141,7 @@ declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) 
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-class_02-82c2f9c.json
+++ b/tests/reference/llvm-class_02-82c2f9c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_02-82c2f9c.stdout",
-    "stdout_hash": "c42a69db27055df0a09471939b6d933a4b90a7820b109c07b8c7a50e",
+    "stdout_hash": "104a8b7138e45c51c27710675e268fc28aff8b20ed8fac1cb069396f",
     "stderr": "llvm-class_02-82c2f9c.stderr",
     "stderr_hash": "cbe4c6f9d712b9d5ee417de42e2ce3b69d43ea5a0b463256ad71acfe",
     "returncode": 0

--- a/tests/reference/llvm-class_02-82c2f9c.stdout
+++ b/tests/reference/llvm-class_02-82c2f9c.stdout
@@ -11,7 +11,7 @@ target datalayout = "..."
 @_Type_Info_circle = linkonce_odr unnamed_addr constant { i8*, i8*, i8* } { i8* getelementptr inbounds ([7 x i8], [7 x i8]* @_Name_circle, i32 0, i32 0), i8* inttoptr (i64 4 to i8*), i8* null }, align 8
 @_VTable_circle = linkonce_odr unnamed_addr constant { [7 x i8*] } { [7 x i8*] [i8* null, i8* bitcast ({ i8*, i8*, i8* }* @_Type_Info_circle to i8*), i8* bitcast (void (i8*, i8*)* @_copy_class_circle2_circle to i8*), i8* bitcast (void (i8**)* @_allocate_struct_class_circle2_circle to i8*), i8* bitcast (void (i8*)* @finalize_StructType__circle_3_of_class_circle2_for_UPoly to i8*), i8* bitcast (float (%class_circle2.circle.3_class*)* @__module_class_circle2_circle_area to i8*), i8* bitcast (void (%class_circle2.circle.3_class*)* @__module_class_circle2_circle_print to i8*)] }, align 8
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-12,R4,S-DESC-8,R4\00", align 1
+@serialization_info = private unnamed_addr constant [31 x i8] c"S-DESC-K1-12,R4,S-DESC-K1-8,R4\00", align 1
 @string_const_data = private constant [12 x i8] c"Circle: r = "
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([12 x i8], [12 x i8]* @string_const_data, i32 0, i32 0), i64 12 }>
 @string_const_data.1 = private constant [8 x i8] c" area = "
@@ -57,7 +57,7 @@ define void @__module_class_circle2_circle_print(%class_circle2.circle.3_class* 
   %10 = load float, float* %9, align 4
   %11 = alloca float, align 4
   store float %10, float* %11, align 4
-  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %11, %string_descriptor* @string_const.2, float* %area)
+  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([31 x i8], [31 x i8]* @serialization_info, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %11, %string_descriptor* @string_const.2, float* %area)
   %13 = load i64, i64* %6, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %12, i8** %14, align 8
@@ -68,7 +68,7 @@ define void @__module_class_circle2_circle_print(%class_circle2.circle.3_class* 
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %19 = load i64, i64* %18, align 8
   %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %21 = icmp eq i8* %12, null
   br i1 %21, label %free_done, label %free_nonnull
 
@@ -164,7 +164,7 @@ declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) 
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-class_04-290b898.json
+++ b/tests/reference/llvm-class_04-290b898.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-class_04-290b898.stdout",
-    "stdout_hash": "be71c90d75876f5f3a56a47ce168203150a156c5e6dfda8dfa857107",
+    "stdout_hash": "409a1797f5a759d3006ac051d0e1c05ffd36653ecc27afacce74b220",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-class_04-290b898.stdout
+++ b/tests/reference/llvm-class_04-290b898.stdout
@@ -76,7 +76,7 @@ define i32 @main(i32 %0, i8** %1) {
   %39 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %40 = load i64, i64* %39, align 8
   %41 = trunc i64 %40 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %38, i32 %41, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %38, i32 %41, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %42 = icmp eq i8* %33, null
   br i1 %42, label %free_done, label %free_nonnull
 
@@ -103,7 +103,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %55 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %56 = load i64, i64* %55, align 8
   %57 = trunc i64 %56 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %54, i32 %57, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %54, i32 %57, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %58 = icmp eq i8* %49, null
   br i1 %58, label %free_done3, label %free_nonnull2
 
@@ -129,7 +129,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %71 = load i64, i64* %70, align 8
   %72 = trunc i64 %71 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %69, i32 %72, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %69, i32 %72, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %73 = icmp eq i8* %64, null
   br i1 %73, label %free_done6, label %free_nonnull5
 
@@ -181,7 +181,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-classes1-d55a38c.json
+++ b/tests/reference/llvm-classes1-d55a38c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-classes1-d55a38c.stdout",
-    "stdout_hash": "54f31b894aca870b9b6a48a3a0625eac546ba6bc0e1cc5352e96859b",
+    "stdout_hash": "7532c04cd2777d382d3844b785f2c4394edb5f9123b367fe7e11b2ca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-classes1-d55a38c.stdout
+++ b/tests/reference/llvm-classes1-d55a38c.stdout
@@ -62,7 +62,7 @@ define i32 @main(i32 %0, i8** %1) {
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %19 = load i64, i64* %18, align 8
   %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %21 = icmp eq i8* %12, null
   br i1 %21, label %free_done, label %free_nonnull
 
@@ -153,7 +153,7 @@ declare void @llvm.memset.p0i8.i32(i8* nocapture writeonly, i8, i32, i1 immarg) 
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-complex2-092502c.json
+++ b/tests/reference/llvm-complex2-092502c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex2-092502c.stdout",
-    "stdout_hash": "62ab3b90f3c1559bebd513732e5ffbc94c43248ccd558103fb7f134b",
+    "stdout_hash": "add7fb9e98487161dda2e353bbbcfcd2ac8b4c55aa231123ddc60ee0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex2-092502c.stdout
+++ b/tests/reference/llvm-complex2-092502c.stdout
@@ -44,7 +44,7 @@ define i32 @main(i32 %0, i8** %1) {
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %18 = load i64, i64* %17, align 8
   %19 = trunc i64 %18 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %16, i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %16, i32 %19, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %20 = icmp eq i8* %11, null
   br i1 %20, label %free_done, label %free_nonnull
 
@@ -73,7 +73,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %36 = load i64, i64* %35, align 8
   %37 = trunc i64 %36 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %34, i32 %37, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %38 = icmp eq i8* %29, null
   br i1 %38, label %free_done3, label %free_nonnull2
 
@@ -108,7 +108,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %59 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %60 = load i64, i64* %59, align 8
   %61 = trunc i64 %60 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %58, i32 %61, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %58, i32 %61, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %62 = icmp eq i8* %53, null
   br i1 %62, label %free_done6, label %free_nonnull5
 
@@ -133,7 +133,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-complex_div_test-0a2468c.json
+++ b/tests/reference/llvm-complex_div_test-0a2468c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_div_test-0a2468c.stdout",
-    "stdout_hash": "5087456b6dc1ab4106e3d337dd2986ad8a7a0c286bfade0719395077",
+    "stdout_hash": "e4fcac3c5e5d5ef5775b5a07ad312965c936215a7d30e312db674a52",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_div_test-0a2468c.stdout
+++ b/tests/reference/llvm-complex_div_test-0a2468c.stdout
@@ -68,7 +68,7 @@ complex_div_cont:                                 ; preds = %complex_div_r_lt_s,
   %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %33 = load i64, i64* %32, align 8
   %34 = trunc i64 %33 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %31, i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %31, i32 %34, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %35 = icmp eq i8* %26, null
   br i1 %35, label %free_done, label %free_nonnull
 
@@ -127,7 +127,7 @@ complex_div_cont3:                                ; preds = %complex_div_r_lt_s2
   %71 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %72 = load i64, i64* %71, align 8
   %73 = trunc i64 %72 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %70, i32 %73, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %70, i32 %73, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %74 = icmp eq i8* %65, null
   br i1 %74, label %free_done6, label %free_nonnull5
 
@@ -192,7 +192,7 @@ complex_div_cont9:                                ; preds = %complex_div_r_lt_s8
   %116 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %117 = load i64, i64* %116, align 8
   %118 = trunc i64 %117 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %115, i32 %118, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %115, i32 %118, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %119 = icmp eq i8* %110, null
   br i1 %119, label %free_done12, label %free_nonnull11
 
@@ -220,7 +220,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-complex_dp-7286fd2.json
+++ b/tests/reference/llvm-complex_dp-7286fd2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp-7286fd2.stdout",
-    "stdout_hash": "1ab472e71cf9d28daea819611df3753b0deb2370dd82ec599b70d2c4",
+    "stdout_hash": "789465c91e0d90d4bf35198127a63dfb017603646b79fb1629f6a768",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp-7286fd2.stdout
+++ b/tests/reference/llvm-complex_dp-7286fd2.stdout
@@ -33,7 +33,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -58,7 +58,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-complex_dp_param-5efce36.json
+++ b/tests/reference/llvm-complex_dp_param-5efce36.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_dp_param-5efce36.stdout",
-    "stdout_hash": "aa6de0c128626de468525684391f07ca3f513daba639c2463704e61a",
+    "stdout_hash": "afea943f0e1905f17cf82a1bdce70e0421188260ae78b2d52c8e40b8",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_dp_param-5efce36.stdout
+++ b/tests/reference/llvm-complex_dp_param-5efce36.stdout
@@ -37,7 +37,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -62,7 +62,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-complex_mul_test-5a74811.json
+++ b/tests/reference/llvm-complex_mul_test-5a74811.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_mul_test-5a74811.stdout",
-    "stdout_hash": "44d5dec9dc4da918de8df62ee311317c599c472c0c2978d0b672a464",
+    "stdout_hash": "14a5cc3ba0a31a7aeae052449d06a7b1750bf93920eba8663caf6ee7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_mul_test-5a74811.stdout
+++ b/tests/reference/llvm-complex_mul_test-5a74811.stdout
@@ -48,7 +48,7 @@ define i32 @main(i32 %0, i8** %1) {
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %22 = load i64, i64* %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 %23, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %24 = icmp eq i8* %15, null
   br i1 %24, label %free_done, label %free_nonnull
 
@@ -81,7 +81,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %44 = load i64, i64* %43, align 8
   %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %42, i32 %45, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %46 = icmp eq i8* %37, null
   br i1 %46, label %free_done3, label %free_nonnull2
 
@@ -114,7 +114,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %66 = load i64, i64* %65, align 8
   %67 = trunc i64 %66 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %64, i32 %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %64, i32 %67, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %68 = icmp eq i8* %59, null
   br i1 %68, label %free_done6, label %free_nonnull5
 
@@ -139,7 +139,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-complex_pow_test-2b160e8.json
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_pow_test-2b160e8.stdout",
-    "stdout_hash": "004884fb21f8c88daddbb83cb0213ae6c820977883bdc0ee06df0d9f",
+    "stdout_hash": "ef2fa321984fe4fec538ab10ab687379f280a8d289aca2c455669255",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_pow_test-2b160e8.stdout
+++ b/tests/reference/llvm-complex_pow_test-2b160e8.stdout
@@ -45,7 +45,7 @@ define i32 @main(i32 %0, i8** %1) {
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %21 = load i64, i64* %20, align 8
   %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i32 %22, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %23 = icmp eq i8* %14, null
   br i1 %23, label %free_done, label %free_nonnull
 
@@ -72,7 +72,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-complex_sub_test-7959339.json
+++ b/tests/reference/llvm-complex_sub_test-7959339.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-complex_sub_test-7959339.stdout",
-    "stdout_hash": "d6421afd327db58bbc727e3a1bf0f600222763dff8ff4e2dfd554a99",
+    "stdout_hash": "c27aca06cd1b77dcc1c3ea213959f211cb7aada628bbab12ed82db85",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-complex_sub_test-7959339.stdout
+++ b/tests/reference/llvm-complex_sub_test-7959339.stdout
@@ -52,7 +52,7 @@ define i32 @main(i32 %0, i8** %1) {
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %25 = load i64, i64* %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %23, i32 %26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
   br i1 %27, label %free_done, label %free_nonnull
 
@@ -81,7 +81,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %42 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %43 = load i64, i64* %42, align 8
   %44 = trunc i64 %43 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %41, i32 %44, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %41, i32 %44, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %45 = icmp eq i8* %36, null
   br i1 %45, label %free_done3, label %free_nonnull2
 
@@ -110,7 +110,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %61 = load i64, i64* %60, align 8
   %62 = trunc i64 %61 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %59, i32 %62, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %59, i32 %62, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %63 = icmp eq i8* %54, null
   br i1 %63, label %free_done6, label %free_nonnull5
 
@@ -135,7 +135,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-const_real_dp-e0fca56.json
+++ b/tests/reference/llvm-const_real_dp-e0fca56.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-const_real_dp-e0fca56.stdout",
-    "stdout_hash": "e46655177b7bd04727c51632bdd2bf3a744097bba5dee6b2d885b6f4",
+    "stdout_hash": "f3da2e1007c0c922fba67dc2d87e300b6023ec0281a0a9af7c7aaed5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-const_real_dp-e0fca56.stdout
+++ b/tests/reference/llvm-const_real_dp-e0fca56.stdout
@@ -33,7 +33,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -58,7 +58,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-derived_types_32-4684b97.json
+++ b/tests/reference/llvm-derived_types_32-4684b97.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-derived_types_32-4684b97.stdout",
-    "stdout_hash": "e30242de2cfaa19c608b10d30ed29307c906d00c33b52ec6480e6365",
+    "stdout_hash": "0a638aa66f1a53c367740ef1cadeaca5e334f0524a02040701429505",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-derived_types_32-4684b97.stdout
+++ b/tests/reference/llvm-derived_types_32-4684b97.stdout
@@ -14,7 +14,7 @@ target datalayout = "..."
 @string_const_data.1 = private constant [1 x i8] c" "
 @string_const.2 = private global %string_descriptor <{ i8* getelementptr inbounds ([1 x i8], [1 x i8]* @string_const_data.1, i32 0, i32 0), i64 1 }>
 @3 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.3 = private unnamed_addr constant [7 x i8] c"S-DESC\00", align 1
+@serialization_info.3 = private unnamed_addr constant [10 x i8] c"S-DESC-K1\00", align 1
 @4 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @string_const_data.4 = private constant [18 x i8] c"10.000000000000000"
 @string_const.5 = private global %string_descriptor <{ i8* getelementptr inbounds ([18 x i8], [18 x i8]* @string_const_data.4, i32 0, i32 0), i64 18 }>
@@ -199,7 +199,7 @@ ifcont:                                           ; preds = %else, %then
   %27 = load i8*, i8** %26, align 8
   %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %29 = load i64, i64* %28, align 8
-  call void (i8*, i8**, i8, i8, i8, i64, i64*, i32*, i8*, i64, ...) @_lfortran_string_write(i8* %0, i8** %16, i8 0, i8 0, i8 0, i64 1, i64* %17, i32* %19, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0), i64 2, i8* %27, i64 %29)
+  call void (i8*, i8**, i8, i8, i8, i32, i64, i64*, i32*, i8*, i64, ...) @_lfortran_string_write(i8* %0, i8** %16, i8 0, i8 0, i8 0, i32 1, i64 1, i64* %17, i32* %19, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @2, i32 0, i32 0), i64 2, i8* %27, i64 %29)
   %30 = icmp eq i8* %22, null
   br i1 %30, label %free_done, label %free_nonnull
 
@@ -280,7 +280,7 @@ declare void @_lfortran_free_alloc(i8*, i8*)
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_string_write(i8*, i8**, i8, i8, i8, i64, i64*, i32*, i8*, i64, ...)
+declare void @_lfortran_string_write(i8*, i8**, i8, i8, i8, i32, i64, i64*, i32*, i8*, i64, ...)
 
 declare void @_lcompilers_print_error(i8*, ...)
 
@@ -314,7 +314,7 @@ define i32 @main(i32 %0, i8** %1) {
   %9 = load %string_descriptor, %string_descriptor* %__libasr__created__var__0_return_slot, align 1
   %10 = alloca %string_descriptor, align 8
   store %string_descriptor %9, %string_descriptor* %10, align 1
-  %11 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([7 x i8], [7 x i8]* @serialization_info.3, i32 0, i32 0), i64* %6, i32 0, i32 1, i32 0, i32 0, i32 0, i64 %8, %string_descriptor* %10)
+  %11 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([10 x i8], [10 x i8]* @serialization_info.3, i32 0, i32 0), i64* %6, i32 0, i32 1, i32 0, i32 0, i32 0, i64 %8, %string_descriptor* %10)
   %12 = load i64, i64* %6, align 8
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %11, i8** %13, align 8
@@ -325,7 +325,7 @@ define i32 @main(i32 %0, i8** %1) {
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %18 = load i64, i64* %17, align 8
   %19 = trunc i64 %18 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %16, i32 %19, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %16, i32 %19, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
   %20 = icmp eq i8* %11, null
   br i1 %20, label %free_done, label %free_nonnull
 
@@ -384,7 +384,7 @@ Finalize_Variable___libasr__created__var__1_return_slot: ; preds = %Finalize_Var
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare i32 @str_compare(i8*, i64, i8*, i64)
 

--- a/tests/reference/llvm-doloop_01-a6563cb.json
+++ b/tests/reference/llvm-doloop_01-a6563cb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_01-a6563cb.stdout",
-    "stdout_hash": "194d4a29b465876298b30033a439532c54f895842c3fde439fcbb01e",
+    "stdout_hash": "8963ada0899d9db3270d86a2d9ba25fc878bb11792706bed7bf0fca1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_01-a6563cb.stdout
+++ b/tests/reference/llvm-doloop_01-a6563cb.stdout
@@ -125,7 +125,7 @@ ifcont:                                           ; preds = %else, %then
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %21 = load i64, i64* %20, align 8
   %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %23 = icmp eq i8* %14, null
   br i1 %23, label %free_done, label %free_nonnull
 
@@ -181,7 +181,7 @@ ifcont6:                                          ; preds = %else5, %then4
   %41 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %42 = load i64, i64* %41, align 8
   %43 = trunc i64 %42 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %40, i32 %43, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %40, i32 %43, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %44 = icmp eq i8* %35, null
   br i1 %44, label %free_done9, label %free_nonnull8
 
@@ -237,7 +237,7 @@ ifcont15:                                         ; preds = %else14, %then13
   %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   %63 = load i64, i64* %62, align 8
   %64 = trunc i64 %63 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %61, i32 %64, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %61, i32 %64, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %65 = icmp eq i8* %56, null
   br i1 %65, label %free_done18, label %free_nonnull17
 
@@ -293,7 +293,7 @@ ifcont24:                                         ; preds = %else23, %then22
   %83 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc25, i32 0, i32 1
   %84 = load i64, i64* %83, align 8
   %85 = trunc i64 %84 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %82, i32 %85, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %82, i32 %85, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %86 = icmp eq i8* %77, null
   br i1 %86, label %free_done27, label %free_nonnull26
 
@@ -349,7 +349,7 @@ ifcont33:                                         ; preds = %else32, %then31
   %104 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc34, i32 0, i32 1
   %105 = load i64, i64* %104, align 8
   %106 = trunc i64 %105 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %103, i32 %106, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %103, i32 %106, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
   %107 = icmp eq i8* %98, null
   br i1 %107, label %free_done36, label %free_nonnull35
 
@@ -405,7 +405,7 @@ ifcont42:                                         ; preds = %else41, %then40
   %125 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc43, i32 0, i32 1
   %126 = load i64, i64* %125, align 8
   %127 = trunc i64 %126 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %124, i32 %127, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %124, i32 %127, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
   %128 = icmp eq i8* %119, null
   br i1 %128, label %free_done45, label %free_nonnull44
 
@@ -461,7 +461,7 @@ ifcont51:                                         ; preds = %else50, %then49
   %146 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc52, i32 0, i32 1
   %147 = load i64, i64* %146, align 8
   %148 = trunc i64 %147 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %145, i32 %148, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %145, i32 %148, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
   %149 = icmp eq i8* %140, null
   br i1 %149, label %free_done54, label %free_nonnull53
 
@@ -517,7 +517,7 @@ ifcont60:                                         ; preds = %else59, %then58
   %167 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc61, i32 0, i32 1
   %168 = load i64, i64* %167, align 8
   %169 = trunc i64 %168 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %166, i32 %169, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %166, i32 %169, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
   %170 = icmp eq i8* %161, null
   br i1 %170, label %free_done63, label %free_nonnull62
 
@@ -573,7 +573,7 @@ ifcont69:                                         ; preds = %else68, %then67
   %188 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc70, i32 0, i32 1
   %189 = load i64, i64* %188, align 8
   %190 = trunc i64 %189 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %187, i32 %190, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %187, i32 %190, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
   %191 = icmp eq i8* %182, null
   br i1 %191, label %free_done72, label %free_nonnull71
 
@@ -629,7 +629,7 @@ ifcont78:                                         ; preds = %else77, %then76
   %209 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc79, i32 0, i32 1
   %210 = load i64, i64* %209, align 8
   %211 = trunc i64 %210 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %208, i32 %211, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %208, i32 %211, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
   %212 = icmp eq i8* %203, null
   br i1 %212, label %free_done81, label %free_nonnull80
 
@@ -685,7 +685,7 @@ ifcont87:                                         ; preds = %else86, %then85
   %230 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc88, i32 0, i32 1
   %231 = load i64, i64* %230, align 8
   %232 = trunc i64 %231 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %229, i32 %232, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %229, i32 %232, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
   %233 = icmp eq i8* %224, null
   br i1 %233, label %free_done90, label %free_nonnull89
 
@@ -716,6 +716,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)

--- a/tests/reference/llvm-doloop_02-9fcb598.json
+++ b/tests/reference/llvm-doloop_02-9fcb598.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_02-9fcb598.stdout",
-    "stdout_hash": "6ee9a8bd660f873376ea08d67fda4f71e6c0f7dc92807e327f4126ab",
+    "stdout_hash": "8a26c6823d85feeecee08ac44deceb38199567318857ae502a280378",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_02-9fcb598.stdout
+++ b/tests/reference/llvm-doloop_02-9fcb598.stdout
@@ -88,7 +88,7 @@ ifcont:                                           ; preds = %else, %then
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %25 = load i64, i64* %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
   br i1 %27, label %free_done, label %free_nonnull
 
@@ -164,7 +164,7 @@ ifcont9:                                          ; preds = %else8, %then7
   %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %55 = load i64, i64* %54, align 8
   %56 = trunc i64 %55 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %53, i32 %56, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %57 = icmp eq i8* %48, null
   br i1 %57, label %free_done12, label %free_nonnull11
 
@@ -239,7 +239,7 @@ ifcont21:                                         ; preds = %else20, %then19
   %82 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc22, i32 0, i32 1
   %83 = load i64, i64* %82, align 8
   %84 = trunc i64 %83 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %81, i32 %84, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %81, i32 %84, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %85 = icmp eq i8* %76, null
   br i1 %85, label %free_done24, label %free_nonnull23
 
@@ -270,6 +270,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)

--- a/tests/reference/llvm-doloop_03-d4372bd.json
+++ b/tests/reference/llvm-doloop_03-d4372bd.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_03-d4372bd.stdout",
-    "stdout_hash": "035bc0136927213fe459bcb7d595aef9a4986c2f8893507d0ecbe4b4",
+    "stdout_hash": "1df771877b7f8fcf93ecb542521cc326011228f0a01797f0146d12a7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_03-d4372bd.stdout
+++ b/tests/reference/llvm-doloop_03-d4372bd.stdout
@@ -102,7 +102,7 @@ ifcont6:                                          ; preds = %else5, %then4
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %25 = load i64, i64* %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
   br i1 %27, label %free_done, label %free_nonnull
 
@@ -172,7 +172,7 @@ ifcont16:                                         ; preds = %else15, %then14
   %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc17, i32 0, i32 1
   %48 = load i64, i64* %47, align 8
   %49 = trunc i64 %48 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %46, i32 %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %46, i32 %49, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %50 = icmp eq i8* %41, null
   br i1 %50, label %free_done19, label %free_nonnull18
 
@@ -242,7 +242,7 @@ ifcont28:                                         ; preds = %else27, %then26
   %70 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc29, i32 0, i32 1
   %71 = load i64, i64* %70, align 8
   %72 = trunc i64 %71 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %69, i32 %72, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %69, i32 %72, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %73 = icmp eq i8* %64, null
   br i1 %73, label %free_done31, label %free_nonnull30
 
@@ -273,6 +273,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)

--- a/tests/reference/llvm-doloop_04-e25bf76.json
+++ b/tests/reference/llvm-doloop_04-e25bf76.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-doloop_04-e25bf76.stdout",
-    "stdout_hash": "7f4df1d6f87de9fcf3ec8ef3b2f34730e26406a04620b1db36f02a54",
+    "stdout_hash": "e1fc96bdc55ab41c403b6428db59872c07ee3f26299f1663127f8cac",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-doloop_04-e25bf76.stdout
+++ b/tests/reference/llvm-doloop_04-e25bf76.stdout
@@ -99,7 +99,7 @@ ifcont:                                           ; preds = %else, %then
   %36 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %37 = load i64, i64* %36, align 8
   %38 = trunc i64 %37 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %35, i32 %38, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %35, i32 %38, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %39 = icmp eq i8* %30, null
   br i1 %39, label %free_done, label %free_nonnull
 
@@ -173,7 +173,7 @@ ifcont6:                                          ; preds = %else5, %then4
   %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %74 = load i64, i64* %73, align 8
   %75 = trunc i64 %74 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %72, i32 %75, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %72, i32 %75, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %76 = icmp eq i8* %67, null
   br i1 %76, label %free_done9, label %free_nonnull8
 
@@ -385,6 +385,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)

--- a/tests/reference/llvm-external_03-c3442bb.json
+++ b/tests/reference/llvm-external_03-c3442bb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-external_03-c3442bb.stdout",
-    "stdout_hash": "326d816fcba3e1950dee57dfba2201f9889ab012b051a6a0cde7d03f",
+    "stdout_hash": "5eb100094824ad41f5b00fc86416cf8f3eb1ada3f7b52574105e8275",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-external_03-c3442bb.stdout
+++ b/tests/reference/llvm-external_03-c3442bb.stdout
@@ -29,7 +29,7 @@ define void @a(float (float*)* %f) {
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %10 = load i64, i64* %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %12 = icmp eq i8* %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
@@ -67,7 +67,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-format2-ed47ddb.json
+++ b/tests/reference/llvm-format2-ed47ddb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-format2-ed47ddb.stdout",
-    "stdout_hash": "f6d0cffc76f3c1ba18ebda3cbfc5e81804c95a26ec1c63b3e5fba250",
+    "stdout_hash": "ba00de43dd3ec6f18065c48cc503e59f0644f221cacc85d47d56277f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-format2-ed47ddb.stdout
+++ b/tests/reference/llvm-format2-ed47ddb.stdout
@@ -29,7 +29,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %14 = icmp eq i8* %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
@@ -54,7 +54,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-generic_name_01-d3550a6.json
+++ b/tests/reference/llvm-generic_name_01-d3550a6.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-generic_name_01-d3550a6.stdout",
-    "stdout_hash": "d234d25eb0558c1ba9fe38fb862b2295e26f9742767f59270f3b4272",
+    "stdout_hash": "ff0ecbed1bb485a41dad98ff1d272d1ac1a87fa011feff53c86074d3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-generic_name_01-d3550a6.stdout
+++ b/tests/reference/llvm-generic_name_01-d3550a6.stdout
@@ -38,7 +38,7 @@ define void @__module_complex_module_integer_add_subrout(%complex_module.complex
   %0 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
   %1 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %3 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
   %4 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
   %5 = load %complex_module.complextype.3*, %complex_module.complextype.3** %4, align 8
@@ -71,7 +71,7 @@ define void @__module_complex_module_real_add_subrout(%complex_module.complextyp
   %0 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 1
   %1 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %2, i32 24, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %2, i32 24, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %3 = getelementptr %complex_module.complextype.3, %complex_module.complextype.3* %sum, i32 0, i32 0
   %4 = getelementptr %complex_module.complextype.3_class, %complex_module.complextype.3_class* %this, i32 0, i32 1
   %5 = load %complex_module.complextype.3*, %complex_module.complextype.3** %4, align 8
@@ -97,7 +97,7 @@ FINALIZE_SYMTABLE_real_add_subrout:               ; preds = %return
   ret void
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
@@ -156,7 +156,7 @@ define i32 @main(i32 %0, i8** %1) {
   %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %29 = load i64, i64* %28, align 8
   %30 = trunc i64 %29 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %27, i32 %30, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %31 = icmp eq i8* %22, null
   br i1 %31, label %free_done, label %free_nonnull
 
@@ -220,7 +220,7 @@ ifcont3:                                          ; preds = %else2, %then1
   %53 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %54 = load i64, i64* %53, align 8
   %55 = trunc i64 %54 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %52, i32 %55, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %52, i32 %55, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %56 = icmp eq i8* %47, null
   br i1 %56, label %free_done6, label %free_nonnull5
 

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.json
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-implicit_interface_04-9b6786e.stdout",
-    "stdout_hash": "2e0da382defc08fba824d8149312d767ab8d77533a5e67906f4d4910",
+    "stdout_hash": "c6aabc8fc2a02de62fc23f328aaf8b63f280a223780bc5dc96b5421c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
+++ b/tests/reference/llvm-implicit_interface_04-9b6786e.stdout
@@ -254,7 +254,7 @@ define void @driver(void (i32*, i32*, i32*)* %fnc, i32* %arr, i32* %m) {
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %10 = load i64, i64* %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %12 = icmp eq i8* %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
@@ -525,7 +525,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-init_values-b1d5491.json
+++ b/tests/reference/llvm-init_values-b1d5491.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-init_values-b1d5491.stdout",
-    "stdout_hash": "a34bab8b37c5031da78f323242b24989ba12ec0a436834d5d48ab90a",
+    "stdout_hash": "99d61ab090ca4d877d2d79b2ae24ff35ada79099f985d179bfcf1356",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-init_values-b1d5491.stdout
+++ b/tests/reference/llvm-init_values-b1d5491.stdout
@@ -12,7 +12,7 @@ target datalayout = "..."
 @s2_data = private global [3 x i8] c"eft"
 @s2 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @s2_data, i32 0, i32 0), i64 3 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [40 x i8] c"I4,I4,R4,{R4,R4},I4,L32,L32,R4,S-DESC-4\00", align 1
+@serialization_info = private unnamed_addr constant [43 x i8] c"I4,I4,R4,{R4,R4},I4,L32,L32,R4,S-DESC-K1-4\00", align 1
 @string_const_data = private constant [4 x i8] c"left"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -55,7 +55,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 1, i32* %10, align 4
   %11 = alloca float, align 4
   store float -4.000000e+00, float* %11, align 4
-  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([40 x i8], [40 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %4, i32* %5, float* %6, %complex_4* %7, i32* %8, i32* %9, i32* %10, float* %11, %string_descriptor* @string_const)
+  %12 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, i32* %4, i32* %5, float* %6, %complex_4* %7, i32* %8, i32* %9, i32* %10, float* %11, %string_descriptor* @string_const)
   %13 = load i64, i64* %3, align 8
   %14 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %12, i8** %14, align 8
@@ -66,7 +66,7 @@ define i32 @main(i32 %0, i8** %1) {
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %19 = load i64, i64* %18, align 8
   %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %21 = icmp eq i8* %12, null
   br i1 %21, label %free_done, label %free_nonnull
 
@@ -91,7 +91,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-int_dp-9b89d9f.json
+++ b/tests/reference/llvm-int_dp-9b89d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp-9b89d9f.stdout",
-    "stdout_hash": "1a77e40ae8be629218f6ff9992c46d80c83ce781db827783358aafcb",
+    "stdout_hash": "5ab83b7feae402720086afc658e20839c296d2a065a29d4e97ecb9cd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp-9b89d9f.stdout
+++ b/tests/reference/llvm-int_dp-9b89d9f.stdout
@@ -27,7 +27,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -52,7 +52,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-int_dp_param-f284039.json
+++ b/tests/reference/llvm-int_dp_param-f284039.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-int_dp_param-f284039.stdout",
-    "stdout_hash": "3bd9af05fdb28d24753ae39ec9b05abbca79b32b2231f0766dc45354",
+    "stdout_hash": "6a6cf6df450cb6f248a487d275213ea74ba262520c0b0df77ed869f6",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-int_dp_param-f284039.stdout
+++ b/tests/reference/llvm-int_dp_param-f284039.stdout
@@ -31,7 +31,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -56,7 +56,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-intent_01-6d96ec5.json
+++ b/tests/reference/llvm-intent_01-6d96ec5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intent_01-6d96ec5.stdout",
-    "stdout_hash": "b076c288c6704e82f7170cd1f2c88c4c60a7fadb933f6a0dd343bbfe",
+    "stdout_hash": "c7ec0387832f20beed64b327d35bccf354270590268ed5b9edad405f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intent_01-6d96ec5.stdout
+++ b/tests/reference/llvm-intent_01-6d96ec5.stdout
@@ -45,7 +45,7 @@ define float @foo.__module_dflt_intent_f(float* %x) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -68,7 +68,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-intrinsics_02-404e16e.json
+++ b/tests/reference/llvm-intrinsics_02-404e16e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_02-404e16e.stdout",
-    "stdout_hash": "36d631646b2e0282357e06b935ae7114348892d5b7dc329ba2b3adbe",
+    "stdout_hash": "06fd9777422a4853b3a2e3ec30783a1ae83408105addc78e13e29af7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_02-404e16e.stdout
+++ b/tests/reference/llvm-intrinsics_02-404e16e.stdout
@@ -77,7 +77,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -187,7 +187,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-intrinsics_03-0771f1b.json
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_03-0771f1b.stdout",
-    "stdout_hash": "c0a691677b320e98077e06350f60195b3f721682b801200f1ce1a86c",
+    "stdout_hash": "f3e93f7a39814a111e6a83889a7201fe8397718736b0a816ced6d50f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_03-0771f1b.stdout
+++ b/tests/reference/llvm-intrinsics_03-0771f1b.stdout
@@ -144,7 +144,7 @@ ifcont10:                                         ; preds = %else9, %then8
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %39 = load i64, i64* %38, align 8
   %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %37, i32 %40, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %41 = icmp eq i8* %32, null
   br i1 %41, label %free_done, label %free_nonnull
 
@@ -198,7 +198,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-intrinsics_05-5a73322.json
+++ b/tests/reference/llvm-intrinsics_05-5a73322.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_05-5a73322.stdout",
-    "stdout_hash": "bb43d977b1176d148ea81b2971011450eac7982e7724d82bf7305924",
+    "stdout_hash": "e8b1510c023a9d982c3a42f653a5fac452049deecc0962a5004d5ba5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_05-5a73322.stdout
+++ b/tests/reference/llvm-intrinsics_05-5a73322.stdout
@@ -35,7 +35,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -57,7 +57,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %22 = load i64, i64* %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %24 = icmp eq i8* %15, null
   br i1 %24, label %free_done3, label %free_nonnull2
 
@@ -79,7 +79,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %33 = load i64, i64* %32, align 8
   %34 = trunc i64 %33 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %31, i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %31, i32 %34, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %35 = icmp eq i8* %26, null
   br i1 %35, label %free_done6, label %free_nonnull5
 
@@ -104,7 +104,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-intrinsics_06-15c0eef.json
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-intrinsics_06-15c0eef.stdout",
-    "stdout_hash": "d1c3b589d6d49309e5505b13ad3b910ec49e34c12aa4dac6f7cb62cd",
+    "stdout_hash": "df33043ab71f615deb7101bffac853ecb3753472d81d1687e11aa86a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-intrinsics_06-15c0eef.stdout
+++ b/tests/reference/llvm-intrinsics_06-15c0eef.stdout
@@ -53,7 +53,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -75,7 +75,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %22 = load i64, i64* %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %24 = icmp eq i8* %15, null
   br i1 %24, label %free_done3, label %free_nonnull2
 
@@ -97,7 +97,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %32 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %33 = load i64, i64* %32, align 8
   %34 = trunc i64 %33 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %31, i32 %34, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %31, i32 %34, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %35 = icmp eq i8* %26, null
   br i1 %35, label %free_done6, label %free_nonnull5
 
@@ -119,7 +119,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %43 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %44 = load i64, i64* %43, align 8
   %45 = trunc i64 %44 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %42, i32 %45, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %42, i32 %45, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %46 = icmp eq i8* %37, null
   br i1 %46, label %free_done9, label %free_nonnull8
 
@@ -141,7 +141,7 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %54 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %55 = load i64, i64* %54, align 8
   %56 = trunc i64 %55 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %53, i32 %56, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %53, i32 %56, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %57 = icmp eq i8* %48, null
   br i1 %57, label %free_done12, label %free_nonnull11
 
@@ -163,7 +163,7 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %65 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   %66 = load i64, i64* %65, align 8
   %67 = trunc i64 %66 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %64, i32 %67, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %64, i32 %67, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %68 = icmp eq i8* %59, null
   br i1 %68, label %free_done15, label %free_nonnull14
 
@@ -185,7 +185,7 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %76 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   %77 = load i64, i64* %76, align 8
   %78 = trunc i64 %77 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %75, i32 %78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %75, i32 %78, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %79 = icmp eq i8* %70, null
   br i1 %79, label %free_done18, label %free_nonnull17
 
@@ -210,7 +210,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-legacy_array_sections_01-2515c0f.stdout",
-    "stdout_hash": "b8d1aaa19d54737b6da20e145f87cbe17db0e1f8a74df10f8b449c1b",
+    "stdout_hash": "1bd154ded835d1ab6d672746c13088d0a36312ebd85c01e043a8a754",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
+++ b/tests/reference/llvm-legacy_array_sections_01-2515c0f.stdout
@@ -988,7 +988,7 @@ ifcont8:                                          ; preds = %loop.end
   %62 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %63 = load i64, i64* %62, align 8
   %64 = trunc i64 %63 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %61, i32 %64, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* %61, i32 %64, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0), i32 1)
   %65 = icmp eq i8* %56, null
   br i1 %65, label %free_done, label %free_nonnull
 
@@ -1111,7 +1111,7 @@ declare void @_lpython_call_initial_functions(i32, i8**)
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 ; Function Attrs: nounwind readnone speculatable willreturn
 declare double @llvm.fabs.f64(double) #2

--- a/tests/reference/llvm-logical1-d46903b.json
+++ b/tests/reference/llvm-logical1-d46903b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical1-d46903b.stdout",
-    "stdout_hash": "d0a2bdc1c03971ef6a4fc49f3fb741024264e14b995cbae6ff730da5",
+    "stdout_hash": "5e44e78b2491f4f2099c3667ad4ddefb1b6bcfc2328334811924c01e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical1-d46903b.stdout
+++ b/tests/reference/llvm-logical1-d46903b.stdout
@@ -29,7 +29,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -54,7 +54,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-logical2-94a2259.json
+++ b/tests/reference/llvm-logical2-94a2259.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical2-94a2259.stdout",
-    "stdout_hash": "09e8c8ce2adf703ca0837b5e6f859cd99c2838d6bae31d8bed24d6a5",
+    "stdout_hash": "48ca97a296f8028602454c239cd58e594f71f6cc1bd19b512bdfd4a0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical2-94a2259.stdout
+++ b/tests/reference/llvm-logical2-94a2259.stdout
@@ -28,12 +28,12 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   %6 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %ifcont
 
 else:                                             ; preds = %.entry
   %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %7, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
@@ -49,6 +49,6 @@ FINALIZE_SYMTABLE_logical2:                       ; preds = %return
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-logical3-4bbf8ea.json
+++ b/tests/reference/llvm-logical3-4bbf8ea.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical3-4bbf8ea.stdout",
-    "stdout_hash": "51992588f6050e2b97ae924a6fffa0a2e49a9f8f71a97257b468051a",
+    "stdout_hash": "68252b892b7f599570a845079312a4118a8000f9ce0bdb83869e8b8b",
     "stderr": "llvm-logical3-4bbf8ea.stderr",
     "stderr_hash": "d7e28e54d198e14f86c18ab4c4ad128018b9bc6523fb945b05607a57",
     "returncode": 0

--- a/tests/reference/llvm-logical3-4bbf8ea.stdout
+++ b/tests/reference/llvm-logical3-4bbf8ea.stdout
@@ -111,7 +111,7 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   %6 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %6, i32 26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -119,7 +119,7 @@ then:                                             ; preds = %.entry
 
 else:                                             ; preds = %.entry
   %7 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %ifcont
 
 ifcont:                                           ; preds = %else, %then
@@ -131,12 +131,12 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   %12 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %12, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %12, i32 26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
   %13 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %13, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %13, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -151,12 +151,12 @@ ifcont3:                                          ; preds = %else2, %then1
 
 then4:                                            ; preds = %ifcont3
   %18 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %18, i32 28, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %18, i32 28, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   br label %ifcont6
 
 else5:                                            ; preds = %ifcont3
   %19 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %19, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %19, i32 29, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -174,12 +174,12 @@ ifcont6:                                          ; preds = %else5, %then4
 
 then7:                                            ; preds = %ifcont6
   %25 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %25, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @19, i32 0, i32 0), i8* %25, i32 26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @18, i32 0, i32 0), i32 1)
   br label %ifcont9
 
 else8:                                            ; preds = %ifcont6
   %26 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %26, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %26, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -194,12 +194,12 @@ ifcont9:                                          ; preds = %else8, %then7
 
 then10:                                           ; preds = %ifcont9
   %31 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.16, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %31, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %31, i32 26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
   br label %ifcont12
 
 else11:                                           ; preds = %ifcont9
   %32 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.18, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %32, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @27, i32 0, i32 0), i8* %32, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @26, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @29, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @28, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -215,7 +215,7 @@ ifcont12:                                         ; preds = %else11, %then10
 
 then13:                                           ; preds = %ifcont12
   %38 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.20, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %38, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @31, i32 0, i32 0), i8* %38, i32 26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @30, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @33, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @32, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -223,7 +223,7 @@ then13:                                           ; preds = %ifcont12
 
 else14:                                           ; preds = %ifcont12
   %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.22, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %39, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @35, i32 0, i32 0), i8* %39, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
   br label %ifcont15
 
 ifcont15:                                         ; preds = %else14, %then13
@@ -237,12 +237,12 @@ ifcont15:                                         ; preds = %else14, %then13
 
 then16:                                           ; preds = %ifcont15
   %44 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.24, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %44, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @37, i32 0, i32 0), i8* %44, i32 26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @36, i32 0, i32 0), i32 1)
   br label %ifcont18
 
 else17:                                           ; preds = %ifcont15
   %45 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.26, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %45, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @39, i32 0, i32 0), i8* %45, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @38, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @41, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @40, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -257,12 +257,12 @@ ifcont18:                                         ; preds = %else17, %then16
 
 then19:                                           ; preds = %ifcont18
   %50 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.28, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %50, i32 26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %50, i32 26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @42, i32 0, i32 0), i32 1)
   br label %ifcont21
 
 else20:                                           ; preds = %ifcont18
   %51 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.30, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %51, i32 27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @45, i32 0, i32 0), i8* %51, i32 27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @44, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @47, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @46, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -277,7 +277,7 @@ ifcont21:                                         ; preds = %else20, %then19
 
 then22:                                           ; preds = %ifcont21
   %56 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.32, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %56, i32 30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @49, i32 0, i32 0), i8* %56, i32 30, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @48, i32 0, i32 0), i32 1)
   call void (i8*, ...) @_lcompilers_print_error(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @51, i32 0, i32 0), i8* getelementptr inbounds ([11 x i8], [11 x i8]* @"ERROR STOP", i32 0, i32 0), i8* getelementptr inbounds ([2 x i8], [2 x i8]* @50, i32 0, i32 0))
   call void @_lfortran_internal_alloc_finalize()
   call void @exit(i32 1)
@@ -285,7 +285,7 @@ then22:                                           ; preds = %ifcont21
 
 else23:                                           ; preds = %ifcont21
   %57 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.34, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* %57, i32 31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @53, i32 0, i32 0), i8* %57, i32 31, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @52, i32 0, i32 0), i32 1)
   br label %ifcont24
 
 ifcont24:                                         ; preds = %else23, %then22
@@ -301,7 +301,7 @@ FINALIZE_SYMTABLE_logical3:                       ; preds = %return
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lcompilers_print_error(i8*, ...)
 

--- a/tests/reference/llvm-logical4-b4e6b33.json
+++ b/tests/reference/llvm-logical4-b4e6b33.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-logical4-b4e6b33.stdout",
-    "stdout_hash": "9e730c767c7f4fc34113e53abef510521ba89f79afa835a1b0699bfa",
+    "stdout_hash": "e5149fdf92bf78105c173eeb72719862d3b16be82b9916f7fe994ebb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-logical4-b4e6b33.stdout
+++ b/tests/reference/llvm-logical4-b4e6b33.stdout
@@ -31,7 +31,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -56,7 +56,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-modules_01-1b129c3.json
+++ b/tests/reference/llvm-modules_01-1b129c3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_01-1b129c3.stdout",
-    "stdout_hash": "7bdd8efae069739778feb85d65790478673d26231b9109f2b1a5ca61",
+    "stdout_hash": "dff120d12ea0f237f8d9a8217079d91efc660b47b88566e7e3065d8d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_01-1b129c3.stdout
+++ b/tests/reference/llvm-modules_01-1b129c3.stdout
@@ -12,7 +12,7 @@ target datalayout = "..."
 define void @__module_modules_01_a_b() {
 .entry:
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -22,7 +22,7 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
   ret void
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-modules_06-03c75b2.json
+++ b/tests/reference/llvm-modules_06-03c75b2.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_06-03c75b2.stdout",
-    "stdout_hash": "ec5c9e7b0e7118ce4db9231b8ae99b6178b83add3e4d9cfb2fb7c89b",
+    "stdout_hash": "b55a6ce8a44f417ac70982ae755b35b320df243cae901833cebfc6d5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_06-03c75b2.stdout
+++ b/tests/reference/llvm-modules_06-03c75b2.stdout
@@ -16,7 +16,7 @@ define i32 @__module_modules_06_a_b() {
 .entry:
   %r = alloca i32, align 4
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   store i32 5, i32* %r, align 4
   br label %return
 
@@ -28,7 +28,7 @@ FINALIZE_SYMTABLE_b:                              ; preds = %return
   ret i32 %1
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
@@ -50,7 +50,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i32 %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %14 = icmp eq i8* %5, null
   br i1 %14, label %free_done, label %free_nonnull
 

--- a/tests/reference/llvm-modules_11-a28ab77.json
+++ b/tests/reference/llvm-modules_11-a28ab77.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_11-a28ab77.stdout",
-    "stdout_hash": "1da1c65c78dfcc912998868f650c67401887ccb6f5b2b9d058e3be5b",
+    "stdout_hash": "0ae4ef24c06777f1255a21f4c636035999b12b8a20a2f3a0e2190137",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_11-a28ab77.stdout
+++ b/tests/reference/llvm-modules_11-a28ab77.stdout
@@ -7,12 +7,12 @@ target datalayout = "..."
 @__module_modules_11_module11_i = global i32 1
 @__module_modules_11_module11_j = global i32 2
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
+@serialization_info = private unnamed_addr constant [15 x i8] c"S-DESC-K1-4,I4\00", align 1
 @string_const_data = private constant [4 x i8] c"i = "
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.1 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
+@serialization_info.1 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-4,I4\00", align 1
 @string_const_data.2 = private constant [4 x i8] c"j = "
 @string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.2, i32 0, i32 0), i64 4 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -22,7 +22,7 @@ define void @__module_modules_11_module11_access_internally() {
   %stringFormat_desc = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* @__module_modules_11_module11_i)
+  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* @__module_modules_11_module11_i)
   %3 = load i64, i64* %1, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
@@ -33,7 +33,7 @@ define void @__module_modules_11_module11_access_internally() {
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -55,7 +55,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 
@@ -65,7 +65,7 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = call i8* @_lfortran_get_default_allocator()
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* @__module_modules_11_module11_j)
+  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* @__module_modules_11_module11_j)
   %5 = load i64, i64* %3, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
@@ -76,7 +76,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 

--- a/tests/reference/llvm-modules_13-6b5ac80.json
+++ b/tests/reference/llvm-modules_13-6b5ac80.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-modules_13-6b5ac80.stdout",
-    "stdout_hash": "34910404e9c193d158d695c0da043e1815c747512e40f3de8886eb3d",
+    "stdout_hash": "4459e7bcaa4594485156cacad3978f4e5d59333f715a671543320859",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-modules_13-6b5ac80.stdout
+++ b/tests/reference/llvm-modules_13-6b5ac80.stdout
@@ -57,7 +57,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %10, i32 %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %14 = icmp eq i8* %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
@@ -82,7 +82,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-nested_01-b01694c.json
+++ b/tests/reference/llvm-nested_01-b01694c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_01-b01694c.stdout",
-    "stdout_hash": "e861d6924e569c02e76513df234cf56daa5ab7da4f44f216c8ba57c1",
+    "stdout_hash": "f3379864576aad38f59617c5862f6edf7eea4fec4b81021556d89470",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_01-b01694c.stdout
+++ b/tests/reference/llvm-nested_01-b01694c.stdout
@@ -18,7 +18,7 @@ define i32 @__module_nested_01_a_b() {
   %b = alloca i32, align 4
   %e = alloca i32, align 4
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 3, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %1 = call i32 @b.__module_nested_01_a_d()
   store i32 %1, i32* %e, align 4
   store i32 0, i32* %b, align 4
@@ -36,7 +36,7 @@ define i32 @b.__module_nested_01_a_d() {
 .entry:
   %d = alloca i32, align 4
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 3, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   store i32 1, i32* %d, align 4
   br label %return
 
@@ -48,7 +48,7 @@ FINALIZE_SYMTABLE_d:                              ; preds = %return
   ret i32 %1
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:

--- a/tests/reference/llvm-nested_02-726d5e8.json
+++ b/tests/reference/llvm-nested_02-726d5e8.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_02-726d5e8.stdout",
-    "stdout_hash": "8ed77d065ae8eff53ca5498af477f8ebe41609362434d7ce1e668639",
+    "stdout_hash": "d512cd588ba63f728cb0c51f1ac13d1974925325099a3a26c53a3385",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_02-726d5e8.stdout
+++ b/tests/reference/llvm-nested_02-726d5e8.stdout
@@ -15,7 +15,7 @@ target datalayout = "..."
 define void @__module_nested_02_a_b() {
 .entry:
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %0, i32 3, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   call void @b.__module_nested_02_a_c()
   br label %return
 
@@ -44,7 +44,7 @@ define void @b.__module_nested_02_a_c() {
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %10 = load i64, i64* %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %12 = icmp eq i8* %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
@@ -66,7 +66,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-nested_03-2eacab7.json
+++ b/tests/reference/llvm-nested_03-2eacab7.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_03-2eacab7.stdout",
-    "stdout_hash": "82dfbc2f35578a181f0a86c6582c34322de7e7ba11b6b85880aa7352",
+    "stdout_hash": "177b72db7226008e96b3e737f30a7830c1236a52ce28702dfb0b56b9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_03-2eacab7.stdout
+++ b/tests/reference/llvm-nested_03-2eacab7.stdout
@@ -21,7 +21,7 @@ define void @__module_nested_03_a_b() {
   %x = alloca float, align 4
   store float 6.000000e+00, float* %x, align 4
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %0, i32 3, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %1 = load float, float* %x, align 4
   store float %1, float* @__module___lcompilers_created__nested_context__nested_03_a__b__x, align 4
   call void @b.__module_nested_03_a_c()
@@ -55,7 +55,7 @@ define void @b.__module_nested_03_a_c() {
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %10 = load i64, i64* %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %12 = icmp eq i8* %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
@@ -76,7 +76,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %21 = load i64, i64* %20, align 8
   %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %23 = icmp eq i8* %14, null
   br i1 %23, label %free_done3, label %free_nonnull2
 
@@ -98,7 +98,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-nested_04-39da8f9.json
+++ b/tests/reference/llvm-nested_04-39da8f9.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_04-39da8f9.stdout",
-    "stdout_hash": "dc9495c5cfe2f1f202dfb3a1c9a4c5873c26523842a17e4df18dbbd2",
+    "stdout_hash": "1a15764115f62e0f6a74eb0d4353e470f0c5ca4a4edf5793b3d32d41",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_04-39da8f9.stdout
+++ b/tests/reference/llvm-nested_04-39da8f9.stdout
@@ -30,7 +30,7 @@ define i32 @__module_nested_04_a_b(i32* %x) {
   %0 = load i32, i32* %x, align 4
   store i32 %0, i32* %y, align 4
   %1 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 3, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %2 = load i32, i32* %y, align 4
   store i32 %2, i32* @__module___lcompilers_created__nested_context__nested_04_a__b__y, align 4
   %3 = load float, float* %yy, align 4
@@ -71,7 +71,7 @@ define i32 @b.__module_nested_04_a_c(i32* %z) {
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -92,7 +92,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %20 = load i64, i64* %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %22 = icmp eq i8* %13, null
   br i1 %22, label %free_done3, label %free_nonnull2
 
@@ -113,7 +113,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %30 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %31 = load i64, i64* %30, align 8
   %32 = trunc i64 %31 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %29, i32 %32, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %29, i32 %32, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %33 = icmp eq i8* %24, null
   br i1 %33, label %free_done6, label %free_nonnull5
 
@@ -138,7 +138,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-nested_05-0252368.json
+++ b/tests/reference/llvm-nested_05-0252368.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_05-0252368.stdout",
-    "stdout_hash": "b3003ac48253657aa01d87609406df2df5e993d3c51e64ce382c37ad",
+    "stdout_hash": "5c76399517259de77ec868558226741a80aa7f7a894e455f043ee55c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_05-0252368.stdout
+++ b/tests/reference/llvm-nested_05-0252368.stdout
@@ -48,7 +48,7 @@ define void @__module_nested_05_a_b() {
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -69,7 +69,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %20 = load i64, i64* %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %18, i32 %21, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %22 = icmp eq i8* %13, null
   br i1 %22, label %free_done3, label %free_nonnull2
 
@@ -99,7 +99,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %35 = load i64, i64* %34, align 8
   %36 = trunc i64 %35 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %33, i32 %36, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %37 = icmp eq i8* %28, null
   br i1 %37, label %free_done6, label %free_nonnull5
 
@@ -120,7 +120,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %45 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %46 = load i64, i64* %45, align 8
   %47 = trunc i64 %46 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %44, i32 %47, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %44, i32 %47, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %48 = icmp eq i8* %39, null
   br i1 %48, label %free_done9, label %free_nonnull8
 
@@ -155,7 +155,7 @@ define void @b.__module_nested_05_a_c() {
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -176,7 +176,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %20 = load i64, i64* %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %18, i32 %21, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %22 = icmp eq i8* %13, null
   br i1 %22, label %free_done3, label %free_nonnull2
 
@@ -200,7 +200,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-nested_06-fa1a99f.json
+++ b/tests/reference/llvm-nested_06-fa1a99f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-nested_06-fa1a99f.stdout",
-    "stdout_hash": "5b5f50fe38c97a432331a4a7407445a6680c550fb1f94b72493536e9",
+    "stdout_hash": "fae24b50abdc2f21030ab3a7770eb93bd68efaad7ce5f763ded8bfa7",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-nested_06-fa1a99f.stdout
+++ b/tests/reference/llvm-nested_06-fa1a99f.stdout
@@ -19,7 +19,7 @@ target datalayout = "..."
 define void @__module_nested_06_a_b(float* %x) {
 .entry:
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %0, i32 3, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %0, i32 3, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %1 = load float, float* %x, align 4
   store float %1, float* @__module___lcompilers_created__nested_context__nested_06_a__b__x, align 4
   call void @b.__module_nested_06_a_c()
@@ -53,7 +53,7 @@ define void @b.__module_nested_06_a_c() {
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %10 = load i64, i64* %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %12 = icmp eq i8* %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
@@ -74,7 +74,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %21 = load i64, i64* %20, align 8
   %22 = trunc i64 %21 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %19, i32 %22, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %23 = icmp eq i8* %14, null
   br i1 %23, label %free_done3, label %free_nonnull2
 
@@ -96,7 +96,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-operator_overloading_01-33c47db.json
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_01-33c47db.stdout",
-    "stdout_hash": "ff3c78f3c1639b0a0d775c2ea732d6b53a99a8884a166c75e264c7e4",
+    "stdout_hash": "6032b8f69e6e7859b46ccc9659f95bac622eaa969f8dab41466886fe",
     "stderr": "llvm-operator_overloading_01-33c47db.stderr",
     "stderr_hash": "bc887b577bc8ccfc15f212c070a67ee8c67af8d343abdd0132e6b6fb",
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_01-33c47db.stdout
+++ b/tests/reference/llvm-operator_overloading_01-33c47db.stdout
@@ -5,42 +5,42 @@ target datalayout = "..."
 %string_descriptor = type <{ i8*, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data = private constant [4 x i8] c"T*T:"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.1 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.1 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.2 = private constant [4 x i8] c"T*F:"
 @string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.2, i32 0, i32 0), i64 4 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.4 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.4 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.5 = private constant [4 x i8] c"F*T:"
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.5, i32 0, i32 0), i64 4 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.7 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.7 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.8 = private constant [4 x i8] c"F*F:"
 @string_const.9 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.8, i32 0, i32 0), i64 4 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.10 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
+@serialization_info.10 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-4,I4\00", align 1
 @string_const_data.11 = private constant [4 x i8] c"T+T:"
 @string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.11, i32 0, i32 0), i64 4 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.13 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
+@serialization_info.13 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-4,I4\00", align 1
 @string_const_data.14 = private constant [4 x i8] c"T+F:"
 @string_const.15 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.14, i32 0, i32 0), i64 4 }>
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.16 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
+@serialization_info.16 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-4,I4\00", align 1
 @string_const_data.17 = private constant [4 x i8] c"F+T:"
 @string_const.18 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.17, i32 0, i32 0), i64 4 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.19 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
+@serialization_info.19 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-4,I4\00", align 1
 @string_const_data.20 = private constant [4 x i8] c"F+F:"
 @string_const.21 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.20, i32 0, i32 0), i64 4 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -126,7 +126,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %t, i32* %t)
   %5 = alloca i32, align 4
   store i32 %4, i32* %5, align 4
-  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %5)
+  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %5)
   %7 = load i64, i64* %3, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %6, i8** %8, align 8
@@ -137,7 +137,7 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %13 = load i64, i64* %12, align 8
   %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %15 = icmp eq i8* %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
@@ -150,7 +150,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %17 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %t, i32* %f)
   %18 = alloca i32, align 4
   store i32 %17, i32* %18, align 4
-  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %18)
+  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %18)
   %20 = load i64, i64* %16, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %19, i8** %21, align 8
@@ -161,7 +161,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %26 = load i64, i64* %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %28 = icmp eq i8* %19, null
   br i1 %28, label %free_done3, label %free_nonnull2
 
@@ -174,7 +174,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %30 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %f, i32* %t)
   %31 = alloca i32, align 4
   store i32 %30, i32* %31, align 4
-  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.4, i32 0, i32 0), i64* %29, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %31)
+  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.4, i32 0, i32 0), i64* %29, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %31)
   %33 = load i64, i64* %29, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %32, i8** %34, align 8
@@ -185,7 +185,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %39 = load i64, i64* %38, align 8
   %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %37, i32 %40, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %41 = icmp eq i8* %32, null
   br i1 %41, label %free_done6, label %free_nonnull5
 
@@ -198,7 +198,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %43 = call i32 @__module_operator_overloading_01_overload_asterisk_m_logical_and(i32* %f, i32* %f)
   %44 = alloca i32, align 4
   store i32 %43, i32* %44, align 4
-  %45 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.7, i32 0, i32 0), i64* %42, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.9, i32* %44)
+  %45 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.7, i32 0, i32 0), i64* %42, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.9, i32* %44)
   %46 = load i64, i64* %42, align 8
   %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %45, i8** %47, align 8
@@ -209,7 +209,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %52 = load i64, i64* %51, align 8
   %53 = trunc i64 %52 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %50, i32 %53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %50, i32 %53, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %54 = icmp eq i8* %45, null
   br i1 %54, label %free_done9, label %free_nonnull8
 
@@ -222,7 +222,7 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %56 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %t, i32* %t)
   %57 = alloca i32, align 4
   store i32 %56, i32* %57, align 4
-  %58 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %55, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %57)
+  %58 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.10, i32 0, i32 0), i64* %55, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %57)
   %59 = load i64, i64* %55, align 8
   %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %58, i8** %60, align 8
@@ -233,7 +233,7 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %65 = load i64, i64* %64, align 8
   %66 = trunc i64 %65 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %63, i32 %66, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %63, i32 %66, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %67 = icmp eq i8* %58, null
   br i1 %67, label %free_done12, label %free_nonnull11
 
@@ -246,7 +246,7 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %69 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %t, i32* %f)
   %70 = alloca i32, align 4
   store i32 %69, i32* %70, align 4
-  %71 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.13, i32 0, i32 0), i64* %68, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %70)
+  %71 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.13, i32 0, i32 0), i64* %68, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %70)
   %72 = load i64, i64* %68, align 8
   %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %71, i8** %73, align 8
@@ -257,7 +257,7 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   %78 = load i64, i64* %77, align 8
   %79 = trunc i64 %78 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %80 = icmp eq i8* %71, null
   br i1 %80, label %free_done15, label %free_nonnull14
 
@@ -270,7 +270,7 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %82 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %f, i32* %t)
   %83 = alloca i32, align 4
   store i32 %82, i32* %83, align 4
-  %84 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.16, i32 0, i32 0), i64* %81, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %83)
+  %84 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.16, i32 0, i32 0), i64* %81, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %83)
   %85 = load i64, i64* %81, align 8
   %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %84, i8** %86, align 8
@@ -281,7 +281,7 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %90 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   %91 = load i64, i64* %90, align 8
   %92 = trunc i64 %91 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %89, i32 %92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %89, i32 %92, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %93 = icmp eq i8* %84, null
   br i1 %93, label %free_done18, label %free_nonnull17
 
@@ -294,7 +294,7 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   %95 = call i32 @__module_operator_overloading_01_overload_asterisk_m_bin_add(i32* %f, i32* %f)
   %96 = alloca i32, align 4
   store i32 %95, i32* %96, align 4
-  %97 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.19, i32 0, i32 0), i64* %94, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %96)
+  %97 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.19, i32 0, i32 0), i64* %94, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %96)
   %98 = load i64, i64* %94, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %97, i8** %99, align 8
@@ -305,7 +305,7 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
   %104 = load i64, i64* %103, align 8
   %105 = trunc i64 %104 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %102, i32 %105, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %102, i32 %105, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %106 = icmp eq i8* %97, null
   br i1 %106, label %free_done21, label %free_nonnull20
 
@@ -330,7 +330,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-operator_overloading_02-adb886e.json
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_02-adb886e.stdout",
-    "stdout_hash": "0690f1aeaee036054b51aeffa394de8a5e49124bf7985e881da61633",
+    "stdout_hash": "0e3d7b53920d49e62b1596bd0eb42d8ee6fb2432b06a1e5c00b7b86d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_02-adb886e.stdout
+++ b/tests/reference/llvm-operator_overloading_02-adb886e.stdout
@@ -5,12 +5,12 @@ target datalayout = "..."
 %string_descriptor = type <{ i8*, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-5,L32\00", align 1
+@serialization_info = private unnamed_addr constant [16 x i8] c"S-DESC-K1-5,L32\00", align 1
 @string_const_data = private constant [5 x i8] c"tf=0:"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data, i32 0, i32 0), i64 5 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.1 = private unnamed_addr constant [13 x i8] c"S-DESC-5,L32\00", align 1
+@serialization_info.1 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-5,L32\00", align 1
 @string_const_data.2 = private constant [5 x i8] c"tf=1:"
 @string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data.2, i32 0, i32 0), i64 5 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -41,7 +41,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i32 0, i32* %call_arg_value, align 4
   call void @__module_overload_assignment_m_logical_gets_integer(i32* %tf, i32* %call_arg_value)
   %3 = alloca i64, align 8
-  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %tf)
+  %4 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %tf)
   %5 = load i64, i64* %3, align 8
   %6 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %4, i8** %6, align 8
@@ -52,7 +52,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -64,7 +64,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   store i32 1, i32* %call_arg_value, align 4
   call void @__module_overload_assignment_m_logical_gets_integer(i32* %tf, i32* %call_arg_value)
   %14 = alloca i64, align 8
-  %15 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %tf)
+  %15 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.1, i32 0, i32 0), i64* %14, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %tf)
   %16 = load i64, i64* %14, align 8
   %17 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %15, i8** %17, align 8
@@ -75,7 +75,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %22 = load i64, i64* %21, align 8
   %23 = trunc i64 %22 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %20, i32 %23, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %24 = icmp eq i8* %15, null
   br i1 %24, label %free_done3, label %free_nonnull2
 
@@ -100,7 +100,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.json
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-operator_overloading_03-d9fd880.stdout",
-    "stdout_hash": "e49ea24acbbe3c5549c7b610b53425a27592f520ea6950adbcd8db47",
+    "stdout_hash": "5d14612b6454db79d5c8fcf81cec376b327583d5af3854e97f354d0a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
+++ b/tests/reference/llvm-operator_overloading_03-d9fd880.stdout
@@ -5,42 +5,42 @@ target datalayout = "..."
 %string_descriptor = type <{ i8*, i64 }>
 
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data = private constant [4 x i8] c"T>T:"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.1 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.1 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.2 = private constant [4 x i8] c"T>F:"
 @string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.2, i32 0, i32 0), i64 4 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.4 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.4 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.5 = private constant [4 x i8] c"F>T:"
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.5, i32 0, i32 0), i64 4 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @6 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.7 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.7 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.8 = private constant [4 x i8] c"F>F:"
 @string_const.9 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.8, i32 0, i32 0), i64 4 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.10 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.10 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.11 = private constant [4 x i8] c"T<T:"
 @string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.11, i32 0, i32 0), i64 4 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @10 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.13 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.13 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.14 = private constant [4 x i8] c"T<F:"
 @string_const.15 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.14, i32 0, i32 0), i64 4 }>
 @11 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @12 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.16 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.16 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.17 = private constant [4 x i8] c"F<T:"
 @string_const.18 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.17, i32 0, i32 0), i64 4 }>
 @13 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @14 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.19 = private unnamed_addr constant [13 x i8] c"S-DESC-4,L32\00", align 1
+@serialization_info.19 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-4,L32\00", align 1
 @string_const_data.20 = private constant [4 x i8] c"F<F:"
 @string_const.21 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.20, i32 0, i32 0), i64 4 }>
 @15 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -129,7 +129,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %t, i32* %t)
   %5 = alloca i32, align 4
   store i32 %4, i32* %5, align 4
-  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %5)
+  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %5)
   %7 = load i64, i64* %3, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %6, i8** %8, align 8
@@ -140,7 +140,7 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %13 = load i64, i64* %12, align 8
   %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %15 = icmp eq i8* %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
@@ -153,7 +153,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %17 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %t, i32* %f)
   %18 = alloca i32, align 4
   store i32 %17, i32* %18, align 4
-  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %18)
+  %19 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.1, i32 0, i32 0), i64* %16, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %18)
   %20 = load i64, i64* %16, align 8
   %21 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %19, i8** %21, align 8
@@ -164,7 +164,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %26 = load i64, i64* %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %24, i32 %27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %28 = icmp eq i8* %19, null
   br i1 %28, label %free_done3, label %free_nonnull2
 
@@ -177,7 +177,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %30 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %f, i32* %t)
   %31 = alloca i32, align 4
   store i32 %30, i32* %31, align 4
-  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.4, i32 0, i32 0), i64* %29, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %31)
+  %32 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.4, i32 0, i32 0), i64* %29, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %31)
   %33 = load i64, i64* %29, align 8
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 0
   store i8* %32, i8** %34, align 8
@@ -188,7 +188,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %38 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %39 = load i64, i64* %38, align 8
   %40 = trunc i64 %39 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %37, i32 %40, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %37, i32 %40, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %41 = icmp eq i8* %32, null
   br i1 %41, label %free_done6, label %free_nonnull5
 
@@ -201,7 +201,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %43 = call i32 @__module_operator_overloading_01_overload_comp_m_greater_than_inverse(i32* %f, i32* %f)
   %44 = alloca i32, align 4
   store i32 %43, i32* %44, align 4
-  %45 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.7, i32 0, i32 0), i64* %42, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.9, i32* %44)
+  %45 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.7, i32 0, i32 0), i64* %42, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.9, i32* %44)
   %46 = load i64, i64* %42, align 8
   %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 0
   store i8* %45, i8** %47, align 8
@@ -212,7 +212,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %51 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %52 = load i64, i64* %51, align 8
   %53 = trunc i64 %52 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %50, i32 %53, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %50, i32 %53, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %54 = icmp eq i8* %45, null
   br i1 %54, label %free_done9, label %free_nonnull8
 
@@ -225,7 +225,7 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %56 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %t, i32* %t)
   %57 = alloca i32, align 4
   store i32 %56, i32* %57, align 4
-  %58 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.10, i32 0, i32 0), i64* %55, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %57)
+  %58 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.10, i32 0, i32 0), i64* %55, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %57)
   %59 = load i64, i64* %55, align 8
   %60 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 0
   store i8* %58, i8** %60, align 8
@@ -236,7 +236,7 @@ free_done9:                                       ; preds = %free_nonnull8, %fre
   %64 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %65 = load i64, i64* %64, align 8
   %66 = trunc i64 %65 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %63, i32 %66, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %63, i32 %66, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %67 = icmp eq i8* %58, null
   br i1 %67, label %free_done12, label %free_nonnull11
 
@@ -249,7 +249,7 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %69 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %t, i32* %f)
   %70 = alloca i32, align 4
   store i32 %69, i32* %70, align 4
-  %71 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.13, i32 0, i32 0), i64* %68, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %70)
+  %71 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.13, i32 0, i32 0), i64* %68, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.15, i32* %70)
   %72 = load i64, i64* %68, align 8
   %73 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 0
   store i8* %71, i8** %73, align 8
@@ -260,7 +260,7 @@ free_done12:                                      ; preds = %free_nonnull11, %fr
   %77 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   %78 = load i64, i64* %77, align 8
   %79 = trunc i64 %78 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %76, i32 %79, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %80 = icmp eq i8* %71, null
   br i1 %80, label %free_done15, label %free_nonnull14
 
@@ -273,7 +273,7 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %82 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %f, i32* %t)
   %83 = alloca i32, align 4
   store i32 %82, i32* %83, align 4
-  %84 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.16, i32 0, i32 0), i64* %81, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %83)
+  %84 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.16, i32 0, i32 0), i64* %81, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.18, i32* %83)
   %85 = load i64, i64* %81, align 8
   %86 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 0
   store i8* %84, i8** %86, align 8
@@ -284,7 +284,7 @@ free_done15:                                      ; preds = %free_nonnull14, %fr
   %90 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc16, i32 0, i32 1
   %91 = load i64, i64* %90, align 8
   %92 = trunc i64 %91 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %89, i32 %92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %89, i32 %92, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %93 = icmp eq i8* %84, null
   br i1 %93, label %free_done18, label %free_nonnull17
 
@@ -297,7 +297,7 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   %95 = call i32 @__module_operator_overloading_01_overload_comp_m_less_than_inverse(i32* %f, i32* %f)
   %96 = alloca i32, align 4
   store i32 %95, i32* %96, align 4
-  %97 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.19, i32 0, i32 0), i64* %94, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %96)
+  %97 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.19, i32 0, i32 0), i64* %94, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.21, i32* %96)
   %98 = load i64, i64* %94, align 8
   %99 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 0
   store i8* %97, i8** %99, align 8
@@ -308,7 +308,7 @@ free_done18:                                      ; preds = %free_nonnull17, %fr
   %103 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
   %104 = load i64, i64* %103, align 8
   %105 = trunc i64 %104 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %102, i32 %105, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @15, i32 0, i32 0), i8* %102, i32 %105, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @14, i32 0, i32 0), i32 1)
   %106 = icmp eq i8* %97, null
   br i1 %106, label %free_done21, label %free_nonnull20
 
@@ -333,7 +333,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-print_01-63a0480.json
+++ b/tests/reference/llvm-print_01-63a0480.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-print_01-63a0480.stdout",
-    "stdout_hash": "bca6cea51335c5187634d6e542f0a229bad230ee8efda6c99b9b1591",
+    "stdout_hash": "2ce8f7eedd09ea709d329c42e8176ffbe0ff78bd85a6684686e6c3bf",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-print_01-63a0480.stdout
+++ b/tests/reference/llvm-print_01-63a0480.stdout
@@ -48,7 +48,7 @@ define i32 @main(i32 %0, i8** %1) {
   %19 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %20 = load i64, i64* %19, align 8
   %21 = trunc i64 %20 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %18, i32 %21, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %18, i32 %21, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %22 = icmp eq i8* %13, null
   br i1 %22, label %free_done, label %free_nonnull
 
@@ -115,7 +115,7 @@ declare i8* @_lfortran_get_default_allocator()
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-procedure_declaration_interface-cb6ba53.json
+++ b/tests/reference/llvm-procedure_declaration_interface-cb6ba53.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-procedure_declaration_interface-cb6ba53.stdout",
-    "stdout_hash": "9d9d90b27437e5d1c563b976bc9cd2f72d59320bc1e17d85a141ee14",
+    "stdout_hash": "95afefbf2723815162ed09737cf9624bd378038d5ba69c7a92251762",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-procedure_declaration_interface-cb6ba53.stdout
+++ b/tests/reference/llvm-procedure_declaration_interface-cb6ba53.stdout
@@ -7,12 +7,12 @@ target datalayout = "..."
 @__module___lcompilers_created__nested_context__example__target_value = global float 0.000000e+00
 @__module___lcompilers_created__nested_context__my_module__my_wrapper__fun = global float ()* null
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-31,R4\00", align 1
+@serialization_info = private unnamed_addr constant [16 x i8] c"S-DESC-K1-31,R4\00", align 1
 @string_const_data = private constant [31 x i8] c"Via wrapper (should equal .5): "
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([31 x i8], [31 x i8]* @string_const_data, i32 0, i32 0), i64 31 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.2 = private unnamed_addr constant [13 x i8] c"S-DESC-31,R4\00", align 1
+@serialization_info.2 = private unnamed_addr constant [16 x i8] c"S-DESC-K1-31,R4\00", align 1
 @string_const_data.3 = private constant [31 x i8] c"Direct call (should equal .5): "
 @string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([31 x i8], [31 x i8]* @string_const_data.3, i32 0, i32 0), i64 31 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -104,7 +104,7 @@ define i32 @main(i32 %0, i8** %1) {
   %5 = call float @__module_my_module_my_wrapper(float ()* @my_fun)
   %6 = alloca float, align 4
   store float %5, float* %6, align 4
-  %7 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %6)
+  %7 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, float* %6)
   %8 = load i64, i64* %4, align 8
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %7, i8** %9, align 8
@@ -115,7 +115,7 @@ define i32 @main(i32 %0, i8** %1) {
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %14 = load i64, i64* %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %12, i32 %15, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %16 = icmp eq i8* %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
@@ -132,7 +132,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %20 = call float @my_fun()
   %21 = alloca float, align 4
   store float %20, float* %21, align 4
-  %22 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info.2, i32 0, i32 0), i64* %19, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.4, float* %21)
+  %22 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info.2, i32 0, i32 0), i64* %19, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.4, float* %21)
   %23 = load i64, i64* %19, align 8
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 0
   store i8* %22, i8** %24, align 8
@@ -143,7 +143,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %28 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %29 = load i64, i64* %28, align 8
   %30 = trunc i64 %29 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %27, i32 %30, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %27, i32 %30, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %31 = icmp eq i8* %22, null
   br i1 %31, label %free_done3, label %free_nonnull2
 
@@ -231,7 +231,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-program1-29eca93.json
+++ b/tests/reference/llvm-program1-29eca93.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program1-29eca93.stdout",
-    "stdout_hash": "b890f45e1f991f70324ab531ea19d85370f161fc04d44a7ca2b4b813",
+    "stdout_hash": "bfd4eb1a22d5dd5504e52395b0fea7a9f4ce07cf7896f8b9dbc85314",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program1-29eca93.stdout
+++ b/tests/reference/llvm-program1-29eca93.stdout
@@ -31,7 +31,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -56,7 +56,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %25 = load i64, i64* %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
   br i1 %27, label %free_done3, label %free_nonnull2
 
@@ -81,7 +81,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-program_03-374e848.json
+++ b/tests/reference/llvm-program_03-374e848.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_03-374e848.stdout",
-    "stdout_hash": "e2d568e0f8a1cc19cdd5c43b3d2af449e27176f2ae13ace6d4618644",
+    "stdout_hash": "50464e6367f41437673447afd1bf0508f28bafa3c7313aa5b6bf50d0",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_03-374e848.stdout
+++ b/tests/reference/llvm-program_03-374e848.stdout
@@ -47,7 +47,7 @@ loop.body:                                        ; preds = %loop.head
   %18 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %19 = load i64, i64* %18, align 8
   %20 = trunc i64 %19 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %17, i32 %20, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %21 = icmp eq i8* %12, null
   br i1 %21, label %free_done, label %free_nonnull
 
@@ -111,7 +111,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-program_cmake_01-caf8f48.json
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-program_cmake_01-caf8f48.stdout",
-    "stdout_hash": "68da5f40052eada8ecf691dd18194540d300a0a1c2220dc74faccd0b",
+    "stdout_hash": "d846cfe346987b94abf105a573b3f46c57f7bb637c9a3d410f5e046e",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-program_cmake_01-caf8f48.stdout
+++ b/tests/reference/llvm-program_cmake_01-caf8f48.stdout
@@ -13,7 +13,7 @@ define i32 @main(i32 %0, i8** %1) {
 .entry:
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 5, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 5, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -26,6 +26,6 @@ FINALIZE_SYMTABLE_testfortran:                    ; preds = %return
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-read_83-d6544e3.json
+++ b/tests/reference/llvm-read_83-d6544e3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-read_83-d6544e3.stdout",
-    "stdout_hash": "50e4a978360e18e839444c169abe611a719f2e379b892cf70282b2e7",
+    "stdout_hash": "0e52f0bf5a68c2c2d48d26039bb8a6de62144a6e96e16b132bb33477",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-read_83-d6544e3.stdout
+++ b/tests/reference/llvm-read_83-d6544e3.stdout
@@ -292,25 +292,25 @@ ifcont:                                           ; preds = %else, %then
 
 then1:                                            ; preds = %ifcont
   %27 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %27, i32 58, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %27, i32 58, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %28 = alloca i32, align 4
   store i32 0, i32* %28, align 4
   %29 = alloca i32, align 4
   call void @_lfortran_empty_read(i32 -2, i32* %28, i32 1)
   %30 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %30, i32 92, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0), i8* %30, i32 92, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0), i32 1)
   %31 = alloca i32, align 4
   store i32 0, i32* %31, align 4
   %32 = alloca i32, align 4
   call void @_lfortran_empty_read(i32 -2, i32* %31, i32 1)
   %33 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %33, i32 78, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %33, i32 78, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %34 = alloca i32, align 4
   store i32 0, i32* %34, align 4
   %35 = alloca i32, align 4
   call void @_lfortran_empty_read(i32 -2, i32* %34, i32 1)
   %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.10, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %36, i32 77, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @10, i32 0, i32 0), i8* %36, i32 77, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @9, i32 0, i32 0), i32 1)
   br label %goto_target
 
 goto_target:                                      ; preds = %then1
@@ -319,7 +319,7 @@ goto_target:                                      ; preds = %then1
   %38 = alloca i32, align 4
   call void @_lfortran_empty_read(i32 -2, i32* %37, i32 1)
   %39 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.12, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %39, i32 93, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %39, i32 93, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   store i32 5, i32* %unit_num, align 4
   %40 = load i32, i32* %unit_num, align 4
   %41 = icmp eq i32 %40, 5
@@ -329,7 +329,7 @@ goto_target:                                      ; preds = %then1
   %44 = alloca i32, align 4
   call void @_lfortran_empty_read(i32 %42, i32* %43, i32 1)
   %45 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.14, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i8* %45, i32 77, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @16, i32 0, i32 0), i8* %45, i32 77, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @15, i32 0, i32 0), i32 1)
   br label %ifcont3
 
 else2:                                            ; preds = %ifcont
@@ -364,7 +364,7 @@ declare i8* @_lfortran_malloc_alloc(i8*, i64)
 
 declare i32 @str_compare(i8*, i64, i8*, i64)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_empty_read(i32, i32*, i32)
 

--- a/tests/reference/llvm-real_dp_01-e53c6fb.json
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_01-e53c6fb.stdout",
-    "stdout_hash": "4bb7f5b8d1af1e7d61aa4c5b021977f25eaf14af5b4f226c1a82d3ce",
+    "stdout_hash": "59efcdc3cdec1f9177d457fcff8bfbc46b28d254368a4f2c236347f9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_01-e53c6fb.stdout
+++ b/tests/reference/llvm-real_dp_01-e53c6fb.stdout
@@ -31,7 +31,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -56,7 +56,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-real_dp_param-bac42bc.json
+++ b/tests/reference/llvm-real_dp_param-bac42bc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-real_dp_param-bac42bc.stdout",
-    "stdout_hash": "9723af18f23ec688a910302da5f76f73278111e445554b94d923f396",
+    "stdout_hash": "c28a999fa427668a244149373e3a3a52ddb0945318396ca95e4d1a57",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-real_dp_param-bac42bc.stdout
+++ b/tests/reference/llvm-real_dp_param-bac42bc.stdout
@@ -32,7 +32,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -57,7 +57,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-recursion_01-95eb32d.json
+++ b/tests/reference/llvm-recursion_01-95eb32d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_01-95eb32d.stdout",
-    "stdout_hash": "84008494da63e339af24e9e7d9c4ad15217e7303e7fa7cd8864bc201",
+    "stdout_hash": "60d221d33cf2c0ea9bd3b2cbad6d78405b414894632a5b394c1dbaf1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_01-95eb32d.stdout
+++ b/tests/reference/llvm-recursion_01-95eb32d.stdout
@@ -11,7 +11,7 @@ target datalayout = "..."
 @serialization_info = private unnamed_addr constant [3 x i8] c"I4\00", align 1
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.1 = private unnamed_addr constant [12 x i8] c"S-DESC-4,I4\00", align 1
+@serialization_info.1 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-4,I4\00", align 1
 @string_const_data = private constant [4 x i8] c"x = "
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data, i32 0, i32 0), i64 4 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -30,7 +30,7 @@ then:                                             ; preds = %.entry
   %5 = add i32 %4, 1
   store i32 %5, i32* %x, align 4
   %6 = alloca i64, align 8
-  %7 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %x)
+  %7 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %6, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %x)
   %8 = load i64, i64* %6, align 8
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %7, i8** %9, align 8
@@ -41,7 +41,7 @@ then:                                             ; preds = %.entry
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %14 = load i64, i64* %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %12, i32 %15, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %16 = icmp eq i8* %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
@@ -90,7 +90,7 @@ define void @sub1.__module_recursion_01_sub2() {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -113,7 +113,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-recursion_02-76da7b3.json
+++ b/tests/reference/llvm-recursion_02-76da7b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_02-76da7b3.stdout",
-    "stdout_hash": "6526ec03760fc34c015d50845cc345d1881010bc2bd31bb60a868495",
+    "stdout_hash": "96e13f9c176441a622d1d8cfb2e7d47951d3b8beb4fefc6a9c5bc081",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_02-76da7b3.stdout
+++ b/tests/reference/llvm-recursion_02-76da7b3.stdout
@@ -6,17 +6,17 @@ target datalayout = "..."
 
 @__module___lcompilers_created__nested_context__recursion_02__sub1__x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-7,I4\00", align 1
+@serialization_info = private unnamed_addr constant [15 x i8] c"S-DESC-K1-7,I4\00", align 1
 @string_const_data = private constant [7 x i8] c"before:"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data, i32 0, i32 0), i64 7 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.1 = private unnamed_addr constant [12 x i8] c"S-DESC-6,I4\00", align 1
+@serialization_info.1 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-6,I4\00", align 1
 @string_const_data.2 = private constant [6 x i8] c"after:"
 @string_const.3 = private global %string_descriptor <{ i8* getelementptr inbounds ([6 x i8], [6 x i8]* @string_const_data.2, i32 0, i32 0), i64 6 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.4 = private unnamed_addr constant [12 x i8] c"S-DESC-9,I4\00", align 1
+@serialization_info.4 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-9,I4\00", align 1
 @string_const_data.5 = private constant [9 x i8] c"x in getx"
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([9 x i8], [9 x i8]* @string_const_data.5, i32 0, i32 0), i64 9 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -25,7 +25,7 @@ target datalayout = "..."
 @string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data.7, i32 0, i32 0), i64 7 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.9 = private unnamed_addr constant [12 x i8] c"S-DESC-3,I4\00", align 1
+@serialization_info.9 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-3,I4\00", align 1
 @string_const_data.10 = private constant [3 x i8] c"r ="
 @string_const.11 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data.10, i32 0, i32 0), i64 3 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -42,7 +42,7 @@ define i32 @__module_recursion_02_solver(i32 ()* %f, i32* %iter) {
   %1 = call i32 %f()
   store i32 %1, i32* %f_val, align 4
   %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
+  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
   %4 = load i64, i64* %2, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
@@ -53,7 +53,7 @@ define i32 @__module_recursion_02_solver(i32 ()* %f, i32* %iter) {
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %10 = load i64, i64* %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %12 = icmp eq i8* %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
@@ -71,7 +71,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %16 = call i32 %f()
   store i32 %16, i32* %f_val, align 4
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %f_val)
+  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.1, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.3, i32* %f_val)
   %19 = load i64, i64* %17, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %18, i8** %20, align 8
@@ -82,7 +82,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
   %25 = load i64, i64* %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
   br i1 %27, label %free_done4, label %free_nonnull3
 
@@ -111,7 +111,7 @@ define i32 @__module_recursion_02_sub1(i32* %y, i32* %iter) {
   %0 = load i32, i32* %y, align 4
   store i32 %0, i32* %x, align 4
   %1 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %2 = load i32, i32* %iter, align 4
   %3 = icmp eq i32 %2, 1
   br i1 %3, label %then, label %else
@@ -155,7 +155,7 @@ define i32 @sub1.__module_recursion_02_getx() {
   %0 = call i8* @_lfortran_get_default_allocator()
   %getx = alloca i32, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.4, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* @__module___lcompilers_created__nested_context__recursion_02__sub1__x)
+  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.4, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* @__module___lcompilers_created__nested_context__recursion_02__sub1__x)
   %3 = load i64, i64* %1, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
@@ -166,7 +166,7 @@ define i32 @sub1.__module_recursion_02_getx() {
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -191,7 +191,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 
@@ -208,7 +208,7 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = call i32 @__module_recursion_02_sub1(i32* %call_arg_value, i32* %call_arg_value1)
   store i32 %3, i32* %r, align 4
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.9, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.11, i32* %r)
+  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.9, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.11, i32* %r)
   %6 = load i64, i64* %4, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %5, i8** %7, align 8
@@ -219,7 +219,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %10, i32 %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %14 = icmp eq i8* %5, null
   br i1 %14, label %free_done, label %free_nonnull
 

--- a/tests/reference/llvm-recursion_03-3285725.json
+++ b/tests/reference/llvm-recursion_03-3285725.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-recursion_03-3285725.stdout",
-    "stdout_hash": "00fd686651e80d86d4bc211a839f459340e88355fd6f74f18bb24faf",
+    "stdout_hash": "6ad18143b4ad5f7bafe44df82d60543ce2ce2e406c84f823198a9692",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-recursion_03-3285725.stdout
+++ b/tests/reference/llvm-recursion_03-3285725.stdout
@@ -6,17 +6,17 @@ target datalayout = "..."
 
 @__module___lcompilers_created__nested_context__recursion_03__sub1__x = global i32 0
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [12 x i8] c"S-DESC-7,I4\00", align 1
+@serialization_info = private unnamed_addr constant [15 x i8] c"S-DESC-K1-7,I4\00", align 1
 @string_const_data = private constant [7 x i8] c"before:"
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data, i32 0, i32 0), i64 7 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.2 = private unnamed_addr constant [12 x i8] c"S-DESC-6,I4\00", align 1
+@serialization_info.2 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-6,I4\00", align 1
 @string_const_data.3 = private constant [6 x i8] c"after:"
 @string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([6 x i8], [6 x i8]* @string_const_data.3, i32 0, i32 0), i64 6 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @4 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.5 = private unnamed_addr constant [12 x i8] c"S-DESC-9,I4\00", align 1
+@serialization_info.5 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-9,I4\00", align 1
 @string_const_data.6 = private constant [9 x i8] c"x in getx"
 @string_const.7 = private global %string_descriptor <{ i8* getelementptr inbounds ([9 x i8], [9 x i8]* @string_const_data.6, i32 0, i32 0), i64 9 }>
 @5 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -25,7 +25,7 @@ target datalayout = "..."
 @string_const.9 = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @string_const_data.8, i32 0, i32 0), i64 7 }>
 @7 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @8 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info.10 = private unnamed_addr constant [12 x i8] c"S-DESC-3,I4\00", align 1
+@serialization_info.10 = private unnamed_addr constant [15 x i8] c"S-DESC-K1-3,I4\00", align 1
 @string_const_data.11 = private constant [3 x i8] c"r ="
 @string_const.12 = private global %string_descriptor <{ i8* getelementptr inbounds ([3 x i8], [3 x i8]* @string_const_data.11, i32 0, i32 0), i64 3 }>
 @9 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -42,7 +42,7 @@ define i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter) {
   %1 = call i32 %f()
   store i32 %1, i32* %f_val, align 4
   %2 = alloca i64, align 8
-  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
+  %3 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info, i32 0, i32 0), i64* %2, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, i32* %f_val)
   %4 = load i64, i64* %2, align 8
   %5 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %3, i8** %5, align 8
@@ -53,7 +53,7 @@ define i32 @__module_recursion_03_solver(i32 ()* %f, i32* %iter) {
   %9 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %10 = load i64, i64* %9, align 8
   %11 = trunc i64 %10 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %8, i32 %11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %12 = icmp eq i8* %3, null
   br i1 %12, label %free_done, label %free_nonnull
 
@@ -71,7 +71,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %16 = call i32 %f()
   store i32 %16, i32* %f_val, align 4
   %17 = alloca i64, align 8
-  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.2, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.4, i32* %f_val)
+  %18 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.2, i32 0, i32 0), i64* %17, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.4, i32* %f_val)
   %19 = load i64, i64* %17, align 8
   %20 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 0
   store i8* %18, i8** %20, align 8
@@ -82,7 +82,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %24 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc2, i32 0, i32 1
   %25 = load i64, i64* %24, align 8
   %26 = trunc i64 %25 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %23, i32 %26, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %27 = icmp eq i8* %18, null
   br i1 %27, label %free_done4, label %free_nonnull3
 
@@ -128,7 +128,7 @@ define i32 @__module_recursion_03_sub1(i32* %y, i32* %iter) {
   %0 = load i32, i32* %y, align 4
   store i32 %0, i32* %x, align 4
   %1 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.9, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %1, i32 7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %2 = load i32, i32* %iter, align 4
   %3 = icmp eq i32 %2, 1
   br i1 %3, label %then, label %else
@@ -172,7 +172,7 @@ define i32 @sub1.__module_recursion_03_getx() {
   %0 = call i8* @_lfortran_get_default_allocator()
   %getx = alloca i32, align 4
   %1 = alloca i64, align 8
-  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.5, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.7, i32* @__module___lcompilers_created__nested_context__recursion_03__sub1__x)
+  %2 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %0, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.5, i32 0, i32 0), i64* %1, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.7, i32* @__module___lcompilers_created__nested_context__recursion_03__sub1__x)
   %3 = load i64, i64* %1, align 8
   %4 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %2, i8** %4, align 8
@@ -183,7 +183,7 @@ define i32 @sub1.__module_recursion_03_getx() {
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -208,7 +208,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 
@@ -225,7 +225,7 @@ define i32 @main(i32 %0, i8** %1) {
   %3 = call i32 @__module_recursion_03_sub1(i32* %call_arg_value, i32* %call_arg_value1)
   store i32 %3, i32* %r, align 4
   %4 = alloca i64, align 8
-  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @serialization_info.10, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %r)
+  %5 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([15 x i8], [15 x i8]* @serialization_info.10, i32 0, i32 0), i64* %4, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.12, i32* %r)
   %6 = load i64, i64* %4, align 8
   %7 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %5, i8** %7, align 8
@@ -236,7 +236,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %10, i32 %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %14 = icmp eq i8* %5, null
   br i1 %14, label %free_done, label %free_nonnull
 

--- a/tests/reference/llvm-return_01-495409d.json
+++ b/tests/reference/llvm-return_01-495409d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_01-495409d.stdout",
-    "stdout_hash": "e9961a7d4a2f26118382139e90818d37716291e7becd252c96ff264b",
+    "stdout_hash": "d255a4f3ab5edaea9f09988e57422a1edd7e41a16a53a5d8e1c7c32b",
     "stderr": "llvm-return_01-495409d.stderr",
     "stderr_hash": "98d80e924c656c0c4a14372c1012a5da09682be3684f582f50255347",
     "returncode": 0

--- a/tests/reference/llvm-return_01-495409d.stdout
+++ b/tests/reference/llvm-return_01-495409d.stdout
@@ -24,7 +24,7 @@ define i32 @main(i32 %0, i8** %1) {
   %2 = call i32 @main1()
   store i32 %2, i32* %main_out, align 4
   %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %3, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %3, i32 12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -48,7 +48,7 @@ then:                                             ; preds = %.entry
   %2 = load i32, i32* %i, align 4
   store i32 %2, i32* %main1, align 4
   %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i32 12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -59,7 +59,7 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
   %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i32 13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %5 = load i32, i32* %i, align 4
   store i32 %5, i32* %main1, align 4
   br label %return
@@ -72,7 +72,7 @@ FINALIZE_SYMTABLE_main1:                          ; preds = %return
   ret i32 %6
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 

--- a/tests/reference/llvm-return_02-99fb0b3.json
+++ b/tests/reference/llvm-return_02-99fb0b3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_02-99fb0b3.stdout",
-    "stdout_hash": "ccb974cc5e56c7d89d77ef0505cc0d06421601827f05c5c43be3829f",
+    "stdout_hash": "ad345dcaa2677b6965ae3544f5cae3ee1d77025ee01c96ab3a38e4d0",
     "stderr": "llvm-return_02-99fb0b3.stderr",
     "stderr_hash": "efcbccc2e2e71c4026b6ef48d5fa977b7432890f8fc2395640038aa4",
     "returncode": 0

--- a/tests/reference/llvm-return_02-99fb0b3.stdout
+++ b/tests/reference/llvm-return_02-99fb0b3.stdout
@@ -26,7 +26,7 @@ define i32 @__module_many_returns_b(i32* %a) {
   %b = alloca i32, align 4
   %e = alloca i32, align 4
   %0 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 9, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %0, i32 9, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %1 = call i32 @b.__module_many_returns_d(i32* %a)
   store i32 %1, i32* %b, align 4
   br label %return
@@ -98,7 +98,7 @@ FINALIZE_SYMTABLE_d:                              ; preds = %return
   ret i32 %6
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 define i32 @main(i32 %0, i8** %1) {
 .entry:
@@ -125,7 +125,7 @@ define i32 @main(i32 %0, i8** %1) {
   %11 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %12 = load i64, i64* %11, align 8
   %13 = trunc i64 %12 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i32 %13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %10, i32 %13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %14 = icmp eq i8* %5, null
   br i1 %14, label %free_done, label %free_nonnull
 
@@ -149,7 +149,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %24 = load i64, i64* %23, align 8
   %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %22, i32 %25, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %26 = icmp eq i8* %17, null
   br i1 %26, label %free_done3, label %free_nonnull2
 
@@ -173,7 +173,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %35 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %36 = load i64, i64* %35, align 8
   %37 = trunc i64 %36 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %34, i32 %37, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %34, i32 %37, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %38 = icmp eq i8* %29, null
   br i1 %38, label %free_done6, label %free_nonnull5
 
@@ -197,7 +197,7 @@ free_done6:                                       ; preds = %free_nonnull5, %fre
   %47 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc7, i32 0, i32 1
   %48 = load i64, i64* %47, align 8
   %49 = trunc i64 %48 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %46, i32 %49, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0), i8* %46, i32 %49, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %50 = icmp eq i8* %41, null
   br i1 %50, label %free_done9, label %free_nonnull8
 

--- a/tests/reference/llvm-return_03-3f7087d.json
+++ b/tests/reference/llvm-return_03-3f7087d.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_03-3f7087d.stdout",
-    "stdout_hash": "43e95fe72656d8993d3ed7ef431b5b4b9e74ba65da00a4bae440aaee",
+    "stdout_hash": "10123c0051b228b591da395f37277359f87b7c9812886da51255b13c",
     "stderr": "llvm-return_03-3f7087d.stderr",
     "stderr_hash": "3a3e7d555e7082b1df762706047d54b39d0484046e5f72bf507b2a3b",
     "returncode": 0

--- a/tests/reference/llvm-return_03-3f7087d.stdout
+++ b/tests/reference/llvm-return_03-3f7087d.stdout
@@ -23,7 +23,7 @@ define i32 @main(i32 %0, i8** %1) {
   call void @_lpython_call_initial_functions(i32 %0, i8** %1)
   call void @main1(i32* @main.main_out)
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %2, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %2, i32 12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %.entry
@@ -46,7 +46,7 @@ then:                                             ; preds = %.entry
   %2 = load i32, i32* %i, align 4
   store i32 %2, i32* %out_var, align 4
   %3 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i32 12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %3, i32 12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %return
 
 unreachable_after_return:                         ; No predecessors!
@@ -57,7 +57,7 @@ else:                                             ; preds = %.entry
 
 ifcont:                                           ; preds = %else, %unreachable_after_return
   %4 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i32 13, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %4, i32 13, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %5 = load i32, i32* %i, align 4
   store i32 %5, i32* %out_var, align 4
   br label %return
@@ -69,7 +69,7 @@ FINALIZE_SYMTABLE_main1:                          ; preds = %return
   ret void
 }
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 

--- a/tests/reference/llvm-return_05-b1ab26b.json
+++ b/tests/reference/llvm-return_05-b1ab26b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-return_05-b1ab26b.stdout",
-    "stdout_hash": "a3c0e131e2e7ebcf54a6c96b0d26f76ccbd2978344290e974d147b54",
+    "stdout_hash": "1f7e69900b40a86b7d5ac11bf6c81cd27921ffbe92311a48579a405d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-return_05-b1ab26b.stdout
+++ b/tests/reference/llvm-return_05-b1ab26b.stdout
@@ -27,7 +27,7 @@ define i32 @main(i32 %0, i8** %1) {
 
 unreachable_after_return:                         ; No predecessors!
   %2 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 11, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %2, i32 11, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %unreachable_after_return, %.entry
@@ -40,6 +40,6 @@ FINALIZE_SYMTABLE_main:                           ; preds = %return
 
 declare void @_lpython_call_initial_functions(i32, i8**)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-select_type_13-f465d8c.json
+++ b/tests/reference/llvm-select_type_13-f465d8c.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-select_type_13-f465d8c.stdout",
-    "stdout_hash": "ec17e120d06afc299ab09e2bd16c3f51dbb5200b3493915a04afe5b6",
+    "stdout_hash": "f9e8d2f5289fd7bda5da288d485cab6dbdd41262be348021dd5057dd",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-select_type_13-f465d8c.stdout
+++ b/tests/reference/llvm-select_type_13-f465d8c.stdout
@@ -200,7 +200,7 @@ ifcont:                                           ; preds = %else, %then1
 "~select_type_block_.start":                      ; preds = %then
   %28 = call i8* @llvm.stacksave()
   %29 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %29, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %29, i32 20, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %"~select_type_block_.end"
 
 "~select_type_block_.end":                        ; preds = %"~select_type_block_.start"
@@ -243,7 +243,7 @@ ifcont6:                                          ; preds = %else5, %then4
 "~select_type_block_1.start":                     ; preds = %then3
   %42 = call i8* @llvm.stacksave()
   %43 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %43, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %43, i32 17, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %44 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s1, align 8
   %45 = ptrtoint %select_type_13_module.shape.3_class** %44 to i64
   %46 = icmp eq i64 %45, 0
@@ -346,7 +346,7 @@ ifcont10:                                         ; preds = %ifcont8
   %105 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %106 = load i64, i64* %105, align 8
   %107 = trunc i64 %106 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %104, i32 %107, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %104, i32 %107, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0), i32 1)
   %108 = icmp eq i8* %99, null
   br i1 %108, label %free_done, label %free_nonnull
 
@@ -427,7 +427,7 @@ else16:                                           ; preds = %ifcont6
 "~select_type_block_2.start":                     ; preds = %else16
   %137 = call i8* @llvm.stacksave()
   %138 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %138, i32 16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @21, i32 0, i32 0), i8* %138, i32 16, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @20, i32 0, i32 0), i32 1)
   br label %"~select_type_block_2.end"
 
 "~select_type_block_2.end":                       ; preds = %"~select_type_block_2.start"
@@ -489,7 +489,7 @@ ifcont21:                                         ; preds = %else20, %then19
 "~select_type_block_3.start":                     ; preds = %then18
   %165 = call i8* @llvm.stacksave()
   %166 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %166, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %166, i32 17, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
   br label %"~select_type_block_3.end"
 
 "~select_type_block_3.end":                       ; preds = %"~select_type_block_3.start"
@@ -532,7 +532,7 @@ ifcont26:                                         ; preds = %else25, %then24
 "~select_type_block_4.start":                     ; preds = %then23
   %179 = call i8* @llvm.stacksave()
   %180 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.8, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %180, i32 20, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @25, i32 0, i32 0), i8* %180, i32 20, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @24, i32 0, i32 0), i32 1)
   %181 = load %select_type_13_module.shape.3_class**, %select_type_13_module.shape.3_class** %s2, align 8
   %182 = ptrtoint %select_type_13_module.shape.3_class** %181 to i64
   %183 = icmp eq i64 %182, 0
@@ -725,7 +725,7 @@ ifcont34:                                         ; preds = %ifcont32
   %296 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc35, i32 0, i32 1
   %297 = load i64, i64* %296, align 8
   %298 = trunc i64 %297 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %295, i32 %298, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @43, i32 0, i32 0), i8* %295, i32 %298, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @34, i32 0, i32 0), i32 1)
   %299 = icmp eq i8* %290, null
   br i1 %299, label %free_done37, label %free_nonnull36
 
@@ -863,7 +863,7 @@ else48:                                           ; preds = %ifcont26
 "~select_type_block_5.start":                     ; preds = %else48
   %356 = call i8* @llvm.stacksave()
   %357 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.11, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @57, i32 0, i32 0), i8* %357, i32 16, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @57, i32 0, i32 0), i8* %357, i32 16, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @56, i32 0, i32 0), i32 1)
   br label %"~select_type_block_5.end"
 
 "~select_type_block_5.end":                       ; preds = %"~select_type_block_5.start"
@@ -1052,7 +1052,7 @@ declare i8* @__lfortran_dynamic_cast(i8*, i8*, i1)
 ; Function Attrs: nounwind
 declare i8* @llvm.stacksave() #1
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 ; Function Attrs: nounwind
 declare void @llvm.stackrestore(i8*) #1

--- a/tests/reference/llvm-sin_03-14abee4.json
+++ b/tests/reference/llvm-sin_03-14abee4.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-sin_03-14abee4.stdout",
-    "stdout_hash": "c50727f98c1e334ffd1e50c3a8d805c734c6e1417a517e98e7a18901",
+    "stdout_hash": "2818622bd9139491ff8f1f87e993ffbcffef8b3a9eefaaf7b69cc49d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-sin_03-14abee4.stdout
+++ b/tests/reference/llvm-sin_03-14abee4.stdout
@@ -27,7 +27,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -52,7 +52,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-string_01-deb8ed3.json
+++ b/tests/reference/llvm-string_01-deb8ed3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_01-deb8ed3.stdout",
-    "stdout_hash": "ef565379c291259557abd75e1d70bbb69f5fce45f416d03cd7c670f0",
+    "stdout_hash": "6e0f7cc49300fa48f0e1fe4d155ad0e7b3d9e09474ca12556e791320",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_01-deb8ed3.stdout
+++ b/tests/reference/llvm-string_01-deb8ed3.stdout
@@ -7,7 +7,7 @@ target datalayout = "..."
 @my_name_data = private global [7 x i8] c"Dominic"
 @my_name = private global %string_descriptor <{ i8* getelementptr inbounds ([7 x i8], [7 x i8]* @my_name_data, i32 0, i32 0), i64 7 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [19 x i8] c"S-DESC-11,S-DESC-7\00", align 1
+@serialization_info = private unnamed_addr constant [25 x i8] c"S-DESC-K1-11,S-DESC-K1-7\00", align 1
 @string_const_data = private constant [11 x i8] c"My name is "
 @string_const = private global %string_descriptor <{ i8* getelementptr inbounds ([11 x i8], [11 x i8]* @string_const_data, i32 0, i32 0), i64 11 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -21,7 +21,7 @@ define i32 @main(i32 %0, i8** %1) {
   %4 = load %string_descriptor, %string_descriptor* @my_name, align 1
   %5 = alloca %string_descriptor, align 8
   store %string_descriptor %4, %string_descriptor* %5, align 1
-  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, %string_descriptor* %5)
+  %6 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @serialization_info, i32 0, i32 0), i64* %3, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const, %string_descriptor* %5)
   %7 = load i64, i64* %3, align 8
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %6, i8** %8, align 8
@@ -32,7 +32,7 @@ define i32 @main(i32 %0, i8** %1) {
   %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %13 = load i64, i64* %12, align 8
   %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %11, i32 %14, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %15 = icmp eq i8* %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
@@ -57,7 +57,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-string_02-c37e098.json
+++ b/tests/reference/llvm-string_02-c37e098.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_02-c37e098.stdout",
-    "stdout_hash": "e29e488f2a412c845036e395fa46229fe5f6f377def3887f570e195f",
+    "stdout_hash": "3c3b5b244635f48a16ea5f17dd7473465013e43646f46d257a245cf9",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_02-c37e098.stdout
+++ b/tests/reference/llvm-string_02-c37e098.stdout
@@ -13,7 +13,7 @@ target datalayout = "..."
 @string_const_data.5 = private constant [25 x i8] c"A big hello from Mr. Bean"
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([25 x i8], [25 x i8]* @string_const_data.5, i32 0, i32 0), i64 25 }>
 @0 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [38 x i8] c"S-DESC-8,S-DESC-6,S-DESC-15,S-DESC-15\00", align 1
+@serialization_info = private unnamed_addr constant [50 x i8] c"S-DESC-K1-8,S-DESC-K1-6,S-DESC-K1-15,S-DESC-K1-15\00", align 1
 @string_const_data.7 = private constant [8 x i8] c"Here is "
 @string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([8 x i8], [8 x i8]* @string_const_data.7, i32 0, i32 0), i64 8 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -83,7 +83,7 @@ define i32 @main(i32 %0, i8** %1) {
   %36 = load %string_descriptor, %string_descriptor* %surname, align 1
   %37 = alloca %string_descriptor, align 8
   store %string_descriptor %36, %string_descriptor* %37, align 1
-  %38 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([38 x i8], [38 x i8]* @serialization_info, i32 0, i32 0), i64* %31, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.8, %string_descriptor* %33, %string_descriptor* %35, %string_descriptor* %37)
+  %38 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([50 x i8], [50 x i8]* @serialization_info, i32 0, i32 0), i64* %31, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.8, %string_descriptor* %33, %string_descriptor* %35, %string_descriptor* %37)
   %39 = load i64, i64* %31, align 8
   %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %38, i8** %40, align 8
@@ -94,7 +94,7 @@ define i32 @main(i32 %0, i8** %1) {
   %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %45 = load i64, i64* %44, align 8
   %46 = trunc i64 %45 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %43, i32 %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %43, i32 %46, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %47 = icmp eq i8* %38, null
   br i1 %47, label %free_done, label %free_nonnull
 
@@ -105,7 +105,7 @@ free_nonnull:                                     ; preds = %.entry
 free_done:                                        ; preds = %free_nonnull, %.entry
   %48 = getelementptr %string_descriptor, %string_descriptor* %greetings, i32 0, i32 0
   %49 = load i8*, i8** %48, align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %49, i32 25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %49, i32 25, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %free_done
@@ -150,7 +150,7 @@ declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-string_03-2cd8fec.json
+++ b/tests/reference/llvm-string_03-2cd8fec.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_03-2cd8fec.stdout",
-    "stdout_hash": "efcc078a3a240a65fee0d8732188b533dd291afd65fc921731822f2d",
+    "stdout_hash": "cfb4284be09d7f5d48c568b8fb94492944a82442b507037ef7ff30ca",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_03-2cd8fec.stdout
+++ b/tests/reference/llvm-string_03-2cd8fec.stdout
@@ -15,19 +15,19 @@ target datalayout = "..."
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([4 x i8], [4 x i8]* @string_const_data.5, i32 0, i32 0), i64 4 }>
 @string_const_data.7 = private constant [5 x i8] c"I've "
 @string_const.8 = private global %string_descriptor <{ i8* getelementptr inbounds ([5 x i8], [5 x i8]* @string_const_data.7, i32 0, i32 0), i64 5 }>
-@0 = private unnamed_addr constant [25 x i8] c"_lcompilers_stringconcat\00", align 1
+@0 = private unnamed_addr constant [27 x i8] c"_lcompilers_stringconcat_1\00", align 1
 @1 = private unnamed_addr constant [41 x i8] c"tests/../integration_tests/string_03.f90\00", align 1
 @2 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
 @3 = private unnamed_addr constant [45 x i8] c"Argument %d of subroutine %s is unallocated.\00", align 1
-@4 = private unnamed_addr constant [25 x i8] c"_lcompilers_stringconcat\00", align 1
+@4 = private unnamed_addr constant [27 x i8] c"_lcompilers_stringconcat_1\00", align 1
 @5 = private unnamed_addr constant [41 x i8] c"tests/../integration_tests/string_03.f90\00", align 1
 @6 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
 @7 = private unnamed_addr constant [45 x i8] c"Argument %d of subroutine %s is unallocated.\00", align 1
-@8 = private unnamed_addr constant [25 x i8] c"_lcompilers_stringconcat\00", align 1
+@8 = private unnamed_addr constant [27 x i8] c"_lcompilers_stringconcat_1\00", align 1
 @9 = private unnamed_addr constant [41 x i8] c"tests/../integration_tests/string_03.f90\00", align 1
 @10 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
 @11 = private unnamed_addr constant [45 x i8] c"Argument %d of subroutine %s is unallocated.\00", align 1
-@12 = private unnamed_addr constant [25 x i8] c"_lcompilers_stringconcat\00", align 1
+@12 = private unnamed_addr constant [27 x i8] c"_lcompilers_stringconcat_1\00", align 1
 @13 = private unnamed_addr constant [41 x i8] c"tests/../integration_tests/string_03.f90\00", align 1
 @14 = private unnamed_addr constant [20 x i8] c"This is unallocated\00", align 1
 @15 = private unnamed_addr constant [45 x i8] c"Argument %d of subroutine %s is unallocated.\00", align 1
@@ -36,7 +36,7 @@ target datalayout = "..."
 @16 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
 @17 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 
-define void @_lcompilers_stringconcat(%string_descriptor* %s1, %string_descriptor* %s2, i32* %s1_len, i32* %s2_len, %string_descriptor* %concat_result) {
+define void @_lcompilers_stringconcat_1(%string_descriptor* %s1, %string_descriptor* %s2, i32* %s1_len, i32* %s2_len, %string_descriptor* %concat_result) {
 .entry:
   %StrSlice_StrView2 = alloca %string_descriptor, align 8
   %0 = call i8* @_lfortran_get_default_allocator()
@@ -120,9 +120,9 @@ ifcont:                                           ; preds = %else, %then
   br label %return
 
 return:                                           ; preds = %ifcont
-  br label %FINALIZE_SYMTABLE__lcompilers_stringconcat
+  br label %FINALIZE_SYMTABLE__lcompilers_stringconcat_1
 
-FINALIZE_SYMTABLE__lcompilers_stringconcat:       ; preds = %return
+FINALIZE_SYMTABLE__lcompilers_stringconcat_1:     ; preds = %return
   ret void
 }
 
@@ -216,7 +216,7 @@ define i32 @main(i32 %0, i8** %1) {
   store i64 0, i64* %36, align 8
   store i32 5, i32* %call_arg_value, align 4
   store i32 8, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* @string_const.8, %string_descriptor* %verb, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__0_return_slot)
+  call void @_lcompilers_stringconcat_1(%string_descriptor* @string_const.8, %string_descriptor* %verb, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__0_return_slot)
   %38 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 0
   %39 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__1_return_slot, i32 0, i32 1
   %40 = load i8*, i8** %38, align 8
@@ -255,14 +255,14 @@ then:                                             ; preds = %.entry
   %59 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %54, i32 0, i32 3
   store i32 1, i32* %59, align 4
   %60 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %45, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %60, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @3, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @0, i32 0, i32 0))
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %60, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @3, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @0, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont:                                           ; preds = %.entry
   store i32 13, i32* %call_arg_value, align 4
   store i32 5, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__0_return_slot, %string_descriptor* %posit, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__1_return_slot)
+  call void @_lcompilers_stringconcat_1(%string_descriptor* %__libasr__created__var__0_return_slot, %string_descriptor* %posit, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__1_return_slot)
   %61 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 0
   %62 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__2_return_slot, i32 0, i32 1
   %63 = load i8*, i8** %61, align 8
@@ -301,14 +301,14 @@ then2:                                            ; preds = %ifcont
   %82 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %77, i32 0, i32 3
   store i32 1, i32* %82, align 4
   %83 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %68, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @7, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @4, i32 0, i32 0))
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %83, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @7, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @4, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont3:                                          ; preds = %ifcont
   store i32 18, i32* %call_arg_value, align 4
   store i32 4, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__1_return_slot, %string_descriptor* %title, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__2_return_slot)
+  call void @_lcompilers_stringconcat_1(%string_descriptor* %__libasr__created__var__1_return_slot, %string_descriptor* %title, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__2_return_slot)
   %84 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 0
   %85 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__3_return_slot, i32 0, i32 1
   %86 = load i8*, i8** %84, align 8
@@ -347,14 +347,14 @@ then4:                                            ; preds = %ifcont3
   %105 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %100, i32 0, i32 3
   store i32 1, i32* %105, align 4
   %106 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %91, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %106, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @11, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @8, i32 0, i32 0))
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %106, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @11, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @8, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont5:                                          ; preds = %ifcont3
   store i32 22, i32* %call_arg_value, align 4
   store i32 7, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__2_return_slot, %string_descriptor* %last_name, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__3_return_slot)
+  call void @_lcompilers_stringconcat_1(%string_descriptor* %__libasr__created__var__2_return_slot, %string_descriptor* %last_name, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__3_return_slot)
   %107 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
   %108 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 1
   %109 = load i8*, i8** %107, align 8
@@ -393,14 +393,14 @@ then6:                                            ; preds = %ifcont5
   %128 = getelementptr { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %123, i32 0, i32 3
   store i32 1, i32* %128, align 4
   %129 = getelementptr [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }], [1 x { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }]* %114, i32 0, i32 0
-  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %129, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @15, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @12, i32 0, i32 0))
+  call void (i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...) @_lcompilers_runtime_error(i8* %2, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }* %129, i32 1, i8* getelementptr inbounds ([45 x i8], [45 x i8]* @15, i32 0, i32 0), i32 1, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @12, i32 0, i32 0))
   call void @exit(i32 1)
   unreachable
 
 ifcont7:                                          ; preds = %ifcont5
   store i32 29, i32* %call_arg_value, align 4
   store i32 1, i32* %call_arg_value1, align 4
-  call void @_lcompilers_stringconcat(%string_descriptor* %__libasr__created__var__3_return_slot, %string_descriptor* @string_const.10, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__4_return_slot)
+  call void @_lcompilers_stringconcat_1(%string_descriptor* %__libasr__created__var__3_return_slot, %string_descriptor* @string_const.10, i32* %call_arg_value, i32* %call_arg_value1, %string_descriptor* %__libasr__created__var__4_return_slot)
   %130 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
   %131 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 1
   %132 = getelementptr %string_descriptor, %string_descriptor* %__libasr__created__var__4_return_slot, i32 0, i32 0
@@ -410,7 +410,7 @@ ifcont7:                                          ; preds = %ifcont5
   call void @_lfortran_strcpy_alloc(i8* %2, i8** %130, i64* %131, i8 0, i8 0, i8* %133, i64 %135, i32 1)
   %136 = getelementptr %string_descriptor, %string_descriptor* %combined, i32 0, i32 0
   %137 = load i8*, i8** %136, align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %137, i32 29, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %137, i32 29, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
   br label %return
 
 return:                                           ; preds = %ifcont7
@@ -491,6 +491,6 @@ declare i8* @_lcompilers_snprintf_alloc(i8*, i8*, ...)
 
 declare void @_lcompilers_runtime_error(i8*, { i1, i8*, { i8*, i32, i32, i32, i32 }*, i32 }*, i32, i8*, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_internal_alloc_finalize()

--- a/tests/reference/llvm-string_10-ef0078f.json
+++ b/tests/reference/llvm-string_10-ef0078f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_10-ef0078f.stdout",
-    "stdout_hash": "d7eda03c22b4031ef3be6ee191782a625a9ce2fec593e9232699e468",
+    "stdout_hash": "ac47644e12c4fa37e1d7bb9138f685eb80fd8e18a3dc1064654c3801",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_10-ef0078f.stdout
+++ b/tests/reference/llvm-string_10-ef0078f.stdout
@@ -101,7 +101,7 @@ define i32 @main(i32 %0, i8** %1) {
   %34 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %35 = load i64, i64* %34, align 8
   %36 = trunc i64 %35 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %33, i32 %36, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %33, i32 %36, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %37 = icmp eq i8* %28, null
   br i1 %37, label %free_done, label %free_nonnull
 
@@ -145,7 +145,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %66 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %67 = load i64, i64* %66, align 8
   %68 = trunc i64 %67 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %65, i32 %68, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %65, i32 %68, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %69 = icmp eq i8* %60, null
   br i1 %69, label %free_done3, label %free_nonnull2
 
@@ -189,7 +189,7 @@ free_done3:                                       ; preds = %free_nonnull2, %fre
   %98 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %99 = load i64, i64* %98, align 8
   %100 = trunc i64 %99 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %97, i32 %100, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %97, i32 %100, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   %101 = icmp eq i8* %92, null
   br i1 %101, label %free_done6, label %free_nonnull5
 
@@ -252,7 +252,7 @@ declare i32 @str_compare(i8*, i64, i8*, i64)
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-string_11-e6c763f.json
+++ b/tests/reference/llvm-string_11-e6c763f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_11-e6c763f.stdout",
-    "stdout_hash": "7b9804001528885fed4ea38be93fb05ea7a6c4229c4e51ca15803d5d",
+    "stdout_hash": "e8eedd013bbb86b98643d5b98fa97edb6396b22a2a0f3281dff73df5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_11-e6c763f.stdout
+++ b/tests/reference/llvm-string_11-e6c763f.stdout
@@ -13,7 +13,7 @@ target datalayout = "..."
 @string_const.4 = private global %string_descriptor <{ i8* getelementptr inbounds ([17 x i8], [17 x i8]* @string_const_data.3, i32 0, i32 0), i64 17 }>
 @1 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
 @2 = private unnamed_addr constant [2 x i8] c"\0A\00", align 1
-@serialization_info = private unnamed_addr constant [13 x i8] c"S-DESC-24,I4\00", align 1
+@serialization_info = private unnamed_addr constant [16 x i8] c"S-DESC-K1-24,I4\00", align 1
 @string_const_data.5 = private constant [24 x i8] c"test is found at index: "
 @string_const.6 = private global %string_descriptor <{ i8* getelementptr inbounds ([24 x i8], [24 x i8]* @string_const_data.5, i32 0, i32 0), i64 24 }>
 @3 = private unnamed_addr constant [5 x i8] c"%s%s\00", align 1
@@ -395,7 +395,7 @@ define i32 @main(i32 %0, i8** %1) {
 
 then:                                             ; preds = %.entry
   %19 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i32 17, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %19, i32 17, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %ifcont
 
 else:                                             ; preds = %.entry
@@ -405,7 +405,7 @@ else:                                             ; preds = %.entry
   %21 = call i32 @_lcompilers_index_str1(%string_descriptor* %mystring, %string_descriptor* %teststring, i32* %call_arg_value, i32* %call_arg_value1)
   %22 = alloca i32, align 4
   store i32 %21, i32* %22, align 4
-  %23 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @serialization_info, i32 0, i32 0), i64* %20, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %22)
+  %23 = call i8* (i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...) @_lcompilers_string_format_fortran(i8* %2, i8* null, i64 0, i8* getelementptr inbounds ([16 x i8], [16 x i8]* @serialization_info, i32 0, i32 0), i64* %20, i32 0, i32 0, i32 0, i32 0, i32 0, %string_descriptor* @string_const.6, i32* %22)
   %24 = load i64, i64* %20, align 8
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 0
   store i8* %23, i8** %25, align 8
@@ -416,7 +416,7 @@ else:                                             ; preds = %.entry
   %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %30 = load i64, i64* %29, align 8
   %31 = trunc i64 %30 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %28, i32 %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %28, i32 %31, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %32 = icmp eq i8* %23, null
   br i1 %32, label %free_done, label %free_nonnull
 
@@ -458,7 +458,7 @@ declare i8* @_lfortran_get_default_allocator()
 
 declare void @_lfortran_strcpy_alloc(i8*, i8**, i64*, i8, i8, i8*, i64, i32)
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i32, i32, i32, i32, ...)
 

--- a/tests/reference/llvm-string_13-8952a13.json
+++ b/tests/reference/llvm-string_13-8952a13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-string_13-8952a13.stdout",
-    "stdout_hash": "c0374a8fdcf48dc96584c24875b0c4256ad0b9fd5cfa618ff10bf548",
+    "stdout_hash": "c1227d5e39d8f30808afd961ee89f24859ca28b0ae7497d8f727f4a3",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-string_13-8952a13.stdout
+++ b/tests/reference/llvm-string_13-8952a13.stdout
@@ -80,7 +80,7 @@ ifcont6:                                          ; preds = %else5, %then4
   %13 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %14 = load i64, i64* %13, align 8
   %15 = trunc i64 %14 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %12, i32 %15, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %12, i32 %15, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %16 = icmp eq i8* %7, null
   br i1 %16, label %free_done, label %free_nonnull
 
@@ -111,6 +111,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.json
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_01-e2ed4a5.stdout",
-    "stdout_hash": "fa09ec2a09177717110be16b2dcc56cc10348e274ba3f79e8c7750a3",
+    "stdout_hash": "ef420bca8e1bb12a327ad8c423029849e72d70b285b7af7911cfe2ee",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
+++ b/tests/reference/llvm-subroutines_01-e2ed4a5.stdout
@@ -76,7 +76,7 @@ ifcont:                                           ; preds = %else, %then
   %12 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %13 = load i64, i64* %12, align 8
   %14 = trunc i64 %13 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %11, i32 %14, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %11, i32 %14, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %15 = icmp eq i8* %6, null
   br i1 %15, label %free_done, label %free_nonnull
 
@@ -142,7 +142,7 @@ ifcont9:                                          ; preds = %else8, %then7
   %29 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc10, i32 0, i32 1
   %30 = load i64, i64* %29, align 8
   %31 = trunc i64 %30 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %28, i32 %31, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @11, i32 0, i32 0), i8* %28, i32 %31, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0), i32 1)
   %32 = icmp eq i8* %23, null
   br i1 %32, label %free_done12, label %free_nonnull11
 
@@ -194,7 +194,7 @@ ifcont18:                                         ; preds = %else17, %then16
   %44 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc19, i32 0, i32 1
   %45 = load i64, i64* %44, align 8
   %46 = trunc i64 %45 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %43, i32 %46, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @17, i32 0, i32 0), i8* %43, i32 %46, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @16, i32 0, i32 0), i32 1)
   %47 = icmp eq i8* %38, null
   br i1 %47, label %free_done21, label %free_nonnull20
 
@@ -248,7 +248,7 @@ ifcont27:                                         ; preds = %else26, %then25
   %61 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc28, i32 0, i32 1
   %62 = load i64, i64* %61, align 8
   %63 = trunc i64 %62 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %60, i32 %63, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @23, i32 0, i32 0), i8* %60, i32 %63, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @22, i32 0, i32 0), i32 1)
   %64 = icmp eq i8* %55, null
   br i1 %64, label %free_done30, label %free_nonnull29
 
@@ -307,6 +307,6 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)

--- a/tests/reference/llvm-subroutines_02-83f1d9f.json
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_02-83f1d9f.stdout",
-    "stdout_hash": "6b9b7cebc6c92c554cc4d835292472e8756a900e73ec1203eb54202e",
+    "stdout_hash": "aa04b17500bd5d1202b73e43b43d1510e4b16ad20df9b909654e669c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_02-83f1d9f.stdout
+++ b/tests/reference/llvm-subroutines_02-83f1d9f.stdout
@@ -51,7 +51,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -101,7 +101,7 @@ ifcont3:                                          ; preds = %else2, %then1
   %25 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc4, i32 0, i32 1
   %26 = load i64, i64* %25, align 8
   %27 = trunc i64 %26 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %24, i32 %27, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %24, i32 %27, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   %28 = icmp eq i8* %19, null
   br i1 %28, label %free_done6, label %free_nonnull5
 
@@ -151,7 +151,7 @@ ifcont12:                                         ; preds = %else11, %then10
   %40 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc13, i32 0, i32 1
   %41 = load i64, i64* %40, align 8
   %42 = trunc i64 %41 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %39, i32 %42, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @13, i32 0, i32 0), i8* %39, i32 %42, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @12, i32 0, i32 0), i32 1)
   %43 = icmp eq i8* %34, null
   br i1 %43, label %free_done15, label %free_nonnull14
 
@@ -244,7 +244,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-subroutines_04-ba99aa1.json
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-subroutines_04-ba99aa1.stdout",
-    "stdout_hash": "031ff2f5f8a12f177dec0f17eb151b44d8212cd7fdd2ab251e04889d",
+    "stdout_hash": "6b195535e4f77a3ebca2b65362c2b61142fe7f499383593c262d0e70",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-subroutines_04-ba99aa1.stdout
+++ b/tests/reference/llvm-subroutines_04-ba99aa1.stdout
@@ -40,7 +40,7 @@ define void @print_int() {
   %8 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %9 = load i64, i64* %8, align 8
   %10 = trunc i64 %9 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %7, i32 %10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %11 = icmp eq i8* %2, null
   br i1 %11, label %free_done, label %free_nonnull
 
@@ -62,7 +62,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-types_03-ce710b0.json
+++ b/tests/reference/llvm-types_03-ce710b0.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-types_03-ce710b0.stdout",
-    "stdout_hash": "0f20e3b48e9ff1094209149c10583d43238d7636ee64d884b02dc41b",
+    "stdout_hash": "736fd15e7b509ab233f7456426452507c85c0f540da05f0f0b78b077",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-types_03-ce710b0.stdout
+++ b/tests/reference/llvm-types_03-ce710b0.stdout
@@ -32,7 +32,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -56,7 +56,7 @@ free_done:                                        ; preds = %free_nonnull, %.ent
   %23 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc1, i32 0, i32 1
   %24 = load i64, i64* %23, align 8
   %25 = trunc i64 %24 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %22, i32 %25, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   %26 = icmp eq i8* %17, null
   br i1 %26, label %free_done3, label %free_nonnull2
 
@@ -81,7 +81,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout",
-    "stdout_hash": "3126adfc39caf17c06b21a415600fcdfa30ec8b502ac0438449e3025",
+    "stdout_hash": "425144121bcb7445c742c109ed9e66944cec007771b34a2c5d5e5658",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
+++ b/tests/reference/llvm-unlimited_polymorphic_intrinsic_type_allocate-3e26601.stdout
@@ -65,7 +65,7 @@ then:                                             ; preds = %.entry
 "~select_type_block_.start":                      ; preds = %then
   %19 = call i8* @llvm.stacksave()
   %20 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %20, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   br label %"~select_type_block_.end"
 
 "~select_type_block_.end":                        ; preds = %"~select_type_block_.start"
@@ -91,7 +91,7 @@ then1:                                            ; preds = %else
 "~select_type_block_1.start":                     ; preds = %then1
   %27 = call i8* @llvm.stacksave()
   %28 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.2, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %28, i32 10, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @3, i32 0, i32 0), i8* %28, i32 10, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0), i32 1)
   br label %"~select_type_block_1.end"
 
 "~select_type_block_1.end":                       ; preds = %"~select_type_block_1.start"
@@ -117,7 +117,7 @@ then3:                                            ; preds = %else2
 "~select_type_block_2.start":                     ; preds = %then3
   %35 = call i8* @llvm.stacksave()
   %36 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.4, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %36, i32 4, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0), i8* %36, i32 4, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0), i32 1)
   br label %"~select_type_block_2.end"
 
 "~select_type_block_2.end":                       ; preds = %"~select_type_block_2.start"
@@ -133,7 +133,7 @@ else4:                                            ; preds = %else2
 "~select_type_block_3.start":                     ; preds = %else4
   %37 = call i8* @llvm.stacksave()
   %38 = load i8*, i8** getelementptr inbounds (%string_descriptor, %string_descriptor* @string_const.6, i32 0, i32 0), align 8
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %38, i32 7, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0), i8* %38, i32 7, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0), i32 1)
   br label %"~select_type_block_3.end"
 
 "~select_type_block_3.end":                       ; preds = %"~select_type_block_3.start"
@@ -205,7 +205,7 @@ declare i8* @__lfortran_dynamic_cast(i8*, i8*, i1)
 ; Function Attrs: nounwind
 declare i8* @llvm.stacksave() #1
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 ; Function Attrs: nounwind
 declare void @llvm.stackrestore(i8*) #1

--- a/tests/reference/llvm-volatile_02-2beae13.json
+++ b/tests/reference/llvm-volatile_02-2beae13.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "llvm-volatile_02-2beae13.stdout",
-    "stdout_hash": "9669ddb260e729da2bb6259f4290f084759ab8e587b8ab2e17405ead",
+    "stdout_hash": "c05167bcf0d692ac607568ff3661f8a0d69a482b33fb591a877a245c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/llvm-volatile_02-2beae13.stdout
+++ b/tests/reference/llvm-volatile_02-2beae13.stdout
@@ -27,7 +27,7 @@ define i32 @main(i32 %0, i8** %1) {
   %10 = getelementptr %string_descriptor, %string_descriptor* %stringFormat_desc, i32 0, i32 1
   %11 = load i64, i64* %10, align 8
   %12 = trunc i64 %11 to i32
-  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
+  call void @_lfortran_printf(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @1, i32 0, i32 0), i8* %9, i32 %12, i32 1, i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0), i32 1)
   %13 = icmp eq i8* %4, null
   br i1 %13, label %free_done, label %free_nonnull
 
@@ -52,7 +52,7 @@ declare i8* @_lcompilers_string_format_fortran(i8*, i8*, i64, i8*, i64*, i32, i3
 
 declare i8* @_lfortran_get_default_allocator()
 
-declare void @_lfortran_printf(i8*, i8*, i32, i8*, i32)
+declare void @_lfortran_printf(i8*, i8*, i32, i32, i8*, i32)
 
 declare void @_lfortran_free_alloc(i8*, i8*)
 

--- a/tests/reference/run-print_12-a2450d8.json
+++ b/tests/reference/run-print_12-a2450d8.json
@@ -2,7 +2,7 @@
     "basename": "run-print_12-a2450d8",
     "cmd": "lfortran --no-color {infile}",
     "infile": "tests/../integration_tests/print_12.f90",
-    "infile_hash": "287e0dfc85f6da9fa31789b0458119a40f3b84c3d43c0a9365aeb3df",
+    "infile_hash": "2b7d1e743d6f3b31c4e3f311fd915cad3dbafbec6e2f351eaca44b94",
     "outfile": null,
     "outfile_hash": null,
     "stdout": "run-print_12-a2450d8.stdout",

--- a/tests/reference/wat-char4_backend_c-670ea10.json
+++ b/tests/reference/wat-char4_backend_c-670ea10.json
@@ -1,0 +1,13 @@
+{
+    "basename": "wat-char4_backend_c-670ea10",
+    "cmd": "lfortran --no-color --show-wat {infile}",
+    "infile": "tests/errors/char4_backend_c.f90",
+    "infile_hash": "3ece0042443ce9e62eb377b1cb078e9bcad1f840bdf28371e7053f99",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "wat-char4_backend_c-670ea10.stderr",
+    "stderr_hash": "7ecce351bcd4a82c551ecedd43fa0c916bf450f2a2454f113ec47ae7",
+    "returncode": 1
+}

--- a/tests/reference/wat-char4_backend_c-670ea10.stderr
+++ b/tests/reference/wat-char4_backend_c-670ea10.stderr
@@ -1,0 +1,5 @@
+code generation error: character(kind=4) is not supported by the WASM backend, only kind 1 is
+ --> tests/errors/char4_backend_c.f90:5:29
+  |
+5 | character(kind=4, len=3) :: wide
+  |                             ^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -3370,6 +3370,12 @@ filename = "errors/use_associated_redeclaration_1.f90"
 asr = true
 
 [[test]]
+filename = "errors/char4_backend_c.f90"
+c = true
+cpp = true
+wat = true
+
+[[test]]
 filename = "errors/continue_compilation_1.f90"
 semantics_only_cc = true
 


### PR DESCRIPTION
## Summary

Last of three towards [#12574](https://github.com/lfortran/lfortran/issues/12574). **Depends on [#12581](https://github.com/lfortran/lfortran/pull/12581) and [#12582](https://github.com/lfortran/lfortran/pull/12582)** — their commits are the parents here, so only `84713b8c` belongs to this PR.

The other PRs make kind 4 work on the LLVM backend. The C backend represents a character value as `char*` and the C++ backend as `std::string`, so both can only carry one byte per character. Neither checked the kind, so a kind 4 declaration was emitted as a byte string and `strlen`, `strcmp` and `%s` then read the four-byte code units as bytes. On `main`:

```fortran
character(kind=4, len=3) :: wide
wide = 4_"abc"
print *, len(wide)
```
```c
char * wide = NULL;
_lfortran_strcpy(&wide, "abc", 1);
printf("%d\n", strlen(wide));      /* a byte count, silently */
```

The WASM backend did reject it, but with `Strings of kind 1 only supported` — no kind, no location.

All three now report the same thing, with a location:

```
code generation error: character(kind=4) is not supported by the C backend, only kind 1 is
 --> tests/errors/char4_backend_c.f90:5:29
```

## Tests

`tests/errors/char4_backend_c.f90`, registered with `c`, `cpp` and `wat`, so all three diagnostics are covered by reference output.

## Verification

```
./run_tests.py --skip-run-with-dbg -t <each of the 117 `run =` tests>   # all pass
./run_tests.py --no-llvm --skip-run-with-dbg                           # TESTS PASSED
cd integration_tests && ./run_tests.py -b llvm -j4                     # pass
cd integration_tests && ./run_tests.py -b gfortran -j4                 # pass
```

`-b c` is not runnable in this sandbox: the in-tree build does not place `lfortran_intrinsics.h` where the generated C includes it from, so every C test fails to compile, plain kind-1 ones included. That is unrelated to this change and is covered by CI. The `c`/`cpp`/`wat` reference tests, which check the generated source rather than compiling it, do run and pass.

## One thing left behind

The C++ backend can still ICE on a kind 4 program before reaching this check, when the character variable sorts after another symbol in the program's symbol table — `character(kind=ucs4, …) :: wide` next to `integer, parameter :: ucs4` reproduces it. That ICE is present on `main` for kind-1 programs too and has a different cause, so it is not fixed here; the test above avoids the ordering that triggers it. Happy to open a separate issue for it.