### PR TITLE
test: cover the intrinsic type member error messages

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -991,6 +991,24 @@ program continue_compilation_1
         s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
     end subroutine
 
+    subroutine intrinsic_type_member_not_found()
+        implicit none
+        type :: itm_t
+            complex :: c
+            character(len=5) :: s
+            integer :: i
+        end type itm_t
+        type :: itm_outer_t
+            type(itm_t) :: in
+        end type itm_outer_t
+        type(itm_t) :: d
+        type(itm_outer_t) :: o
+        print *, d%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+        print *, d%s%bogus  ! {Error} Character variable 's' only has %len and %kind members, not 'bogus'
+        print *, d%i%bogus  ! {Error} Variable 'i' doesn't have any member named, 'bogus'.
+        print *, o%in%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+    end subroutine
+
     ! Keep the unsupported character kind declarations last: a rejected
     ! declaration makes the symbol table visitor skip the program units that
     ! follow it, which would hide the errors expected above.

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "225aedafcfbdd579cc77da7548f73331b6b9411119af8b5db5b1df07",
+    "infile_hash": "dbea2639352ae32971c02b69361df56537c86105ac465660bab30795",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "21c248cf709e49318348b5fa37b69129e90c49925faa086b22c099fb",
+    "stderr_hash": "0139cda7172f978f7ba504a2fecd9d4f6188378162cd90267496f0b5",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -11,9 +11,9 @@ syntax error: implicit statement must appear before declaration and executable s
     |         ^^^^^^^^^^^^^^ 
 
 syntax error: Token 'foo' (of type 'identifier') is unexpected here
-    --> tests/errors/continue_compilation_1.f90:1012:7
+    --> tests/errors/continue_compilation_1.f90:1030:7
      |
-1012 |       foo    end type t_recovery
+1030 |       foo    end type t_recovery
      |       ^^^ 
 
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
@@ -545,21 +545,21 @@ semantic error: equivalence between a common block variable and this array eleme
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
 
 semantic error: kind 2 is not supported for character, only 1 and 4 are
-   --> tests/errors/continue_compilation_1.f90:999:19
-    |
-999 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
-    |                   ^^^^^^ 
+    --> tests/errors/continue_compilation_1.f90:1017:19
+     |
+1017 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
+     |                   ^^^^^^ 
 
 semantic error: kind 3 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1000:19
+    --> tests/errors/continue_compilation_1.f90:1018:19
      |
-1000 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+1018 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: kind 8 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1001:19
+    --> tests/errors/continue_compilation_1.f90:1019:19
      |
-1001 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
+1019 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: Symbol 'undeclared_proc' not declared
@@ -569,9 +569,9 @@ semantic error: Symbol 'undeclared_proc' not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Derived type 't_recovery' not declared
-    --> tests/errors/continue_compilation_1.f90:1015:7
+    --> tests/errors/continue_compilation_1.f90:1033:7
      |
-1015 |       class(t_recovery), intent(in) :: self
+1033 |       class(t_recovery), intent(in) :: self
      |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Symbol 'bad_op' not declared
@@ -1919,3 +1919,27 @@ semantic error: kind 3 is not supported for character, only 1 and 4 are
     |
 991 |         s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
     |             ^^^^^^^ 
+
+semantic error: Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+    --> tests/errors/continue_compilation_1.f90:1006:18
+     |
+1006 |         print *, d%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+     |                  ^^^^^^^^^ 
+
+semantic error: Character variable 's' only has %len and %kind members, not 'bogus'
+    --> tests/errors/continue_compilation_1.f90:1007:18
+     |
+1007 |         print *, d%s%bogus  ! {Error} Character variable 's' only has %len and %kind members, not 'bogus'
+     |                  ^^^^^^^^^ 
+
+semantic error: Variable 'i' doesn't have any member named, 'bogus'.
+    --> tests/errors/continue_compilation_1.f90:1008:18
+     |
+1008 |         print *, d%i%bogus  ! {Error} Variable 'i' doesn't have any member named, 'bogus'.
+     |                  ^^^^^^^^^ 
+
+semantic error: Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+    --> tests/errors/continue_compilation_1.f90:1009:18
+     |
+1009 |         print *, o%in%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+     |                  ^^^^^^^^^^^^ 


### PR DESCRIPTION
## Summary

Follow-up to the review comment on #12586: *"We should add tests for all these new error messages here."*

`resolve_intrinsic_type_member` reports three errors that no test exercised. All three are now covered.

## Scope

Test-only — no compiler source changes.

`tests/errors/continue_compilation_1.f90` gains one subroutine covering every `diag.add` site in the helper:

| designator | error message |
| --- | --- |
| `d%c%bogus` | `Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'` |
| `d%s%bogus` | `Character variable 's' only has %len and %kind members, not 'bogus'` |
| `d%i%bogus` | `Variable 'i' doesn't have any member named, 'bogus'.` |
| `o%in%c%bogus` | same as the first, reached through a nested component so the multi-level designator path is covered too |

The helper's fourth branch, `%kind`, returns without raising an error, so it has nothing to cover here.

## Placement

The new subroutine goes immediately before the unsupported character kind declarations, which the file's own comment requires to stay last — a rejected declaration makes the symbol table visitor skip the program units after it, which would hide these errors. That position is the latest safe one, so the reference update is limited to the four new blocks plus an 18-line shift for the trailing declarations. No existing error message changed or disappeared: the reference goes from 303 to 307 errors, and a sorted diff of the message lines shows no removals.

## Verification

```
$ ./run_tests.py -t continue_compilation_1 -s     # before -u: shows exactly the 4 new errors
$ ./run_tests.py -t continue_compilation_1 -u -s  # reference updated and reviewed
$ ./run_tests.py --no-llvm
TESTS PASSED
```

As on #12586, the `llvm` reference outputs are not checkable in this environment (LLVM 18 here prints opaque pointers, the project pins `llvmdev=11`); CI covers them.

## Note, not changed here

The three messages are capitalised, while `AGENTS.md` asks for lowercase error messages, and the third reads `doesn't have any member named, 'bogus'.` with a stray comma. Both were copied verbatim from the pre-existing messages in `resolve_variable2` directly above, so they are at least self-consistent. Rewording them would touch those existing messages and their references too, so I left it out of this PR — happy to do it as a separate one if you want.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4ridD8pPKn6nkZV4L6Nb8)_