### PR TITLE
fix: blank pad character arguments in string helpers

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1857,6 +1857,7 @@ RUN(NAME intrinsics_473 LABELS gfortran llvm) # maxloc/minloc with compile-time 
 RUN(NAME intrinsics_474 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_ARGS -fcoarray=single) # co_broadcast
 RUN(NAME intrinsics_475 LABELS gfortran llvm) # ishftc with SIZE keeps high bits of I
 RUN(NAME intrinsics_476 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # scale with a negative exponent
+RUN(NAME intrinsics_477 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # right-padding of character args for LGT/LLT/LGE/LLE
 RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME storage_size_01 LABELS gfortran llvm) # storage_size of allocatable character
 

--- a/integration_tests/intrinsics_477.f90
+++ b/integration_tests/intrinsics_477.f90
@@ -1,0 +1,20 @@
+program intrinsics_477
+! Lexical character comparisons use the collating sequence: the shorter operand
+! is blank-padded on the right to the length of the longer before comparing.
+implicit none
+
+! 'A' (len 1) and 'A ' (len 2) are equal after padding to length 2.
+if (llt('A', 'A ')) error stop 'llt(A, A )'
+if (lgt('A ', 'A')) error stop 'lgt(A , A)'
+if (.not. lge('A', 'A ')) error stop 'lge(A, A )'
+if (.not. lle('A', 'A ')) error stop 'lle(A, A )'
+
+! 'B' (len 1) and 'B ' (len 2) are equal after padding.
+if (lgt('B ', 'B')) error stop 'lgt(B , B)'
+if (llt('B', 'B ')) error stop 'llt(B, B )'
+if (.not. lge('B ', 'B')) error stop 'lge(B , B)'
+if (.not. lle('B', 'B ')) error stop 'lle(B, B )'
+
+print *, "Done"
+
+end program intrinsics_477

--- a/src/libasr/pass/intrinsic_functions.h
+++ b/src/libasr/pass/intrinsic_functions.h
@@ -2651,17 +2651,30 @@ namespace Ble {
 
 } // namespace Ble
 
+//     Character arguments are compared by the comparing sequence after the shorter
+//     is blank-padded on the right to the length of the longer. Pad compile-time
+//     strings before comparing so they compare by the collating sequence..
+//     Used by MAX/MIN eval_* and LGT/LLT/LGE/LLE eval_*.
+
+static inline std::vector<std::string> blank_pad_string_args(Vec<ASR::expr_t*>& args) {
+    std::vector<std::string> values;
+    size_t max_len = 0;
+    for (size_t i = 0; i < args.size(); i++) {
+        values.push_back(ASR::down_cast<ASR::StringConstant_t>(args[i])->m_s);
+        max_len = std::max(max_len, values.back().size());
+    }
+    for (size_t i = 0; i < values.size(); i++) {
+        values[i].resize(max_len, ' ');
+    }
+    return values;
+}
+
 namespace Lgt {
 
     static ASR::expr_t *eval_Lgt(Allocator &al, const Location &loc,
         ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string_A = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* string_B = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
-        bool result = false;
-        if (strcmp(string_A, string_B) > 0) {
-            result = true;
-        }
-        return make_ConstantWithType(make_LogicalConstant_t, result, t1, loc);
+        std::vector<std::string> values = blank_pad_string_args(args);
+        return make_ConstantWithType(make_LogicalConstant_t, values[0] > values[1], t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_Lgt(Allocator &al, const Location &loc,
@@ -2685,13 +2698,8 @@ namespace Llt {
 
     static ASR::expr_t *eval_Llt(Allocator &al, const Location &loc,
         ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string_A = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* string_B = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
-        bool result = false;
-        if (strcmp(string_A, string_B) < 0) {
-            result = true;
-        }
-        return make_ConstantWithType(make_LogicalConstant_t, result, t1, loc);
+        std::vector<std::string> values = blank_pad_string_args(args);
+        return make_ConstantWithType(make_LogicalConstant_t, values[0] < values[1], t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_Llt(Allocator &al, const Location &loc,
@@ -2715,13 +2723,8 @@ namespace Lge {
 
     static ASR::expr_t *eval_Lge(Allocator &al, const Location &loc,
         ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string_A = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* string_B = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
-        bool result = false;
-        if (strcmp(string_A, string_B) >= 0) {
-            result = true;
-        }
-        return make_ConstantWithType(make_LogicalConstant_t, result, t1, loc);
+        std::vector<std::string> values = blank_pad_string_args(args);
+        return make_ConstantWithType(make_LogicalConstant_t, values[0] >= values[1], t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_Lge(Allocator &al, const Location &loc,
@@ -2745,13 +2748,8 @@ namespace Lle {
 
     static ASR::expr_t *eval_Lle(Allocator &al, const Location &loc,
         ASR::ttype_t* t1, Vec<ASR::expr_t*> &args, diag::Diagnostics& /*diag*/) {
-        char* string_A = ASR::down_cast<ASR::StringConstant_t>(args[0])->m_s;
-        char* string_B = ASR::down_cast<ASR::StringConstant_t>(args[1])->m_s;
-        bool result = false;
-        if (strcmp(string_A, string_B) <= 0) {
-            result = true;
-        }
-        return make_ConstantWithType(make_LogicalConstant_t, result, t1, loc);
+        std::vector<std::string> values = blank_pad_string_args(args);
+        return make_ConstantWithType(make_LogicalConstant_t, values[0] <= values[1], t1, loc);
     }
 
     static inline ASR::expr_t* instantiate_Lle(Allocator &al, const Location &loc,
@@ -7740,21 +7738,10 @@ static inline ASR::asr_t* create_SetRemove(Allocator& al, const Location& loc,
     The standard requires the result of MAX/MIN with character arguments to
     have the length of the longest argument, with a shorter selected argument
     blank-padded on the right. The helpers below build that length, and pad the
-    compile-time argument values so they compare by the collating sequence.
+    compile-time argument values so they compare by the collating sequence. 
+    The helper `blank_pad_string_args` as defined above is used to pad the compile-time
+    argument values.
 */
-
-static inline std::vector<std::string> blank_pad_string_args(Vec<ASR::expr_t*>& args) {
-    std::vector<std::string> values;
-    size_t max_len = 0;
-    for (size_t i = 0; i < args.size(); i++) {
-        values.push_back(ASR::down_cast<ASR::StringConstant_t>(args[i])->m_s);
-        max_len = std::max(max_len, values.back().size());
-    }
-    for (size_t i = 0; i < values.size(); i++) {
-        values[i].resize(max_len, ' ');
-    }
-    return values;
-}
 
 static inline ASR::expr_t* get_string_length_expr(Allocator& al,
     const Location& loc, ASR::expr_t* arg) {


### PR DESCRIPTION
Lexical intrinsics compared unpadded string literals with strcmp, so expressions like llt('A', 'A ') resulted wrong values.
Use blank_pad_string_args before comparisions.

Fixes #12599 