### PR TITLE
style: lowercase the invalid component reference errors

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -13286,7 +13286,7 @@ public:
                 }
             }
             if( member == nullptr ) {
-                diag.add(Diagnostic("Variable '" + dt_name + "' doesn't have any member named, '" + var_name + "'.",
+                diag.add(Diagnostic("variable '" + dt_name + "' doesn't have any member named '" + var_name + "'",
                     Level::Error, Stage::Semantic, {Label("", {loc})}));
                 throw SemanticAbort();
             }
@@ -13376,7 +13376,7 @@ public:
                     member_struct_m_args, member_struct_n_args, ASRUtils::EXPR(expr_), expr_, loc);
                 return expr_;
             }
-            diag.add(Diagnostic("Variable '" + dt_name + "' doesn't have any member named, '" + var_name + "'.",
+            diag.add(Diagnostic("variable '" + dt_name + "' doesn't have any member named '" + var_name + "'",
                 Level::Error, Stage::Semantic, {Label("", {loc})}));
             throw SemanticAbort();
         }
@@ -13422,7 +13422,7 @@ public:
                     al, loc, ASR::down_cast<ASR::expr_t>(v_var), member, member_var->m_type, nullptr);
                 return expr_;
             }
-            diag.add(Diagnostic("Variable '" + dt_name + "' doesn't have any member named, '" + var_name + "'.",
+            diag.add(Diagnostic("variable '" + dt_name + "' doesn't have any member named '" + var_name + "'",
                 Level::Error, Stage::Semantic, {Label("", {loc})}));
             throw SemanticAbort();
         }
@@ -13439,7 +13439,7 @@ public:
 
         if (ASR::is_a<ASR::Complex_t>(*v_variable_m_type)) {
             if (var_name != "re" && var_name != "im") {
-                diag.add(Diagnostic("Complex variable '" + dt_name + "' only has %re, %im, and %kind members, not '" + var_name + "'",
+                diag.add(Diagnostic("complex variable '" + dt_name + "' only has %re, %im, and %kind members, not '" + var_name + "'",
                     Level::Error, Stage::Semantic, {Label("", {loc})}));
                 throw SemanticAbort();
             }
@@ -13508,7 +13508,7 @@ public:
             }
         } else if (ASR::is_a<ASR::String_t>(*v_variable_m_type)) {
             if (var_name != "len") {
-                diag.add(Diagnostic("Character variable '" + dt_name + "' only has %len and %kind members, not '" + var_name + "'",
+                diag.add(Diagnostic("character variable '" + dt_name + "' only has %len and %kind members, not '" + var_name + "'",
                     Level::Error, Stage::Semantic, {Label("", {loc})}));
                 throw SemanticAbort();
             }
@@ -13517,7 +13517,7 @@ public:
                 dt_struct_m_args, dt_struct_n_args, ASRUtils::EXPR(v_var), v_var, loc);
             return create_StringLen_from_expr(ASRUtils::EXPR(v_var), int32, loc);
         } else {
-            diag.add(Diagnostic("Variable '" + dt_name + "' is not a derived or union type",
+            diag.add(Diagnostic("variable '" + dt_name + "' is not a derived or union type",
                 Level::Error, Stage::Semantic, {Label("", {loc})}));
             throw SemanticAbort();
         }
@@ -13547,7 +13547,7 @@ public:
         }
         if (ASR::is_a<ASR::Complex_t>(*base_type)) {
             if (member_name != "re" && member_name != "im") {
-                diag.add(Diagnostic("Complex variable '" + base_name + "' only has %re, %im, and %kind members, not '" + member_name + "'",
+                diag.add(Diagnostic("complex variable '" + base_name + "' only has %re, %im, and %kind members, not '" + member_name + "'",
                     Level::Error, Stage::Semantic, {Label("", {loc})}));
                 throw SemanticAbort();
             }
@@ -13575,13 +13575,13 @@ public:
         }
         if (ASR::is_a<ASR::String_t>(*base_type)) {
             if (member_name != "len") {
-                diag.add(Diagnostic("Character variable '" + base_name + "' only has %len and %kind members, not '" + member_name + "'",
+                diag.add(Diagnostic("character variable '" + base_name + "' only has %len and %kind members, not '" + member_name + "'",
                     Level::Error, Stage::Semantic, {Label("", {loc})}));
                 throw SemanticAbort();
             }
             return create_StringLen_from_expr(base, int32, loc);
         }
-        diag.add(Diagnostic("Variable '" + base_name + "' doesn't have any member named, '" + member_name + "'.",
+        diag.add(Diagnostic("variable '" + base_name + "' doesn't have any member named '" + member_name + "'",
             Level::Error, Stage::Semantic, {Label("", {loc})}));
         throw SemanticAbort();
     }
@@ -13600,7 +13600,7 @@ public:
                 der_type = ASR::down_cast<ASR::Struct_t>(ASRUtils::symbol_get_past_external(
                     ASRUtils::symbol_get_past_external(ASRUtils::get_struct_sym_from_struct_expr(dt_expr))));
             } else {
-                diag.add(Diagnostic("Variable '" + dt_name + "' is not a derived type",
+                diag.add(Diagnostic("variable '" + dt_name + "' is not a derived type",
                     Level::Error, Stage::Semantic, {Label("", {loc})}));
                 throw SemanticAbort();
             }
@@ -13614,7 +13614,7 @@ public:
         } else if( der_type->m_parent != nullptr ) {
             member = resolve_deriv_type_proc(loc, var_name, "", nullptr, nullptr, scope, der_type->m_parent);
         } else {
-            diag.add(Diagnostic("Variable '" + dt_name + "' doesn't have any member named, '" + var_name + "'.",
+            diag.add(Diagnostic("variable '" + dt_name + "' doesn't have any member named '" + var_name + "'",
                 Level::Error, Stage::Semantic, {Label("", {loc})}));
             throw SemanticAbort();
         }

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -1003,10 +1003,10 @@ program continue_compilation_1
         end type itm_outer_t
         type(itm_t) :: d
         type(itm_outer_t) :: o
-        print *, d%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
-        print *, d%s%bogus  ! {Error} Character variable 's' only has %len and %kind members, not 'bogus'
-        print *, d%i%bogus  ! {Error} Variable 'i' doesn't have any member named, 'bogus'.
-        print *, o%in%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+        print *, d%c%bogus  ! {Error} complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+        print *, d%s%bogus  ! {Error} character variable 's' only has %len and %kind members, not 'bogus'
+        print *, d%i%bogus  ! {Error} variable 'i' doesn't have any member named 'bogus'
+        print *, o%in%c%bogus  ! {Error} complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
     end subroutine
 
     ! Keep the unsupported character kind declarations last: a rejected

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "dbea2639352ae32971c02b69361df56537c86105ac465660bab30795",
+    "infile_hash": "f82c8ac8d2b2e4c51a587f99be6312528f493a894f5db59c01391fa5",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "0139cda7172f978f7ba504a2fecd9d4f6188378162cd90267496f0b5",
+    "stderr_hash": "f02a8e7c3c3defa064b165ec71e60cb40116f04c5ad5cf65525f4d2a",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1225,13 +1225,13 @@ semantic error: Incompatible ranks 2 and 1 in assignment
 499 |     matrix = reshape(source, shape_, pad=[0])
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
-semantic error: Complex variable 'c' only has %re, %im, and %kind members, not 'mymember'
+semantic error: complex variable 'c' only has %re, %im, and %kind members, not 'mymember'
    --> tests/errors/continue_compilation_1.f90:504:14
     |
 504 |     print *, c%mymember
     |              ^^^^^^^^^^ 
 
-semantic error: Character variable 'c1' only has %len and %kind members, not 'mymember'
+semantic error: character variable 'c1' only has %len and %kind members, not 'mymember'
    --> tests/errors/continue_compilation_1.f90:506:14
     |
 506 |     print *, c1%mymember
@@ -1920,26 +1920,26 @@ semantic error: kind 3 is not supported for character, only 1 and 4 are
 991 |         s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
     |             ^^^^^^^ 
 
-semantic error: Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+semantic error: complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
     --> tests/errors/continue_compilation_1.f90:1006:18
      |
-1006 |         print *, d%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+1006 |         print *, d%c%bogus  ! {Error} complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
      |                  ^^^^^^^^^ 
 
-semantic error: Character variable 's' only has %len and %kind members, not 'bogus'
+semantic error: character variable 's' only has %len and %kind members, not 'bogus'
     --> tests/errors/continue_compilation_1.f90:1007:18
      |
-1007 |         print *, d%s%bogus  ! {Error} Character variable 's' only has %len and %kind members, not 'bogus'
+1007 |         print *, d%s%bogus  ! {Error} character variable 's' only has %len and %kind members, not 'bogus'
      |                  ^^^^^^^^^ 
 
-semantic error: Variable 'i' doesn't have any member named, 'bogus'.
+semantic error: variable 'i' doesn't have any member named 'bogus'
     --> tests/errors/continue_compilation_1.f90:1008:18
      |
-1008 |         print *, d%i%bogus  ! {Error} Variable 'i' doesn't have any member named, 'bogus'.
+1008 |         print *, d%i%bogus  ! {Error} variable 'i' doesn't have any member named 'bogus'
      |                  ^^^^^^^^^ 
 
-semantic error: Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+semantic error: complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
     --> tests/errors/continue_compilation_1.f90:1009:18
      |
-1009 |         print *, o%in%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+1009 |         print *, o%in%c%bogus  ! {Error} complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
      |                  ^^^^^^^^^^^^ 

--- a/tests/reference/asr-continue_compilation_2-a6145a1.json
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.json
@@ -8,6 +8,6 @@
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_2-a6145a1.stderr",
-    "stderr_hash": "2b628b7972c682156569e860bc7c27203d02fcae869c83f32c6f565e",
+    "stderr_hash": "e52428c1f4d81c61b363889eff10937041476ffa5d978b2d4f072894",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_2-a6145a1.stderr
+++ b/tests/reference/asr-continue_compilation_2-a6145a1.stderr
@@ -836,7 +836,7 @@ semantic error: Type mismatch in assignment, the types must be compatible
 490 |     tm2_x = 5 + "x"
     |     ^^^^^       ^^^ type mismatch (integer and string)
 
-semantic error: Variable 'mycircle' doesn't have any member named, 'mymember'.
+semantic error: variable 'mycircle' doesn't have any member named 'mymember'
    --> tests/errors/continue_compilation_2.f90:497:14
     |
 497 |     print *, myCircle%mymember


### PR DESCRIPTION
## Summary

Follow-up to the note on #12593. `AGENTS.md` asks for lowercase error messages; the four errors that report an invalid component or member reference were capitalised, and one carried a stray comma before the member name plus a trailing period the surrounding messages do not use.

## Scope

Wording only — no behaviour change.

| before | after |
| --- | --- |
| `Variable 'd' doesn't have any member named, 'x'.` | `variable 'd' doesn't have any member named 'x'` |
| `Complex variable 'c' only has %re, %im, and %kind members, not 'x'` | `complex variable 'c' only has %re, %im, and %kind members, not 'x'` |
| `Character variable 's' only has %len and %kind members, not 'x'` | `character variable 's' only has %len and %kind members, not 'x'` |
| `Variable 'v' is not a derived or union type` | `variable 'v' is not a derived or union type` |
| `Variable 'v' is not a derived type` | `variable 'v' is not a derived type` |

These messages are shared by `resolve_variable2`, `resolve_intrinsic_type_member` and `resolve_deriv_type_proc`, so all eleven call sites change together rather than leaving the three functions inconsistent with each other.

Lowercasing also makes the leading word read as the Fortran type name in the `complex`/`character` variants, which lines up with `AGENTS.md`'s preference for naming types explicitly.

### Deliberately left alone

`"Variable 'x' not declared"` in `resolve_variable2` is still capitalised. It is a different message that appears at seven more sites in this file and elsewhere; changing it only here would make things less consistent, not more, and changing it everywhere is a much larger sweep than this PR. Happy to do that separately if you want it.

## Verification

Pure rewording, so the diff is symmetric (29 insertions, 29 deletions) and the reference error counts are unchanged — `continue_compilation_1` stays at 307 errors and `continue_compilation_2` at 153. Every changed reference line is one of the five messages above or the source line echoed beneath it; a sorted diff of the message lines, normalised for the leading letter, shows only the comma and period removal.

```
$ ./run_tests.py -t continue_compilation_ -u -s   # 2 reference files updated and reviewed
$ ./run_tests.py --no-llvm
TESTS PASSED
```

Integration suite: one failure, `string_120`, which fails identically on a clean build of `main` here and is unrelated to a message-text change — it is a `trim` character-kind comparison. It passes in CI on LLVM 11 and 21; I have only been able to reproduce it locally on LLVM 18. As on the previous two PRs, the `llvm` reference outputs are not checkable in this environment (LLVM 18 prints opaque pointers, the project pins `llvmdev=11`); CI covers them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4ridD8pPKn6nkZV4L6Nb8)_