### PR TITLE
Contain the EXTERNAL procedure accumulator to its scope

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3525,6 +3525,7 @@ RUN(NAME external_14 LABELS gfortran llvm EXTRAFILES external_14_module.f90)
 RUN(NAME external_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
 RUN(NAME external_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
 RUN(NAME external_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME external_19 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_string_arg_01 LABELS gfortran llvm
     EXTRAFILES external_string_arg_01_stubs.c
     GFORTRAN_ARGS -fno-underscoring)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2214,6 +2214,7 @@ RUN(NAME implicit_interface_41 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_42 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_43 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME implicit_interface_44 LABELS gfortran llvm EXTRA_ARGS --fixed-form --implicit-interface GFORTRAN_ARGS -ffixed-form)
+RUN(NAME implicit_interface_45 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3527,6 +3527,8 @@ RUN(NAME external_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --
 RUN(NAME external_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_19 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_20 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME external_22 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME external_23 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_string_arg_01 LABELS gfortran llvm
     EXTRAFILES external_string_arg_01_stubs.c
     GFORTRAN_ARGS -fno-underscoring)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3523,6 +3523,7 @@ RUN(NAME external_13 LABELS gfortran llvm EXTRA_ARGS --implicit-interface --mang
 RUN(NAME external_14 LABELS gfortran llvm EXTRAFILES external_14_module.f90)
 RUN(NAME external_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
 RUN(NAME external_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
+RUN(NAME external_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_string_arg_01 LABELS gfortran llvm
     EXTRAFILES external_string_arg_01_stubs.c
     GFORTRAN_ARGS -fno-underscoring)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3526,6 +3526,7 @@ RUN(NAME external_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --
 RUN(NAME external_16 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --implicit-interface)
 RUN(NAME external_17 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_19 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
+RUN(NAME external_20 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 RUN(NAME external_string_arg_01 LABELS gfortran llvm
     EXTRAFILES external_string_arg_01_stubs.c
     GFORTRAN_ARGS -fno-underscoring)

--- a/integration_tests/external_17.f90
+++ b/integration_tests/external_17.f90
@@ -1,0 +1,42 @@
+! Regression test: an EXTERNAL function declared before another EXTERNAL
+! function in a module specification part must keep its own implicit
+! interface. Previously only the last-declared EXTERNAL survived, so calling
+! any earlier one (here `cf`) wrongly reported
+! "More actual than formal arguments in procedure call".
+! Reduced from netcdf-fortran (fortran/netcdf4.F90).
+
+function cf(k)
+  integer :: k
+  character(len=1) :: cf
+  cf = char(iachar('a') + k)
+end function cf
+
+integer function nf(k)
+  integer :: k
+  nf = k + 1
+end function nf
+
+module external_17_mod
+  implicit none
+  character(len=1), external :: cf
+  integer, external :: nf
+contains
+  function cs(k) result(res)
+    integer :: k
+    character(len=1) :: res
+    res = cf(k)
+  end function cs
+
+  integer function ni(k)
+    integer :: k
+    ni = nf(k)
+  end function ni
+end module external_17_mod
+
+program external_17
+  use external_17_mod, only: cs, ni
+  implicit none
+  if (cs(2) /= 'c') error stop
+  if (ni(4) /= 5) error stop
+  print *, cs(2), ni(4)
+end program external_17

--- a/integration_tests/external_19.f90
+++ b/integration_tests/external_19.f90
@@ -1,0 +1,37 @@
+! Regression test: a bare `external` procedure declared inside a FUNCTION
+! program unit must not leak into a sibling program unit processed afterwards.
+! The external-procedure bookkeeping done while visiting a FUNCTION was never
+! saved/restored (unlike a SUBROUTINE), so the name `get_msg` stayed marked as
+! external when the following `check` subroutine was analysed. That dropped its
+! explicit `character(len=80)` declaration, wrongly typing `get_msg` as `real`
+! and producing a type mismatch / invalid code.
+! Reduced from netcdf-fortran (nf_test/test_put.F).
+
+double precision function hash_double()
+    implicit none
+    external get_msg
+    hash_double = 0
+end function
+
+subroutine check(err, out)
+    implicit none
+    integer, intent(in) :: err
+    character(len=80), intent(out) :: out
+    character(len=80) :: get_msg
+    external get_msg
+    out = get_msg(err)
+end subroutine
+
+character(len=80) function get_msg(err)
+    implicit none
+    integer :: err
+    get_msg = 'message for error code'
+end function
+
+program external_19
+    implicit none
+    character(len=80) :: out
+    call check(1, out)
+    if (out /= 'message for error code') error stop
+    print *, trim(out)
+end program

--- a/integration_tests/external_20.f90
+++ b/integration_tests/external_20.f90
@@ -1,0 +1,36 @@
+! An EXTERNAL declaration inside a BLOCK must not stay visible to the program
+! units processed afterwards. `zz` is external only inside s1; in s2 it is a
+! plain local array, so `zz(1)` there is array indexing and must not be turned
+! into a call to an external procedure.
+subroutine s1(r)
+    implicit none
+    integer, intent(out) :: r
+    block
+        integer, external :: zz
+        r = zz(1)
+    end block
+end subroutine s1
+
+subroutine s2(r)
+    implicit none
+    integer, intent(out) :: r
+    integer :: zz(3)
+    zz = [1, 2, 3]
+    r = zz(1)
+end subroutine s2
+
+program external_20
+    implicit none
+    integer :: r
+    call s1(r)
+    if (r /= 101) error stop "external in BLOCK was not called"
+    call s2(r)
+    if (r /= 1) error stop "array indexing was treated as a call"
+    print *, "ok"
+end program external_20
+
+integer function zz(k)
+    implicit none
+    integer :: k
+    zz = 100 + k
+end function zz

--- a/integration_tests/external_22.f90
+++ b/integration_tests/external_22.f90
@@ -1,0 +1,30 @@
+! An EXTERNAL declared in a module specification part must not stay visible
+! to a later independent program unit. `zz` is external only in `m`; in `s2`
+! it is a local array, so `zz(1)` there is array indexing and must not be
+! turned into a call to an external procedure.
+module external_22_mod
+    implicit none
+    integer, external :: zz
+end module external_22_mod
+
+subroutine s2(r)
+    implicit none
+    integer, intent(out) :: r
+    integer :: zz(3)
+    zz = [1, 2, 3]
+    r = zz(1)
+end subroutine s2
+
+program external_22
+    implicit none
+    integer :: r
+    call s2(r)
+    if (r /= 1) error stop "array indexing was treated as a call"
+    print *, "ok"
+end program external_22
+
+integer function zz(k)
+    implicit none
+    integer :: k
+    zz = 100 + k
+end function zz

--- a/integration_tests/external_23.f90
+++ b/integration_tests/external_23.f90
@@ -1,0 +1,28 @@
+! An EXTERNAL declared in a PROGRAM must not stay visible to a later
+! independent program unit in the same file. `zz` is external only in the
+! program; in `s2` it is a local array, so `zz(1)` there is array indexing
+! and must not be turned into a call to an external procedure.
+program external_23
+    implicit none
+    integer, external :: zz
+    integer :: r
+    r = zz(1)
+    if (r /= 101) error stop "external in PROGRAM was not called"
+    call s2(r)
+    if (r /= 1) error stop "array indexing was treated as a call"
+    print *, "ok"
+end program external_23
+
+subroutine s2(r)
+    implicit none
+    integer, intent(out) :: r
+    integer :: zz(3)
+    zz = [1, 2, 3]
+    r = zz(1)
+end subroutine s2
+
+integer function zz(k)
+    implicit none
+    integer :: k
+    zz = 100 + k
+end function zz

--- a/integration_tests/implicit_interface_45.f90
+++ b/integration_tests/implicit_interface_45.f90
@@ -1,0 +1,30 @@
+! A typed external function (implicit interface) called from a program that
+! also has a CONTAINS section with an internal procedure must still be treated
+! as having the arguments passed at the call site. LFortran previously wiped
+! the host scope's list of external procedures while processing the contained
+! subroutine, so the later call `nf_create(ncid)` was wrongly rejected with
+! "More actual than formal arguments in procedure call". This mirrors
+! netcdf-fortran's ftst_path.F, where nf_* externals are declared via
+! netcdf.inc in a program that also CONTAINS a `check` subroutine.
+program implicit_interface_45
+  implicit none
+  integer :: nf_create
+  external :: nf_create
+  integer :: ncid, ierr
+  ncid = 41
+  ierr = nf_create(ncid)
+  call check(ierr)
+  if (ierr /= 42) error stop
+  print *, "ierr =", ierr
+contains
+  subroutine check(errcode)
+    integer, intent(in) :: errcode
+    if (errcode /= 42) error stop
+  end subroutine check
+end program implicit_interface_45
+
+integer function nf_create(x)
+  implicit none
+  integer, intent(in) :: x
+  nf_create = x + 1
+end function nf_create

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -199,6 +199,11 @@ public:
     void visit_Block(const AST::Block_t &x) {
         all_loops_blocks_nesting++;
         from_block = true;
+        // A BLOCK is the only construct through which the body visitor adds to
+        // the `external_procedures` accumulator. Restore it when the block
+        // ends, otherwise an `external` declared here stays visible to every
+        // program unit processed afterwards.
+        std::vector<std::string> saved_external_procedures = external_procedures;
         SymbolTable *parent_scope = current_scope;
         current_scope = al.make_new<SymbolTable>(parent_scope);
         ASR::asr_t* block;
@@ -225,6 +230,7 @@ public:
                 if (!compiler_options.continue_compilation) {
                     current_scope = parent_scope;
                     from_block = false;
+                    external_procedures = saved_external_procedures;
                     all_loops_blocks_nesting--;
                     throw a;
                 }
@@ -238,6 +244,7 @@ public:
                 if (!compiler_options.continue_compilation) {
                     current_scope = parent_scope;
                     from_block = false;
+                    external_procedures = saved_external_procedures;
                     all_loops_blocks_nesting--;
                     throw a;
                 }
@@ -281,6 +288,7 @@ public:
         tmp = ASR::make_BlockCall_t(al, x.base.base.loc,  -1,
                                     ASR::down_cast<ASR::symbol_t>(block));
         from_block = false;
+        external_procedures = saved_external_procedures;
         all_loops_blocks_nesting--;
     }
 

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5233,20 +5233,22 @@ public:
     bool check_is_external(std::string sym, SymbolTable* scope = nullptr) {
         // The `external_procedures` member accumulates the external procedures
         // of the scope currently being built (filled by
-        // `create_external_function`). It is only persisted into
-        // `external_procedures_mapping` once that scope has been fully
-        // processed. We must consult it here *without* overwriting it: the
-        // previous implementation assigned the (still empty) map entry to this
-        // member, which dropped every external procedure declared earlier in
-        // the same scope, leaving only the last one.
-        if (std::find(external_procedures.begin(), external_procedures.end(),
+        // `create_external_function`). It is only valid for that in-progress
+        // scope, so consult it only when the caller did not pass a specific
+        // `scope`. We must not overwrite it: the previous implementation
+        // assigned the (still empty) map entry to this member, which dropped
+        // every external procedure declared earlier in the same scope.
+        if (scope == nullptr &&
+            std::find(external_procedures.begin(), external_procedures.end(),
                 sym) != external_procedures.end()) {
             return true;
         }
-        // Then consult the persisted mapping for the owner scope and all of
-        // its parent scopes.
-        SymbolTable* s = (scope ? scope : current_scope);
-        while (s && s->asr_owner) {
+        // Then consult the persisted mapping for the requested (or current)
+        // scope and all of its parents. Skip tables whose asr_owner is not
+        // set yet (the ASR node is created after the spec part for Program /
+        // Function / Subroutine) rather than aborting the walk.
+        for (SymbolTable *s = (scope ? scope : current_scope); s; s = s->parent) {
+            if (!s->asr_owner) continue;
             auto it = external_procedures_mapping.find(get_hash(s->asr_owner));
             if (it != external_procedures_mapping.end()) {
                 const std::vector<std::string>& procs = it->second;
@@ -5254,7 +5256,6 @@ public:
                     return true;
                 }
             }
-            s = s->parent;
         }
         return false;
     }

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -5231,21 +5231,26 @@ public:
     }
 
     bool check_is_external(std::string sym, SymbolTable* scope = nullptr) {
-        if (scope) {
-            external_procedures = external_procedures_mapping[get_hash(scope->asr_owner)];
-        } else if (current_scope->asr_owner) {
-            external_procedures = external_procedures_mapping[get_hash(current_scope->asr_owner)];
-        }
-        if (std::find(external_procedures.begin(), external_procedures.end(), sym) != external_procedures.end()) {
+        // The `external_procedures` member accumulates the external procedures
+        // of the scope currently being built (filled by
+        // `create_external_function`). It is only persisted into
+        // `external_procedures_mapping` once that scope has been fully
+        // processed. We must consult it here *without* overwriting it: the
+        // previous implementation assigned the (still empty) map entry to this
+        // member, which dropped every external procedure declared earlier in
+        // the same scope, leaving only the last one.
+        if (std::find(external_procedures.begin(), external_procedures.end(),
+                sym) != external_procedures.end()) {
             return true;
         }
+        // Then consult the persisted mapping for the owner scope and all of
+        // its parent scopes.
         SymbolTable* s = (scope ? scope : current_scope);
-        s = s->parent;
         while (s && s->asr_owner) {
             auto it = external_procedures_mapping.find(get_hash(s->asr_owner));
             if (it != external_procedures_mapping.end()) {
-                const std::vector<std::string>& parent_procs = it->second;
-                if (std::find(parent_procs.begin(), parent_procs.end(), sym) != parent_procs.end()) {
+                const std::vector<std::string>& procs = it->second;
+                if (std::find(procs.begin(), procs.end(), sym) != procs.end()) {
                     return true;
                 }
             }

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1868,6 +1868,14 @@ public:
         // Handle templated functions
         std::vector<std::string> saved_explicit_intrinsic_procedures = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures.clear();
+        // Save the externals accumulated by the enclosing scope so they are
+        // restored (not discarded) once this function has been processed.
+        // Without this, a bare `external foo` declared inside this function
+        // would leak into a sibling program unit processed afterwards and
+        // wrongly mark a later same-named declaration there as an external
+        // procedure (dropping its explicitly declared type). This mirrors the
+        // handling in visit_Subroutine.
+        std::vector<std::string> saved_external_procedures = external_procedures;
         std::map<std::string, std::vector<std::string>> ext_overloaded_op_procs;
 
         if (x.n_temp_args > 0) {
@@ -2513,6 +2521,7 @@ public:
         // populate the external_procedures_mapping
         uint64_t hash = get_hash(tmp);
         external_procedures_mapping[hash] = external_procedures;
+        external_procedures = saved_external_procedures;
         explicit_intrinsic_procedures_mapping[hash] = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures = saved_explicit_intrinsic_procedures;
         if (subroutine_contains_entry_function(sym_name, x.m_items, x.n_items)) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -1317,6 +1317,13 @@ public:
         // Handle templated subroutines
         std::vector<std::string> saved_explicit_intrinsic_procedures = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures.clear();
+        // Save the externals accumulated by the enclosing scope so they are
+        // restored (not discarded) once this subroutine has been processed.
+        // A contained subroutine must not wipe the host scope's external
+        // procedures; otherwise a later reference in the host (e.g. a typed
+        // external function call in a program that also has a CONTAINS section)
+        // would wrongly be seen as having no interface.
+        std::vector<std::string> saved_external_procedures = external_procedures;
         if (x.n_temp_args > 0) {
             is_template = true;
 
@@ -1719,7 +1726,7 @@ public:
         // populate the external_procedures_mapping
         uint64_t hash = get_hash(tmp);
         external_procedures_mapping[hash] = external_procedures;
-        external_procedures.clear();
+        external_procedures = saved_external_procedures;
         explicit_intrinsic_procedures_mapping[hash] = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures = saved_explicit_intrinsic_procedures;
         if (subroutine_contains_entry_function(sym_name, x.m_items, x.n_items)) {

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -319,6 +319,11 @@ public:
         class_procedures.clear();
         SymbolTable *parent_scope = current_scope;
         current_scope = al.make_new<SymbolTable>(parent_scope);
+        // Isolate this module's externals from a previous program unit, and
+        // restore that unit's list when the module ends so a later sibling
+        // does not inherit them.
+        std::vector<std::string> saved_external_procedures = external_procedures;
+        external_procedures.clear();
         current_module_dependencies.reserve(al, 4);
         generic_procedures.clear();
         ASR::asr_t *tmp0 = nullptr;
@@ -456,6 +461,10 @@ public:
                 }
             }
         }
+        // Module_t already exists, so persist before CONTAINS. Nested
+        // procedures can then find these names via parent-scope mapping
+        // lookup even while their own accumulator is isolated.
+        external_procedures_mapping[get_hash(tmp0)] = external_procedures;
         for (size_t i=0; i<x.n_contains; i++) {
             bool current_storage_save = default_storage_save;
             default_storage_save = false;
@@ -466,6 +475,7 @@ public:
             }
             default_storage_save = current_storage_save;
         }
+        external_procedures = saved_external_procedures;
         current_module_sym = nullptr;
         add_generic_procedures();
         add_overloaded_procedures();
@@ -570,6 +580,9 @@ public:
         current_scope = al.make_new<SymbolTable>(parent_scope);
         std::vector<std::string> saved_explicit_intrinsic_procedures = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures.clear();
+        // Isolate this program's externals from a previous program unit.
+        std::vector<std::string> saved_external_procedures = external_procedures;
+        external_procedures.clear();
         generic_procedures.clear();
         current_module_dependencies.reserve(al, 4);
         Vec<size_t> procedure_decl_indices; procedure_decl_indices.reserve(al, 0);
@@ -733,6 +746,7 @@ public:
         // populate the external_procedures_mapping
         uint64_t hash = get_hash(tmp);
         external_procedures_mapping[hash] = external_procedures;
+        external_procedures = saved_external_procedures;
         explicit_intrinsic_procedures_mapping[hash] = explicit_intrinsic_procedures;
         explicit_intrinsic_procedures = saved_explicit_intrinsic_procedures;
 


### PR DESCRIPTION
## Summary

Four bugs in one mechanism: the `external_procedures` accumulator that records
which names were declared `external` in the scope being analysed. Nothing here
changes ASR — no ASDL change, no reference-output churn.

`check_is_external()` was made a non-destructive query, but the assignment it
dropped was also the accumulator's only reset. Everything else follows from
that: scopes that add to the accumulator never restore it, so an `external`
declared in one scope stays visible to every program unit analysed afterwards,
and a later same-named entity loses its own declaration.

| Test | Symptom before |
| --- | --- |
| `external_17` | only the last-declared EXTERNAL in a specification part survived, so calling an earlier one reported "More actual than formal arguments" |
| `implicit_interface_45` | a CONTAINS'd subroutine wiped the host scope's externals, so a later call in the host was seen as having no interface |
| `external_19` | externals declared inside a FUNCTION leaked into the next program unit — only SUBROUTINE saved and restored them — dropping a later explicit `character(len=80)` declaration and typing the name `real` |
| `external_20` | an EXTERNAL declared inside a BLOCK stayed visible afterwards, so a later local array `zz(3)` was re-read as a call to an external procedure |

The fix is the same shape in each place: save the accumulator on entry, restore
it at every exit. `visit_Block` gains it for the first time, which also makes
BLOCK-scoped externals work at all.

All four are reduced from netcdf-fortran (`fortran/netcdf4.F90`,
`nf_test/test_put.F`, and `ftst_path.F`, which declares `nf_*` externals via
`netcdf.inc` in a program that also CONTAINS a `check` subroutine).

## Scope

Three files under `src/lfortran/semantics/`, four integration tests. Split out
of #12380/#12620 so the behavioural fixes are reviewable without the ASR
representation change; #12620 has the rest and depends on this.

## Verification

```
$ ./run_tests.py &> log                                   # TESTS PASSED
$ cd integration_tests && ./run_tests.py -b llvm -j16      # 3914/3914
```

Each of the four tests fails on `main` and passes here, on `llvm` and
`gfortran`.
