### PR TITLE
fix: do not raise an ICE from the character MaxVal/MinVal identity

### DIFF
--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -2856,7 +2856,9 @@ static inline ASR::expr_t* get_minimum_value_with_given_type(Allocator& al, ASR:
                 case 4: val = std::numeric_limits<int32_t>::min(); break;
                 case 8: val = std::numeric_limits<int64_t>::min(); break;
                 default:
-                    throw LCompilersException("get_minimum_value_with_given_type: Unsupported integer kind " + std::to_string(kind));
+                    // integer kinds are restricted to 1, 2, 4 and 8 in semantics
+                    LCOMPILERS_ASSERT(false);
+                    val = 0;
             }
             return ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, asr_type->base.loc, val, asr_type));
         }
@@ -2870,19 +2872,10 @@ static inline ASR::expr_t* get_minimum_value_with_given_type(Allocator& al, ASR:
             }
             return ASRUtils::EXPR(ASR::make_RealConstant_t(al, asr_type->base.loc, val, asr_type));
         }
-        case ASR::ttypeType::String: {
-            // The smallest character value is char(0), the first character of
-            // the collating sequence (Fortran 2018, 16.9.126 requires MAXVAL of
-            // a zero sized character array to be a string of char(0))
-            ASR::expr_t* min_value = get_string_filled_with_char(al, asr_type, 0);
-            if (!min_value) {
-                throw LCompilersException("get_minimum_value_with_given_type: "
-                    "string length is not known at compile time");
-            }
-            return min_value;
-        }
         default: {
-            throw LCompilersException("get_minimum_value_with_given_type: Not implemented " + std::to_string(asr_type->type));
+            // MaxVal and MinVal only accept integer, real and character arrays,
+            // and a character reduction is seeded with its identity instead
+            LCOMPILERS_ASSERT(false);
         }
     }
     return nullptr;
@@ -2900,7 +2893,9 @@ static inline ASR::expr_t* get_maximum_value_with_given_type(Allocator& al, ASR:
                 case 4: val = std::numeric_limits<int32_t>::max(); break;
                 case 8: val = std::numeric_limits<int64_t>::max(); break;
                 default:
-                    throw LCompilersException("get_maximum_value_with_given_type: Unsupported integer kind " + std::to_string(kind));
+                    // integer kinds are restricted to 1, 2, 4 and 8 in semantics
+                    LCOMPILERS_ASSERT(false);
+                    val = 0;
             }
             return ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, asr_type->base.loc, val, asr_type));
         }
@@ -2914,25 +2909,10 @@ static inline ASR::expr_t* get_maximum_value_with_given_type(Allocator& al, ASR:
             }
             return ASRUtils::EXPR(ASR::make_RealConstant_t(al, asr_type->base.loc, val, asr_type));
         }
-        case ASR::ttypeType::String: {
-            // The largest character value is char(n - 1), the last character of
-            // the collating sequence, where n is the number of characters
-            // representable with the given kind (Fortran 2018, 16.9.135
-            // requires MINVAL of a zero sized character array to be a string
-            // of that character)
-            if (kind != 1) {
-                throw LCompilersException("get_maximum_value_with_given_type: "
-                    "Unsupported character kind " + std::to_string(kind));
-            }
-            ASR::expr_t* max_value = get_string_filled_with_char(al, asr_type, 0xff);
-            if (!max_value) {
-                throw LCompilersException("get_maximum_value_with_given_type: "
-                    "string length is not known at compile time");
-            }
-            return max_value;
-        }
         default: {
-            throw LCompilersException("get_maximum_value_with_given_type: Not implemented " + std::to_string(asr_type->type));
+            // MaxVal and MinVal only accept integer, real and character arrays,
+            // and a character reduction is seeded with its identity instead
+            LCOMPILERS_ASSERT(false);
         }
     }
     return nullptr;

--- a/src/libasr/pass/intrinsic_array_function_registry.h
+++ b/src/libasr/pass/intrinsic_array_function_registry.h
@@ -389,6 +389,21 @@ static inline ASR::expr_t *eval_ArrIntrinsic(Allocator & al,
         if (size == 0 && intrinsic_func_id == ASRUtils::IntrinsicArrayFunctions::Iparity) {
             return ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 0, t));
         }
