### PR TITLE
Fix generic interface named after a used procedure

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2237,6 +2237,7 @@ RUN(NAME generic_name_07 LABELS gfortran llvm)
 RUN(NAME generic_name_08 LABELS gfortran llvm)
 RUN(NAME generic_name_09 LABELS gfortran llvm)
 RUN(NAME generic_name_10 LABELS gfortran llvm)
+RUN(NAME generic_name_11 LABELS gfortran llvm)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/generic_name_11.f90
+++ b/integration_tests/generic_name_11.f90
@@ -1,0 +1,39 @@
+module generic_name_11_mod
+    implicit none
+contains
+    function ff(i) result(r)
+        integer, intent(in) :: i
+        integer :: r
+        r = 10 * i
+    end function ff
+
+    function gg() result(r)
+        integer :: r
+        r = 7
+    end function gg
+end module generic_name_11_mod
+
+module generic_name_11_mod2
+    use generic_name_11_mod
+    implicit none
+    ! The generic interface has the same name as one of its use associated
+    ! specific procedures.
+    interface ff
+        module procedure ff
+        module procedure gg
+    end interface
+end module generic_name_11_mod2
+
+program generic_name_11
+    use generic_name_11_mod2
+    implicit none
+    integer :: x
+
+    x = ff(3)
+    print *, x
+    if (x /= 30) error stop
+
+    x = ff()
+    print *, x
+    if (x /= 7) error stop
+end program generic_name_11

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -3833,16 +3833,28 @@ public:
             symbols.reserve(al, proc.second.size());
             bool any_error = false;
             for (auto &pname : proc.second) {
-                std::string correct_pname = pname.first;
-                if( to_lower(pname.first) == proc.first ) {
-                    correct_pname = pname.first + "~genericprocedure";
+                std::string name = to_lower(pname.first);
+                ASR::symbol_t *x = nullptr;
+                if( name == proc.first ) {
+                    // A specific procedure declared in this scope under its
+                    // generic interface's name is stored with the
+                    // genericprocedure suffix, see the comment where the
+                    // suffix is added.
+                    x = current_scope->resolve_symbol(
+                        name + ASRUtils::genericprocedure_suffix);
+                    if (!x) {
+                        // Otherwise it comes from another scope (e.g. it is
+                        // use associated), where it keeps its plain name. The
+                        // generic interface itself is not a candidate.
+                        x = current_scope->resolve_symbol(name);
+                        if (x && ASR::is_a<ASR::GenericProcedure_t>(
+                                *ASRUtils::symbol_get_past_external(x))) {
+                            x = nullptr;
+                        }
+                    }
+                } else {
+                    x = current_scope->resolve_symbol(name);
                 }
-                Str s;
-                s.from_str_view(correct_pname);
-                char *name = s.c_str(al);
-                // lower case the name
-                name = s2c(al, to_lower(name));
-                ASR::symbol_t *x = current_scope->resolve_symbol(name);
                 if (!x) {
                     diag.add(Diagnostic(
                         "Symbol '" + std::string(pname.first) + "' not declared",


### PR DESCRIPTION
An interface whose name matches one of its specific procedures stores that procedure under "<name>~genericprocedure", and add_generic_procedures() looked the specific up under that name only. When the specific procedure is declared elsewhere (for example use associated from another module) it keeps its plain name, so the lookup failed with "Symbol 'ff' not declared".

Fall back to the plain name when the suffixed one is not found, skipping a resolution that lands on a generic interface rather than a procedure.

Adds integration test generic_name_11.

Fixes #12423.