### PR TITLE
fix: use the longest argument's length for character max/min

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -561,6 +561,7 @@ RUN(NAME max_03 LABELS  llvm llvm_wasm llvm_wasm_emcc) #gfortran does not suppor
 RUN(NAME min_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)
 RUN(NAME min_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)
 RUN(NAME minmax_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm c fortran)
+RUN(NAME minmax_02 LABELS gfortran llvm)
 RUN(NAME arithmetic_if_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran) # arithmetic tests use goto
 RUN(NAME arithmetic_if_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)
 RUN(NAME arithmetic_if_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc c fortran)

--- a/integration_tests/minmax_02.f90
+++ b/integration_tests/minmax_02.f90
@@ -1,0 +1,70 @@
+program minmax_02
+! The result of MAX/MIN with character arguments has the length of the longest
+! argument, and a shorter selected argument is blank-padded on the right.
+implicit none
+character(len=1) :: a(2)
+character(len=2) :: b(2), r(2)
+character(len=1) :: s1
+character(len=2) :: s2
+character(len=6) :: s3
+integer :: n
+
+! Arrays: max(['A','Z'], ['BB','Y ']) == ['BB', 'Z ']
+a(1) = 'A'
+a(2) = 'Z'
+b(1) = 'BB'
+b(2) = 'Y '
+r = max(a, b)
+if (r(1) /= 'BB') error stop
+if (r(2) /= 'Z ') error stop
+if ('[' // r(1) // ']' /= '[BB]') error stop
+if ('[' // r(2) // ']' /= '[Z ]') error stop
+r = min(a, b)
+if ('[' // r(1) // ']' /= '[A ]') error stop
+if ('[' // r(2) // ']' /= '[Y ]') error stop
+
+! Scalars, shorter argument first
+s1 = 'Z'
+s2 = 'BB'
+if (len(max(s1, s2)) /= 2) error stop
+if ('[' // max(s1, s2) // ']' /= '[Z ]') error stop
+if (len(min(s1, s2)) /= 2) error stop
+if ('[' // min(s1, s2) // ']' /= '[BB]') error stop
+
+! Scalars, longer argument first
+if (len(max(s2, s1)) /= 2) error stop
+if ('[' // max(s2, s1) // ']' /= '[Z ]') error stop
+if ('[' // min(s2, s1) // ']' /= '[BB]') error stop
+
+! More than two arguments
+s3 = 'cc'
+if (len(max(s1, s2, s3)) /= 6) error stop
+if ('[' // max(s1, s2, s3) // ']' /= '[cc    ]') error stop
+if ('[' // min(s1, s2, s3) // ']' /= '[BB    ]') error stop
+
+! Compile time
+if (len(max('Z', 'BB')) /= 2) error stop
+if ('[' // max('Z', 'BB') // ']' /= '[Z ]') error stop
+if (len(min('Z', 'BB')) /= 2) error stop
+if ('[' // min('Z', 'BB') // ']' /= '[BB]') error stop
+if ('[' // max('a', 'bbbb', 'cc') // ']' /= '[cc  ]') error stop
+if ('[' // min('a', 'bbbb', 'cc') // ']' /= '[a   ]') error stop
+
+! Runtime length
+n = 4
+call check_runtime_length(n)
+
+contains
+
+    subroutine check_runtime_length(m)
+    integer, intent(in) :: m
+    character(len=3) :: c3
+    character(len=m) :: v
+    c3 = 'AAA'
+    v = 'ZZ'
+    if (len(max(c3, v)) /= 4) error stop
+    if ('[' // max(c3, v) // ']' /= '[ZZ  ]') error stop
+    if ('[' // min(c3, v) // ']' /= '[AAA ]') error stop
+    end subroutine check_runtime_length
+
+end program minmax_02

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -7668,6 +7668,77 @@ static inline ASR::asr_t* create_SetRemove(Allocator& al, const Location& loc,
 
 } // namespace SetRemove
 
+/*
+    The standard requires the result of MAX/MIN with character arguments to
+    have the length of the longest argument, with a shorter selected argument
+    blank-padded on the right. The helpers below build that length, and pad the
+    compile-time argument values so they compare by the collating sequence.
+*/
+
+static inline std::vector<std::string> blank_pad_string_args(Vec<ASR::expr_t*>& args) {
+    std::vector<std::string> values;
+    size_t max_len = 0;
+    for (size_t i = 0; i < args.size(); i++) {
+        values.push_back(ASR::down_cast<ASR::StringConstant_t>(args[i])->m_s);
+        max_len = std::max(max_len, values.back().size());
+    }
+    for (size_t i = 0; i < values.size(); i++) {
+        values[i].resize(max_len, ' ');
+    }
+    return values;
+}
+
+static inline ASR::expr_t* get_string_length_expr(Allocator& al,
+    const Location& loc, ASR::expr_t* arg) {
+    ASR::String_t* str_type = ASRUtils::get_string_type(ASRUtils::expr_type(arg));
+    if (str_type->m_len && str_type->m_len_kind == ASR::string_length_kindType::ExpressionLength) {
+        return str_type->m_len;
+    }
+    return ASRUtils::EXPR(ASR::make_StringLen_t(al, loc, arg,
+        ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4)), nullptr));
+}
+
+static inline ASR::expr_t* longest_string_length(Allocator& al,
+    const Location& loc, ASR::expr_t** args, size_t n_args) {
+    ASR::expr_t* max_len = get_string_length_expr(al, loc, args[0]);
+    for (size_t i = 1; i < n_args; i++) {
+        ASR::expr_t* len = get_string_length_expr(al, loc, args[i]);
+        int64_t max_len_value, len_value;
+        if (ASRUtils::is_value_constant(max_len, max_len_value) &&
+                ASRUtils::is_value_constant(len, len_value)) {
+            if (len_value > max_len_value) {
+                max_len = len;
+            }
+        } else {
+            ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
+            ASR::ttype_t* logical_type = ASRUtils::TYPE(ASR::make_Logical_t(al, loc, 4));
+            ASR::expr_t* test = ASRUtils::EXPR(ASR::make_IntegerCompare_t(al, loc,
+                len, ASR::cmpopType::Gt, max_len, logical_type, nullptr));
+            max_len = ASRUtils::EXPR(ASR::make_IfExp_t(al, loc, test, len, max_len,
+                int32_type, nullptr));
+        }
+    }
+    return max_len;
+}
+
+/*
+    Returns `type` with its character length replaced by the length of the
+    longest argument. The array shape (if any) of `type` is preserved.
+*/
+static inline ASR::ttype_t* set_longest_string_length(Allocator& al,
+    const Location& loc, ASR::ttype_t* type, ASR::expr_t** args, size_t n_args) {
+    ASR::String_t* str_type = ASRUtils::get_string_type(type);
+    ASR::ttype_t* new_str_type = ASRUtils::TYPE(ASR::make_String_t(al, loc,
+        str_type->m_kind, longest_string_length(al, loc, args, n_args),
+        ASR::string_length_kindType::ExpressionLength, str_type->m_physical_type));
+    if (ASR::is_a<ASR::Array_t>(*type)) {
+        ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(type);
+        return ASRUtils::TYPE(ASR::make_Array_t(al, loc, new_str_type,
+            array_type->m_dims, array_type->n_dims, array_type->m_physical_type));
+    }
+    return new_str_type;
+}
+
 namespace Max {
 
     static inline void verify_args(const ASR::IntrinsicElementalFunction_t& x, diag::Diagnostics& diagnostics) {
@@ -7706,16 +7777,15 @@ namespace Max {
             }
             return ASR::down_cast<ASR::expr_t>(ASR::make_IntegerConstant_t(al, loc, max_val, arg_type));
         } else if (ASR::is_a<ASR::String_t>(*arg_type)) {
-            char* max_val = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-            arg_type = expr_type(args[0]);
-            for (size_t i = 1; i < args.size(); i++) {
-                char* val = ASR::down_cast<ASR::StringConstant_t>(args[i])->m_s;
-                if (strcmp(val, max_val) > 0) {
-                    max_val = val;
-                    arg_type = expr_type(args[i]);
+            std::vector<std::string> values = blank_pad_string_args(args);
+            std::string max_val = values[0];
+            for (size_t i = 1; i < values.size(); i++) {
+                if (values[i] > max_val) {
+                    max_val = values[i];
                 }
             }
-            return ASR::down_cast<ASR::expr_t>(ASR::make_StringConstant_t(al, loc, max_val, arg_type));
+            return ASR::down_cast<ASR::expr_t>(ASR::make_StringConstant_t(al, loc,
+                s2c(al, max_val), arg_type));
         } else {
             return nullptr;
         }
@@ -7776,15 +7846,21 @@ namespace Max {
             }
             arg_values.push_back(al, arg_value);
         }
+        // For character arguments the result has the length of the longest
+        // argument, and a shorter selected argument is blank-padded to it.
+        ASR::ttype_t *return_type = ASRUtils::expr_type(args[0]);
+        if (ASRUtils::is_character(*return_type)) {
+            return_type = set_longest_string_length(al, loc, return_type, args.p, args.size());
+        }
         if (is_compile_time) {
-            ASR::expr_t *value = eval_Max(al, loc, expr_type(args[0]), arg_values, diag);
+            ASR::expr_t *value = eval_Max(al, loc, return_type, arg_values, diag);
             return ASRUtils::make_IntrinsicElementalFunction_t_util(al, loc,
                 static_cast<int64_t>(IntrinsicElementalFunctions::Max),
-                args.p, args.n, 0, ASRUtils::expr_type(args[0]), value);
+                args.p, args.n, 0, return_type, value);
         } else {
             return ASRUtils::make_IntrinsicElementalFunction_t_util(al, loc,
                 static_cast<int64_t>(IntrinsicElementalFunctions::Max),
-                args.p, args.n, 0, ASRUtils::expr_type(args[0]), nullptr);
+                args.p, args.n, 0, return_type, nullptr);
         }
     }
 
@@ -7820,8 +7896,10 @@ namespace Max {
                 fill_func_arg("x" + std::to_string(i), TYPE(ASR::make_String_t(al, loc, kind,
                     nullptr, ASR::AssumedLength, ASR::DescriptorString)));
             }
+            // The result has the length of the longest argument, so that a
+            // shorter selected argument gets blank-padded on assignment.
             function_return_type = TYPE(ASR::make_String_t(al, loc, kind,
-                EXPR(ASR::make_StringLen_t(al, loc, args[0], int32, nullptr)),
+                longest_string_length(al, loc, args.p, args.size()),
                 ASR::ExpressionLength, ASR::DescriptorString));
         } else if (ASR::is_a<ASR::Real_t>(*arg_types[0])) {
             for (size_t i = 0; i < new_args.size(); i++) {
@@ -7886,14 +7964,15 @@ namespace Min {
             }
             return ASR::down_cast<ASR::expr_t>(ASR::make_IntegerConstant_t(al, loc, min_val, arg_type));
         } else if (ASR::is_a<ASR::String_t>(*arg_type)) {
-            char* min_val = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-            for (size_t i = 1; i < args.size(); i++) {
-                char* val = ASR::down_cast<ASR::StringConstant_t>(args[i])->m_s;
-                if (strcmp(val, min_val) < 0) {
-                    min_val = val;
+            std::vector<std::string> values = blank_pad_string_args(args);
+            std::string min_val = values[0];
+            for (size_t i = 1; i < values.size(); i++) {
+                if (values[i] < min_val) {
+                    min_val = values[i];
                 }
             }
-            return ASR::down_cast<ASR::expr_t>(ASR::make_StringConstant_t(al, loc, min_val, arg_type));
+            return ASR::down_cast<ASR::expr_t>(ASR::make_StringConstant_t(al, loc,
+                s2c(al, min_val), arg_type));
         } else {
             return nullptr;
         }
@@ -7955,15 +8034,21 @@ namespace Min {
             }
             arg_values.push_back(al, arg_value);
         }
+        // For character arguments the result has the length of the longest
+        // argument, and a shorter selected argument is blank-padded to it.
+        ASR::ttype_t *return_type = ASRUtils::expr_type(args[0]);
+        if (ASRUtils::is_character(*return_type)) {
+            return_type = set_longest_string_length(al, loc, return_type, args.p, args.size());
+        }
         if (is_compile_time) {
-            ASR::expr_t *value = eval_Min(al, loc, expr_type(args[0]), arg_values, diag);
+            ASR::expr_t *value = eval_Min(al, loc, return_type, arg_values, diag);
             return ASRUtils::make_IntrinsicElementalFunction_t_util(al, loc,
                 static_cast<int64_t>(IntrinsicElementalFunctions::Min),
-                args.p, args.n, 0, ASRUtils::expr_type(args[0]), value);
+                args.p, args.n, 0, return_type, value);
         } else {
             return ASRUtils::make_IntrinsicElementalFunction_t_util(al, loc,
                 static_cast<int64_t>(IntrinsicElementalFunctions::Min),
-                args.p, args.n, 0, ASRUtils::expr_type(args[0]), nullptr);
+                args.p, args.n, 0, return_type, nullptr);
         }
     }
 
@@ -7998,8 +8083,10 @@ namespace Min {
                 fill_func_arg("x" + std::to_string(i), TYPE(ASR::make_String_t(al, loc, kind,
                     nullptr, ASR::AssumedLength, ASR::DescriptorString)));
             }
+            // The result has the length of the longest argument, so that a
+            // shorter selected argument gets blank-padded on assignment.
             return_type = TYPE(ASR::make_String_t(al, loc, kind,
-                EXPR(ASR::make_StringLen_t(al, loc, args[0], int32, nullptr)),
+                longest_string_length(al, loc, args.p, args.size()),
                 ASR::string_length_kindType::ExpressionLength,
                 ASR::string_physical_typeType::DescriptorString));
         } else if (ASR::is_a<ASR::Real_t>(*arg_types[0])) {
@@ -8020,8 +8107,12 @@ namespace Min {
             }, {}));
         }
         if (ASR::is_a<ASR::String_t>(*arg_types[0])) {
+            Vec<ASR::expr_t*> caller_args; caller_args.reserve(al, new_args.size());
+            for (size_t i = 0; i < new_args.size(); i++) {
+                caller_args.push_back(al, new_args[i].m_value);
+            }
             return_type = TYPE(ASR::make_String_t(al, loc, kind,
-                EXPR(ASR::make_StringLen_t(al, loc, new_args[0].m_value, int32, nullptr)),
+                longest_string_length(al, loc, caller_args.p, caller_args.size()),
                 ASR::string_length_kindType::ExpressionLength,
                 ASR::string_physical_typeType::DescriptorString));
         }


### PR DESCRIPTION
## Summary

Fixes #12354.

The standard (16.9.135 for `MAX`, 16.9.141 for `MIN`) requires the result of `MAX`/`MIN` with character arguments to have the length of the **longest** argument, and a shorter selected argument to be blank-padded on the right up to that length:

> For arguments of character type, the length of the result is the length of the longest argument. […] If the selected argument is shorter than the longest argument, the result is extended with blanks on the right to the length of the longest argument.
>
> `MAX(['A', 'Z'], ['BB', 'Y '])` has the value `['BB', 'Z ']`.

LFortran used the length of the **first** argument instead, so a longer selected argument was truncated.

MRE:

```fortran
program mre_max_char
implicit none
character(len=1) :: a(2)
character(len=2) :: b(2), r(2)
a(1) = 'A'
a(2) = 'Z'
b(1) = 'BB'
b(2) = 'Y '
r = max(a, b)
print *, "["//r(1)//"]["//r(2)//"]"
end program mre_max_char
```

| | output |
| --- | --- |
| gfortran | `[BB][Z ]` |
| lfortran (before) | `[B ][Z ]` |
| lfortran (after) | `[BB][Z ]` |

## Scope

`src/libasr/pass/intrinsic_functions.h`, `MAX` and `MIN`:

- **Semantics (`create_Max` / `create_Min`)** — the result type now carries the length of the longest argument instead of `expr_type(args[0])`. Constant lengths fold to the larger constant; otherwise an `IfExp` over the two length expressions is built. The array shape of the first argument is preserved.
- **`instantiate_Max` / `instantiate_Min`** — the helper function's result variable is declared with the longest dummy's length, so the existing `result = x(i)` assignment blank-pads a shorter selected argument instead of truncating a longer one. `instantiate_Min`'s call-site return type is computed the same way.
- **Compile-time folding (`eval_Max` / `eval_Min`)** — arguments are blank-padded to the longest length before being compared and returned, which is both what the collating sequence requires and what makes the folded constant carry the right length. This replaces the previous `strcmp` on unpadded values.

The fix is entirely in AST→ASR semantics and the instantiated ASR helper; no backend was touched.

## Verification

New integration test `integration_tests/minmax_02.f90` (labels `gfortran llvm`), covering arrays, scalars with the shorter and the longer argument first, more than two arguments, compile-time folding, and a runtime-length (`character(len=m)`) argument.

- Test fails on `main` (`ERROR STOP`, exit 1) and passes on this branch — verified by stashing the source change and rebuilding.
- `gfortran` compiles and runs the new test successfully, so it does not rely on LFortran-specific behavior.
- Integration suite: `cd integration_tests && ./run_tests.py -j4` → **100% tests passed, 0 tests failed out of 3892**.
- Reference suite: `./run_tests.py -u` produces **no** AST/ASR reference changes, and no reference diff touches the `max0`/`min0` helpers. (The local box has LLVM 18 while CI pins LLVM 11, so `llvm-*` references differ purely by opaque-pointer/register-numbering IR text; those were reverted and not committed.)

## Rationale

Per `AGENTS.md`, type and length decisions belong in AST→ASR rather than in codegen, so the result length is computed where the intrinsic node is built and simply lowered from there. `MIN` shares the same code path and the same defect as `MAX` — the standard's wording for both is identical — so both are fixed together rather than leaving `MIN` knowingly broken.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FGhZgYpF9RSBgd8UsXhK4i)_