+        bool is_max_or_min = intrinsic_func_id == ASRUtils::IntrinsicArrayFunctions::MaxVal ||
+                             intrinsic_func_id == ASRUtils::IntrinsicArrayFunctions::MinVal;
+        if (size == 0 && is_max_or_min && ASRUtils::is_character(*t)) {
+            // MAXVAL of a zero sized character array is a string of char(0) and
+            // MINVAL of one is a string of char(n - 1), the last character of
+            // the collating sequence (Fortran 2018, 16.9.126 and 16.9.135).
+            // A length or a kind we cannot fold gives nullptr, leaving the
+            // reduction to be evaluated at runtime.
+            ASR::ttype_t* string_type = ASRUtils::extract_type(t);
+            if (ASRUtils::extract_kind_from_ttype_t(string_type) != 1) {
+                return nullptr;
+            }
+            return ASRUtils::get_string_filled_with_char(al, string_type,
+                intrinsic_func_id == ASRUtils::IntrinsicArrayFunctions::MinVal ? 0xff : 0);
+        }
         if (size == 0 && intrinsic_func_id == ASRUtils::IntrinsicArrayFunctions::MaxVal) {
             return ASRUtils::get_minimum_value_with_given_type(al, t);
         }
@@ -802,6 +817,11 @@ static inline ASR::asr_t* create_ArrIntrinsic(
     }
     if (dim && mask) {
         overload_id = id_array_dim_mask;
+    }
+    if (overload_id != id_array && ASRUtils::is_character(*ASRUtils::expr_type(array))) {
+        append_error(diag, "`dim` and `mask` arguments to `" + intrinsic_func_name +
+            "` are not implemented yet for arrays of character type", loc);
+        return nullptr;
     }
 
     ASR::expr_t *value = nullptr;

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -1009,6 +1009,16 @@ program continue_compilation_1
         print *, o%in%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
     end subroutine
 
+    subroutine character_maxval_dim_mask_not_supported()
+        implicit none
+        character(len=3) :: c(2,2), r(2), s
+        c = 'abc'
+        r = maxval(c, dim=1)  ! {Error} `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
+        r = minval(c, dim=1)  ! {Error} `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
+        s = maxval(c, mask=.false.)  ! {Error} `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
+        s = minval(c, mask=.false.)  ! {Error} `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
+    end subroutine
+
     ! Keep the unsupported character kind declarations last: a rejected
     ! declaration makes the symbol table visitor skip the program units that
     ! follow it, which would hide the errors expected above.

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "dbea2639352ae32971c02b69361df56537c86105ac465660bab30795",
+    "infile_hash": "fff0a72a666d12f4c860329aaa15030fc2d2a6905f1130d4ef6db6ee",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "0139cda7172f978f7ba504a2fecd9d4f6188378162cd90267496f0b5",
+    "stderr_hash": "5b2e751b156e20ac65ed7eb5211654340b57d55cc5a01ad89e2d0ffd",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -11,9 +11,9 @@ syntax error: implicit statement must appear before declaration and executable s
     |         ^^^^^^^^^^^^^^ 
 
 syntax error: Token 'foo' (of type 'identifier') is unexpected here
-    --> tests/errors/continue_compilation_1.f90:1030:7
+    --> tests/errors/continue_compilation_1.f90:1040:7
      |
-1030 |       foo    end type t_recovery
+1040 |       foo    end type t_recovery
      |       ^^^ 
 
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
@@ -545,21 +545,21 @@ semantic error: equivalence between a common block variable and this array eleme
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
 
 semantic error: kind 2 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1017:19
+    --> tests/errors/continue_compilation_1.f90:1027:19
      |
-1017 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
+1027 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: kind 3 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1018:19
+    --> tests/errors/continue_compilation_1.f90:1028:19
      |
-1018 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+1028 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: kind 8 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1019:19
+    --> tests/errors/continue_compilation_1.f90:1029:19
      |
-1019 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
+1029 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: Symbol 'undeclared_proc' not declared
@@ -569,9 +569,9 @@ semantic error: Symbol 'undeclared_proc' not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Derived type 't_recovery' not declared
-    --> tests/errors/continue_compilation_1.f90:1033:7
+    --> tests/errors/continue_compilation_1.f90:1043:7
      |
-1033 |       class(t_recovery), intent(in) :: self
+1043 |       class(t_recovery), intent(in) :: self
      |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Symbol 'bad_op' not declared
@@ -1943,3 +1943,27 @@ semantic error: Complex variable 'c' only has %re, %im, and %kind members, not '
      |
 1009 |         print *, o%in%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
      |                  ^^^^^^^^^^^^ 
