### PR TITLE
fix: give character MAXVAL/MINVAL a reduction identity

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3289,6 +3289,7 @@ RUN(NAME empty_array_02 LABELS gfortran llvm)
 
 RUN(NAME empty_array_03 LABELS gfortran llvm)
 RUN(NAME empty_array_04 LABELS gfortran llvm)
+RUN(NAME empty_array_05 LABELS gfortran llvm)
 
 RUN(NAME kwargs_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME kwargs_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/empty_array_05.f90
+++ b/integration_tests/empty_array_05.f90
@@ -1,0 +1,65 @@
+program empty_array_05
+    implicit none
+
+    character(len=3) :: c(2), c0(0), r3
+    character(len=:), allocatable :: d(:), r
+    integer :: i
+
+    c(1) = 'abc'
+    c(2) = 'xyz'
+
+    ! a non empty character array reduces to one of its elements
+    if (maxval(c) /= 'xyz') error stop
+    if (minval(c) /= 'abc') error stop
+
+    ! MAXVAL of a zero sized character array is a string of char(0) and
+    ! MINVAL of one is a string of char(255)
+    r3 = maxval(c0)
+    do i = 1, 3
+        if (ichar(r3(i:i)) /= 0) error stop
+    end do
+    r3 = minval(c0)
+    do i = 1, 3
+        if (ichar(r3(i:i)) /= 255) error stop
+    end do
+
+    ! the same holds for a zero sized array constructor
+    r3 = maxval([character(len=3) :: ])
+    do i = 1, 3
+        if (ichar(r3(i:i)) /= 0) error stop
+    end do
+    r3 = minval([character(len=3) :: ])
+    do i = 1, 3
+        if (ichar(r3(i:i)) /= 255) error stop
+    end do
+
+    ! and for a deferred length array allocated with size zero
+    allocate(character(len=4) :: d(0))
+    r = maxval(d)
+    if (len(r) /= 4) error stop
+    do i = 1, 4
+        if (ichar(r(i:i)) /= 0) error stop
+    end do
+    r = minval(d)
+    if (len(r) /= 4) error stop
+    do i = 1, 4
+        if (ichar(r(i:i)) /= 255) error stop
+    end do
+    deallocate(d)
+
+    ! the elements of a deferred length array may have zero length themselves
+    allocate(character(len=0) :: d(5))
+    if (len(maxval(d)) /= 0) error stop
+    if (len(minval(d)) /= 0) error stop
+    deallocate(d)
+
+    ! a deferred length array with elements of non zero length
+    allocate(character(len=3) :: d(2))
+    d(1) = 'abc'
+    d(2) = 'xyz'
+    if (maxval(d) /= 'xyz') error stop
+    if (minval(d) /= 'abc') error stop
+    deallocate(d)
+
+    print *, "Pass"
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2830,6 +2830,20 @@ static inline ASR::expr_t* get_constant_one_with_given_type(Allocator& al, ASR::
 
 void mark_modules_as_external(const LCompilers::ASR::TranslationUnit_t &u);
 
+// Returns a string as long as `string_type` with every character equal to
+// `fill`, or nullptr when that length is not known at compile time.
+static inline ASR::expr_t* get_string_filled_with_char(Allocator& al,
+        ASR::ttype_t* string_type, unsigned char fill) {
+    ASR::String_t* str_type = ASR::down_cast<ASR::String_t>(string_type);
+    int64_t len = -1;
+    if (!str_type->m_len || !ASRUtils::extract_value(str_type->m_len, len) || len < 0) {
+        return nullptr;
+    }
+    std::string value((size_t) len, (char) fill);
+    return ASRUtils::EXPR(ASR::make_StringConstant_t(al, string_type->base.loc,
+        s2c(al, value), string_type));
+}
+
 static inline ASR::expr_t* get_minimum_value_with_given_type(Allocator& al, ASR::ttype_t* asr_type) {
     asr_type = ASRUtils::type_get_past_array(asr_type);
     int kind = ASRUtils::extract_kind_from_ttype_t(asr_type);
@@ -2855,6 +2869,17 @@ static inline ASR::expr_t* get_minimum_value_with_given_type(Allocator& al, ASR:
                     throw LCompilersException("get_minimum_value_with_given_type: Unsupported real kind " + std::to_string(kind));
             }
             return ASRUtils::EXPR(ASR::make_RealConstant_t(al, asr_type->base.loc, val, asr_type));
+        }
+        case ASR::ttypeType::String: {
+            // The smallest character value is char(0), the first character of
+            // the collating sequence (Fortran 2018, 16.9.126 requires MAXVAL of
+            // a zero sized character array to be a string of char(0))
+            ASR::expr_t* min_value = get_string_filled_with_char(al, asr_type, 0);
+            if (!min_value) {
+                throw LCompilersException("get_minimum_value_with_given_type: "
+                    "string length is not known at compile time");
+            }
+            return min_value;
         }
         default: {
             throw LCompilersException("get_minimum_value_with_given_type: Not implemented " + std::to_string(asr_type->type));
@@ -2888,6 +2913,23 @@ static inline ASR::expr_t* get_maximum_value_with_given_type(Allocator& al, ASR:
                     throw LCompilersException("get_maximum_value_with_given_type: Unsupported real kind " + std::to_string(kind));
             }
             return ASRUtils::EXPR(ASR::make_RealConstant_t(al, asr_type->base.loc, val, asr_type));
+        }
+        case ASR::ttypeType::String: {
+            // The largest character value is char(n - 1), the last character of
+            // the collating sequence, where n is the number of characters
+            // representable with the given kind (Fortran 2018, 16.9.135
+            // requires MINVAL of a zero sized character array to be a string
+            // of that character)
+            if (kind != 1) {
+                throw LCompilersException("get_maximum_value_with_given_type: "
+                    "Unsupported character kind " + std::to_string(kind));
+            }
+            ASR::expr_t* max_value = get_string_filled_with_char(al, asr_type, 0xff);
+            if (!max_value) {
+                throw LCompilersException("get_maximum_value_with_given_type: "
+                    "string length is not known at compile time");
+            }
+            return max_value;
         }
         default: {
             throw LCompilersException("get_maximum_value_with_given_type: Not implemented " + std::to_string(asr_type->type));

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -14473,7 +14473,9 @@ public:
             }
             case (ASR::cmpopType::Gt) : {
                 if( is_single_char ) {
-                    tmp = builder->CreateICmpSGT(left, right);
+                    // characters are ordered by their position in the
+                    // collating sequence, so compare them as unsigned values
+                    tmp = builder->CreateICmpUGT(left, right);
                 } else {
                     tmp = builder->CreateICmpSGT(tmp, llvm::ConstantInt::get(context, llvm::APInt(32,0)));
                 }
@@ -14481,7 +14483,9 @@ public:
             }
             case (ASR::cmpopType::GtE) : {
                 if( is_single_char ) {
-                    tmp = builder->CreateICmpSGE(left, right);
+                    // characters are ordered by their position in the
+                    // collating sequence, so compare them as unsigned values
+                    tmp = builder->CreateICmpUGE(left, right);
                 } else {
                     tmp = builder->CreateICmpSGE(tmp, llvm::ConstantInt::get(context, llvm::APInt(32,0)));
                 }
@@ -14489,7 +14493,9 @@ public:
             }
             case (ASR::cmpopType::Lt) : {
                 if( is_single_char ) {
-                    tmp = builder->CreateICmpSLT(left, right);
+                    // characters are ordered by their position in the
+                    // collating sequence, so compare them as unsigned values
+                    tmp = builder->CreateICmpULT(left, right);
                 } else {
                     tmp = builder->CreateICmpSLT(tmp, llvm::ConstantInt::get(context, llvm::APInt(32,0)));
                 }
@@ -14497,7 +14503,9 @@ public:
             }
             case (ASR::cmpopType::LtE) : {
                 if( is_single_char ) {
-                    tmp = builder->CreateICmpSLE(left, right);
+                    // characters are ordered by their position in the
+                    // collating sequence, so compare them as unsigned values
+                    tmp = builder->CreateICmpULE(left, right);
                 } else {
                     tmp = builder->CreateICmpSLE(tmp, llvm::ConstantInt::get(context, llvm::APInt(32,0)));
                 }

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -835,6 +835,13 @@ static inline ASR::asr_t* create_ArrIntrinsic(
         ASR::ttype_t* type = ASRUtils::type_get_past_allocatable(
         ASRUtils::type_get_past_pointer(array_type));
         return_type = ASRUtils::duplicate_type_without_dims(al, type, loc);
+        if (ASR::is_a<ASR::String_t>(*return_type) &&
+            ASR::down_cast<ASR::String_t>(return_type)->m_len_kind ==
+                ASR::string_length_kindType::DeferredLength) {
+            // A deferred length string is only representable as an allocatable;
+            // the reduction allocates it to `len(array)`
+            return_type = ASRUtils::TYPE(ASR::make_Allocatable_t(al, loc, return_type));
+        }
     } else if( overload_id == id_array_dim || overload_id == id_array_dim_mask ) {
         Vec<ASR::dimension_t> dims;
         size_t n_dims = ASRUtils::extract_n_dims_from_ttype(array_type);
@@ -869,6 +876,61 @@ static inline ASR::asr_t* create_ArrIntrinsic(
         arr_intrinsic_args.p, arr_intrinsic_args.n, overload_id, return_type, value);
 }
 
+// A `DeferredLength` string is only a valid declaration for an allocatable or a
+// pointer variable. The `array` dummy argument of a generated reduction is
+// neither, so it is declared with an assumed length instead.
+static inline ASR::ttype_t* assumed_length_if_deferred(Allocator& al, ASR::ttype_t* type) {
+    ASR::ttype_t* element_type = ASRUtils::extract_type(type);
+    if (!ASR::is_a<ASR::String_t>(*element_type)) {
+        return type;
+    }
+    ASR::String_t* str_type = ASR::down_cast<ASR::String_t>(element_type);
+    if (str_type->m_len_kind != ASR::string_length_kindType::DeferredLength) {
+        return type;
+    }
+    ASRBuilder b(al, type->base.loc);
+    ASR::ttype_t* assumed_length_type = b.String(nullptr,
+        ASR::string_length_kindType::AssumedLength, str_type->m_physical_type,
+        str_type->m_kind);
+    if (!ASRUtils::is_array(type)) {
+        return assumed_length_type;
+    }
+    ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(
+        ASRUtils::type_get_past_allocatable_pointer(type));
+    return ASRUtils::make_Array_t_util(al, type->base.loc, assumed_length_type,
+        array_type->m_dims, array_type->n_dims, ASR::abiType::Source, true,
+        array_type->m_physical_type, true);
+}
+
+// Seeds a character reduction with its identity value: a string as long as the
+// elements of `array` with every character equal to `fill`. Every element of
+// `array` compares greater than a string of char(0) and smaller than a string
+// of char(255), so seeding this way also gives an empty `array` (a zero sized
+// array, or one fully masked out) the result the standard requires
+// (Fortran 2018, 16.9.126 and 16.9.135).
+static inline void seed_string_reduction(Allocator& al, const Location& loc,
+    SymbolTable* fn_scope, Vec<ASR::stmt_t*>& fn_body, ASRBuilder& b,
+    ASR::expr_t* return_var, ASR::expr_t* array, unsigned char fill) {
+    ASR::ttype_t* return_type = ASRUtils::expr_type(return_var);
+    ASR::expr_t* identity = ASRUtils::get_string_filled_with_char(al,
+        ASRUtils::extract_type(return_type), fill);
+    if (identity) {
+        fn_body.push_back(al, b.Assignment(return_var, identity));
+        return;
+    }
+    // The length of the elements of `array` is only known at runtime
+    if (ASRUtils::is_allocatable(return_type)) {
+        fn_body.push_back(al, b.Allocate(return_var, nullptr, 0, b.StringLen(array)));
+    }
+    ASR::expr_t* idx = b.Variable(fn_scope,
+        fn_scope->get_unique_name("_lcompilers_string_seed_idx", false),
+        int32, ASR::intentType::Local);
+    fn_body.push_back(al, b.DoLoop(idx, b.i32(1), b.StringLen(array), {
+        b.Assignment(b.StringSection(return_var, idx, idx),
+            b.StringConstant(std::string(1, (char) fill), character(1)))
+    }));
+}
+
 static inline void generate_body_for_array_input(Allocator& al, const Location& loc,
     ASR::expr_t* array, ASR::expr_t* return_var, SymbolTable* fn_scope,
     Vec<ASR::stmt_t*>& fn_body, get_initial_value_func get_initial_value, elemental_operation_func elemental_operation,
@@ -882,18 +944,9 @@ static inline void generate_body_for_array_input(Allocator& al, const Location& 
             ASR::ttype_t* array_type = ASRUtils::expr_type(array);
             ASR::ttype_t* element_type = ASRUtils::duplicate_type_without_dims(al, array_type, loc);
             if (ASR::is_a<ASR::String_t>(*element_type)) {
-                Vec<ASR::expr_t*> first_idx;
-                first_idx.reserve(al, 1);
-                ASR::expr_t* one = ASRUtils::EXPR(
-                    ASR::make_IntegerConstant_t(
-                        al, loc, 1, ASRUtils::TYPE(ASR::make_Integer_t(al, loc, index_kind))));
-                first_idx.push_back(al, one);
-                ASR::expr_t* first_elem = PassUtils::create_array_ref(array, first_idx, al);
-                ASR::expr_t* tmp =
-                    builder.Variable(fn_scope, "_lcompilers_string_tmp", element_type,
-                        ASR::intentType::Local, nullptr, ASR::abiType::Source, false);
-                fn_body.push_back(al, builder.Assignment(tmp, first_elem));
-                fn_body.push_back(al, builder.Assignment(return_var, tmp));
+                seed_string_reduction(al, loc, fn_scope, fn_body, builder,
+                    return_var, array,
+                    elemental_operation == &ASRBuilder::Min ? 0xff : 0);
             } else {
                 ASR::expr_t* initial_val = get_initial_value(al, element_type);
                 ASR::stmt_t* return_var_init = builder.Assignment(return_var, initial_val);
@@ -1222,6 +1275,19 @@ static inline ASR::expr_t* instantiate_ArrIntrinsic(Allocator &al,
                             "_" + std::to_string(rank) +
                             "_" + std::to_string(overload_id) +
                             "_idx" + std::to_string(index_kind);
+    ASR::ttype_t* arg_element_type = ASRUtils::extract_type(arg_type);
+    if (ASR::is_a<ASR::String_t>(*arg_element_type)) {
+        // Two character arrays whose elements differ only in length compare
+        // equal with `types_equal`, so make the length part of the name of the
+        // generated function to avoid reusing one written for another length
+        ASR::String_t* str_type = ASR::down_cast<ASR::String_t>(arg_element_type);
+        int64_t str_len = -1;
+        if (str_type->m_len && ASRUtils::extract_value(str_type->m_len, str_len)) {
+            new_name += "_len" + std::to_string(str_len);
+        } else {
+            new_name += "_lenstar";
+        }
+    }
     // Check if Function is already defined.
     {
         std::string new_func_name = new_name;
@@ -1254,7 +1320,8 @@ static inline ASR::expr_t* instantiate_ArrIntrinsic(Allocator &al,
     Vec<ASR::expr_t*> args;
     args.reserve(al, 1);
 
-    ASR::ttype_t* array_type = ASRUtils::duplicate_type_with_empty_dims(al, arg_type);
+    ASR::ttype_t* array_type = assumed_length_if_deferred(al,
+        ASRUtils::duplicate_type_with_empty_dims(al, arg_type));
     fill_func_arg("array", array_type)
     if( overload_id == id_array_dim || overload_id == id_array_dim_mask ) {
         ASR::ttype_t* dim_type = ASRUtils::TYPE(ASR::make_Integer_t(
@@ -1307,6 +1374,14 @@ static inline ASR::expr_t* instantiate_ArrIntrinsic(Allocator &al,
         ASR::expr_t *result = declare("result", return_type_, Out);
         args.push_back(al, result);
     } else if( result_dims == 0 ) {
+        ASR::ttype_t* result_type = ASRUtils::extract_type(return_type);
+        if (ASR::is_a<ASR::String_t>(*result_type) && !ASRUtils::is_allocatable(return_type)
+            && ASR::down_cast<ASR::String_t>(result_type)->m_len_kind ==
+                ASR::string_length_kindType::DeferredLength) {
+            // A deferred length result must be allocatable; it is allocated to
+            // `len(array)` when the reduction is seeded
+            return_type = b.allocatable(result_type);
+        }
         return_var = declare("result", return_type, ReturnVar);
     }
 

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5060,7 +5060,9 @@ int str_compare(char *s1, int64_t s1_len, char *s2, int64_t s2_len){
     int i ;
     for (i = 0; i < lim; i++) {
         if (s1[i] != s2[i]) {
-            res = s1[i] - s2[i];
+            /* Characters are ordered by their position in the collating
+               sequence, so compare them as unsigned values */
+            res = (unsigned char)s1[i] - (unsigned char)s2[i];
             break;
         }
     }


### PR DESCRIPTION
## Summary

Fixes #12344.

`MAXVAL`/`MINVAL` of a character array had no identity value, so the generated reduction seeded its result from element 1 of the array. That reads out of bounds for a zero sized array, and for a deferred length array it declares a `DeferredLength` string variable that is neither allocatable nor a pointer, which ASR verification rejects. Before that seed was introduced the same gap surfaced as the `get_minimum_value_with_given_type: Not implemented 4` ICE reported in the issue — it is still reachable on `main` through `maxval(character_array, dim=1)`.

The reduction is now seeded with the identity the standard defines: a string as long as the elements of the array with every character equal to `char(0)` for `MAXVAL` and `char(255)` for `MINVAL` (Fortran 2018, 16.9.126 and 16.9.135). Every element compares greater than the first and smaller than the second, so a non empty array reduces exactly as before, while an empty one (zero sized, or fully masked out) yields the identity itself. When the element length is only known at runtime the result is allocated to `len(array)` and filled in a loop.

The MRE from the issue now agrees with GFortran:

```fortran
program mre
implicit none
character(len=:), allocatable :: strs(:)
allocate(character(len=0) :: strs(5))
if (len(maxval(strs)) /= 0) error stop
end program mre
```

The `demo_maxval.f90` attached to the issue also compiles and runs, and its `is maxval of strings all null characters?  T T T T T` line matches GFortran.

## Scope

The fix is in AST→ASR/ASR (the intrinsic array function registry and the ASR utilities); the backends only lower what they are given. Two supporting fixes it needs:

- `str_compare` in the runtime, and the single character comparison in the LLVM backend, ordered characters as **signed** values, so everything from `char(128)` up compared below `char(0)`. Characters are ordered by their position in the collating sequence, so they are now compared as unsigned. Without this the `MINVAL` identity of `char(255)` would never be beaten by a real element. Compile time folding already compared unsigned, so this also removes an inconsistency between constant folding and runtime.
- `types_equal` compares only the *kind* of two string types, so a reduction generated for one element length was silently reused for another (`maxval` on a `character(len=3)` array and then on a `character(len=:), allocatable` one returned the first helper). The element length is now part of the generated function's name.

Not addressed here, and unchanged by this PR: `maxval`/`minval` of a character array with `dim=` or `mask=` still fail to compile — the `dim`/`mask` body generators have no string handling at all, and `verify_args` rejects character input for these intrinsics. That is a separate gap; no working program regresses.

## Verification

New integration test `integration_tests/empty_array_05.f90` (labels `gfortran llvm`), the character counterpart to the existing `empty_array_03.f90`. It covers a non empty character array, a zero sized one, a zero sized array constructor, a deferred length array allocated with size zero, deferred length elements of zero length, and a deferred length array with non zero length elements.

Test fails on `main` and passes on this branch:

```
$ git stash && cmake --build build -j && ./build/src/bin/lfortran integration_tests/empty_array_05.f90
LCompilersException: get_minimum_value_with_given_type: Not implemented 4

$ git stash pop && cmake --build build -j && ./build/src/bin/lfortran integration_tests/empty_array_05.f90 -o t && ./t
 Pass
```

Suites run locally (Ubuntu, LLVM 18):

```
./run_tests.py --no-llvm                            TESTS PASSED
cd integration_tests && ./run_tests.py -b llvm      100% tests passed, 0 failed out of 3892
cd integration_tests && ./run_tests.py -b llvm -f -nf16   100% tests passed, 0 failed out of 3892
cd integration_tests && ./run_tests.py -b gfortran  100% tests passed, 0 failed out of 3951
```

The `llvm` reference outputs could not be checked locally — they are pinned to CI's LLVM 11 and LLVM 18 emits opaque pointers (`ptr` vs `i8**`) throughout. The `c`/`cpp` integration backends need `lfortran_intrinsics.h` on the include path and Kokkos, which this environment lacks. Both are covered by the exhaustive CI run requested on this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSLVVoJokrwXCo5XWGUWrR)_