### PR TITLE
docs: add the EnumConstructor example

### DIFF
--- a/doc/src/asr/asr_nodes/expression_nodes/EnumConstructor.md
+++ b/doc/src/asr/asr_nodes/expression_nodes/EnumConstructor.md
@@ -29,9 +29,34 @@ The value of the expression.
 Fortran has no such conversion: an enumerator there is an ordinary named
 constant, so the Fortran frontend never produces this node.
 
-There is no example on this page: an **EnumConstructor** cannot currently be
-printed as ASR text, because the type encoding used to name the operation has
-no case for [EnumType](../type_nodes/EnumType.md).
+## Examples
+
+Converting the integer `1` into a value of the enumeration `color`:
+
+```clojure
+(EnumConstructor
+  :dt_sym (SymbolRef 3 "color")
+  :args [
+    (IntegerConstant
+      :n 1
+      :type (Integer
+        :kind 4
+      )
+      :intboz_type :Decimal
+    )
+  ]
+  :type (EnumType
+    :enum_type (SymbolRef 3 "color")
+  )
+  :value nil
+)
+```
+
+It comes from this complete ASR text document:
+
+```{literalinclude} ../../examples/enum_expr.asr
+:language: clojure
+```
 
 ## See Also
 

--- a/doc/src/asr/examples/enum_expr.asr
+++ b/doc/src/asr/examples/enum_expr.asr
@@ -215,6 +215,30 @@
         :body [
           (Assignment
             :target (Var
+              :v (SymbolRef 3 "c")
+            )
+            :value (EnumConstructor
+              :dt_sym (SymbolRef 3 "color")
+              :args [
+                (IntegerConstant
+                  :n 1
+                  :type (Integer
+                    :kind 4
+                  )
+                  :intboz_type :Decimal
+                )
+              ]
+              :type (EnumType
+                :enum_type (SymbolRef 3 "color")
+              )
+              :value nil
+            )
+            :overloaded nil
+            :realloc_lhs false
+            :move_allocation false
+          )
+          (Assignment
+            :target (Var
               :v (SymbolRef 3 "i")
             )
             :value (EnumValue


### PR DESCRIPTION
## Summary

`EnumConstructor` was the one ASR node page shipped without an example.
Printing one threw `Type encoding not implemented for enum`, so it could not
round-trip through the ASR text reader and the documentation test would have
rejected it. lfortran/lfortran#12608 fixed that, so the node can now be
documented the way every other one is.

## Scope

- The example is an `EnumConstructor` converting the integer `1` into a value
  of the enumeration `color`, quoted on the page and included whole from
  `doc/src/asr/examples/enum_expr.asr`.
- It goes into that existing document rather than a new one: `enum_expr.asr`
  already declares the enumeration, the `ExternalSymbol` reaching it from the
  program, and a variable of its type, so the statement is two lines of new
  ASR instead of a second copy of the same scaffolding.
- The page's "There is no example" note is removed.

## Verification

```console
$ python tests/asr/check_docs.py --lfortran build/src/bin/lfortran
77 ASR examples round-trip, 286 pages agree with ASR.asdl
```

The example verifies and round-trips byte-exactly:

```console
$ lfortran --verify-asr doc/src/asr/examples/enum_expr.asr --no-color
$ lfortran --from-asr doc/src/asr/examples/enum_expr.asr --show-asr --clojure --no-color \
    | diff -u doc/src/asr/examples/enum_expr.asr -
```

## Rationale

This is the third of the three PRs agreed for this work: the documentation
(lfortran/lfortran#12607), the compiler fix that unblocked this node
(lfortran/lfortran#12608), and now the example itself.

The remaining items from the checklist on lfortran/lfortran#12607 —
recording the check in `ASR.asdl`, tightening the excerpt check to the page's
own document, requiring an example on every node page, documenting how the
whole thing works, generating Fortran from each `.asr` for the rendered page,
and deciding how much the `.asr` files should be shared — are follow-ups and
are not in this PR. Reusing `enum_expr.asr` here is a first, small instance of
that last one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYz59Huatfy7a4KBweQpV9)_