+
+semantic error: `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
+    --> tests/errors/continue_compilation_1.f90:1016:13
+     |
+1016 |         r = maxval(c, dim=1)  ! {Error} `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
+     |             ^^^^^^^^^^^^^^^^ 
+
+semantic error: `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
+    --> tests/errors/continue_compilation_1.f90:1017:13
+     |
+1017 |         r = minval(c, dim=1)  ! {Error} `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
+     |             ^^^^^^^^^^^^^^^^ 
+
+semantic error: `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
+    --> tests/errors/continue_compilation_1.f90:1018:13
+     |
+1018 |         s = maxval(c, mask=.false.)  ! {Error} `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
+     |             ^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
+    --> tests/errors/continue_compilation_1.f90:1019:13
+     |
+1019 |         s = minval(c, mask=.false.)  ! {Error} `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
+     |             ^^^^^^^^^^^^^^^^^^^^^^^ 


### PR DESCRIPTION
## Summary

Follow-up to the review comment on #12587 ("We should not be raising LCompilersException, as that is an ICE... if it can't be triggered, then all these should be converted to just asserts").

I checked each of them, and they split into three groups.

**The two I added are gone.** They fired when the element length or the kind of a character identity was not known at compile time, and they were reachable from valid Fortran:

```fortran
character(len=:), allocatable :: d(:,:)
allocate(character(len=4) :: d(2,2))
r = maxval(d, dim=1)   ! LCompilersException: string length is not known at compile time
```

The constant identity is only ever *needed* for constant folding, so it now lives in `eval_ArrIntrinsic`, where returning `nullptr` already means "evaluate this at runtime". A length or kind we cannot fold falls through to the runtime reduction, which handles it. Neither helper needs a `String` case any more.

**The `dim` and `mask` overloads are now rejected in semantics.** Their body generators have no string handling at all, so they reached the same internal error. Depending on the argument they gave an ICE, an LLVM verifier failure, or an ASR verify error; they now give one diagnostic:

```
semantic error: `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
```

This was the caveat flagged in #12587 as "not addressed here"; it is still not implemented, but it no longer reports an internal error. Implementing it properly stays a separate piece of work.

**The remaining ones become asserts, with one deliberate exception.** With the character paths handled, the integer kind and the type switch in `get_minimum_value_with_given_type` / `get_maximum_value_with_given_type` are compiler invariants — semantics restricts integer kinds to 1, 2, 4 and 8 (`integer(16)` is rejected with `Kind 16 is not supported for Integer`), and `create_MaxVal` / `create_MinVal` only accept integer, real and character arrays. Those are now `LCOMPILERS_ASSERT`.

The unsupported **real** kind stays an exception on purpose, because it is *not* an invariant — it is reachable from valid Fortran and already raises an ICE on `main`:

```fortran
real(16) :: a(3)
print *, maxval(a)   ! LCompilersException: Unsupported real kind 16
```

Turning that into an assert would hide a genuine bug in release builds. It is unrelated to the character work, so I have left it alone rather than widen this PR — happy to fix it separately if you'd like.

## Verification

Error test appended to `tests/errors/continue_compilation_1.f90` covering all four rejected combinations (`maxval`/`minval` × `dim`/`mask`), with the reference output regenerated. `integration_tests/empty_array_05.f90` from #12587 is unchanged and still passes, including the constant-folded `maxval([character(len=3) :: ])` path that exercises the relocated folding.

Before and after on the three character paths that previously reported an internal error:

| input | before | after |
| --- | --- | --- |
| `maxval(d, dim=1)`, deferred length | `LCompilersException: string length is not known at compile time` | semantic error |
| `maxval(c, dim=1)`, `character(len=3)` | LLVM verifier failure | semantic error |
| `maxval(c, mask=.false.)` | `ASR verify pass error: Input to MaxVal intrinsic must be of integer or real type` | semantic error |

Suites run locally on this branch (Ubuntu, LLVM 18):

```
./run_tests.py --no-llvm                            TESTS PASSED
cd integration_tests && ./run_tests.py -b llvm      100% tests passed, 0 failed out of 3900
cd integration_tests && ./run_tests.py -b gfortran  100% tests passed, 0 failed out of 3958
```

As on the previous PR, the `llvm` reference outputs are pinned to CI's LLVM 11 and cannot be checked against local LLVM 18 (opaque pointers), and the `c`/`cpp` integration backends need `lfortran_intrinsics.h` on the include path and Kokkos, which this environment lacks; CI covers both.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSLVVoJokrwXCo5XWGUWrR)_