### PR TITLE
Remove hard clang runtime dependency for linking

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -35,6 +35,11 @@ src/bin/lfortran integration_tests/intrinsics_04s.f90 -o intrinsics_04s
 src/bin/lfortran integration_tests/intrinsics_04.f90 -o intrinsics_04
 ./intrinsics_04
 
+# Link with an explicit non-default C compiler driver: any of clang, cc
+# or gcc can drive the final link, there is no clang-specific coupling
+LFORTRAN_LINKER=gcc src/bin/lfortran integration_tests/intrinsics_04.f90 -o intrinsics_04_gcc
+./intrinsics_04_gcc
+
 
 # Run all tests (does not work on Windows yet):
 cmake --version

--- a/doc/man/lfortran.md
+++ b/doc/man/lfortran.md
@@ -62,6 +62,8 @@ LFortran is a modern interactive Fortran compiler based on LLVM.
 - `--symtab-only`: Only create symbol tables in ASR (skip executable stmt)
 - `--time-report`: Show compilation time report
 - `--static`: Create a static executable
+- `--linker TEXT`: Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; by default $PATH is searched for clang, then cc, then gcc
+- `--linker-path TEXT`: Use the linker from this path
 - `--no-warnings`: Turn off all warnings
 - `--no-style-suggestions`: Turn off style suggestions
 - `--no-error-banner`: Turn off error banner

--- a/doc/man/lfortran.md
+++ b/doc/man/lfortran.md
@@ -62,7 +62,7 @@ LFortran is a modern interactive Fortran compiler based on LLVM.
 - `--symtab-only`: Only create symbol tables in ASR (skip executable stmt)
 - `--time-report`: Show compilation time report
 - `--static`: Create a static executable
-- `--linker TEXT`: Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; defaults to the `CC` environment variable if set, otherwise the platform C compiler driver (clang on macOS, gcc on Windows, cc otherwise)
+- `--linker TEXT`: Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; defaults to the platform C compiler driver (clang on macOS, gcc on Windows MinGW targets, cc otherwise)
 - `--linker-path TEXT`: Use the linker from this path
 - `--no-warnings`: Turn off all warnings
 - `--no-style-suggestions`: Turn off style suggestions

--- a/doc/man/lfortran.md
+++ b/doc/man/lfortran.md
@@ -62,7 +62,7 @@ LFortran is a modern interactive Fortran compiler based on LLVM.
 - `--symtab-only`: Only create symbol tables in ASR (skip executable stmt)
 - `--time-report`: Show compilation time report
 - `--static`: Create a static executable
-- `--linker TEXT`: Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; by default $PATH is searched for clang, then cc, then gcc
+- `--linker TEXT`: Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; defaults to the `CC` environment variable if set, otherwise the platform C compiler driver (clang on macOS, gcc on Windows, cc otherwise)
 - `--linker-path TEXT`: Use the linker from this path
 - `--no-warnings`: Turn off all warnings
 - `--no-style-suggestions`: Turn off style suggestions

--- a/doc/src/installation.md
+++ b/doc/src/installation.md
@@ -225,7 +225,6 @@ including `git`.
   sudo apt update
   sudo apt-get install build-essential
   sudo apt-get install zlib1g-dev libzstd-dev
-  sudo apt install clang
   ```
 
 * Run the following commands
@@ -236,6 +235,11 @@ including `git`.
   cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=yes -DCMAKE_INSTALL_PREFIX=`pwd`/inst .
   make -j8
   ```
+
+  Note: producing executables with the built `lfortran` requires a C
+  compiler driver (`clang`, `cc` or `gcc`) in `$PATH`, which the
+  `build-essential` package above provides; see the user guide section
+  "Selecting the C Compiler (Link Driver)".
 
 * If everything compiles, you can use LFortran as follows
 

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -295,19 +295,23 @@ backends (`--backend=c`, `--backend=cpp`) compile the generated C/C++
 source with the driver from the `LFORTRAN_CC` environment variable
 (default `cc`).
 
-If no driver is selected explicitly, LFortran searches `$PATH` for the
-first executable among `clang`, `cc` and `gcc`, in this order (`clang` is
-preferred for historical reasons). This means that producing executables
-works with any installed C compiler, and on a system without any of the
-three drivers LFortran fails with an explicit, actionable error message
-instead of a shell error.
+If no driver is selected with `--linker` or `LFORTRAN_LINKER`, LFortran
+uses the standard `CC` environment variable if it is set (conda compiler
+environments set it, and CMake and autotools honor it), and otherwise a
+fixed per-platform default driver (`clang` on macOS, `gcc` on Windows,
+`cc` on Linux and other Unix systems, where it is normally provided by
+the system gcc). LFortran deliberately does not search `$PATH` for a
+driver on every invocation — the selected name is resolved by the shell
+when the link command runs; if it does not exist, LFortran reports that
+the linker command was not found and how to select a different one.
 
-The driver can be selected explicitly with the `--linker` option or the
-`LFORTRAN_LINKER` environment variable, and a non-standard directory
-containing it with `--linker-path` or `LFORTRAN_LINKER_PATH`:
+A non-standard directory containing the driver can be selected with
+`--linker-path` or `LFORTRAN_LINKER_PATH`; that directory is verified
+up front, so a misplaced `--linker-path` fails with an explicit,
+actionable error message instead of a shell error:
 
 ```
-lfortran hw.f90                      # first of clang, cc, gcc found in $PATH
+lfortran hw.f90                      # $CC if set, otherwise platform default
 lfortran hw.f90 --linker=gcc         # use gcc
 export LFORTRAN_LINKER=gcc
 lfortran hw.f90                      # same via environment variable
@@ -332,11 +336,12 @@ clang.
 When compiling with `-g`, LFortran additionally generates side files with
 line information used to print source line numbers in runtime stacktraces.
 This step uses the external LLVM tools `llvm-dwarfdump` (and `dsymutil` on
-macOS, which ships with the Xcode command line tools). If those tools are
-not in `$PATH`, LFortran prints a warning and skips this step — the
-executable is still built with the DWARF debug information emitted by
-LLVM, only the line numbers in runtime stacktraces are missing. Install
-the LLVM tools (for example `conda install llvm-tools`) to enable them.
+macOS, which ships with the Xcode command line tools) plus Python. This
+step is optional: if any of these tools are missing or the step otherwise
+fails, LFortran prints a warning and continues — the executable is still
+built with the DWARF debug information emitted by LLVM, only the line
+numbers in runtime stacktraces are missing. Install the LLVM tools (for
+example `conda install llvm-tools`) to enable them.
 
 ## Differences from other compilers
 

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -280,26 +280,58 @@ module varray
 end module varray
 ```
 
-## Selecting the C Compiler
+## Selecting the C Compiler (Link Driver)
 
-By default LFortran uses the `clang` compiler.  On some systems
-the compiler has a version number or spelling difference.  The compiler
-can be changed with the `LFORTRAN_CC` symbol:
+Producing an executable (for example `lfortran hw.f90` or
+`lfortran -o hw hw.o`) requires a C compiler driver, because the LLVM
+backend invokes one at run time to link the generated object files against
+the LFortran runtime library. Any standard C compiler driver works — there
+is no clang-specific coupling, the driver only supplies the platform glue
+(startup object files, the C library, default library search paths).
+
+The `--linker`/`LFORTRAN_LINKER` selection described here only affects
+the final link step of the LLVM backend. Separately, the C and C++
+backends (`--backend=c`, `--backend=cpp`) compile the generated C/C++
+source with the driver from the `LFORTRAN_CC` environment variable
+(default `cc`).
+
+If no driver is selected explicitly, LFortran searches `$PATH` for the
+first executable among `clang`, `cc` and `gcc`, in this order (`clang` is
+preferred for historical reasons). This means that producing executables
+works with any installed C compiler, and on a system without any of the
+three drivers LFortran fails with an explicit, actionable error message
+instead of a shell error.
+
+The driver can be selected explicitly with the `--linker` option or the
+`LFORTRAN_LINKER` environment variable, and a non-standard directory
+containing it with `--linker-path` or `LFORTRAN_LINKER_PATH`:
 
 ```
-unset LFORTRAN_CC
-lfortran hw.f90
-Hello World!
-
-export LFORTRAN_CC=gcc
-lfortran hw.f90
-Hello World!
-
-export LFORTRAN_CC=clang-14
-lfortran hw.f90
-sh: clang-14: not found
-...(further error messages)...
+lfortran hw.f90                      # first of clang, cc, gcc found in $PATH
+lfortran hw.f90 --linker=gcc         # use gcc
+export LFORTRAN_LINKER=gcc
+lfortran hw.f90                      # same via environment variable
+export LFORTRAN_LINKER_PATH=/usr/local/bin
+export LFORTRAN_LINKER=gcc-13
+lfortran hw.f90                      # use /usr/local/bin/gcc-13
 ```
+
+Only the final link step needs a C compiler driver: interactive mode,
+the `--show-*` text outputs and compiling to object files (`-c`) do not
+need one; WASM targets either need no driver or use user-provided
+toolchains (`EMSDK_PATH`, `WASI_SDK_PATH`). On Windows the default link
+path uses MSVC's `link` instead.
+
+## Debug Line Information
+
+When compiling with `-g`, LFortran additionally generates side files with
+line information used to print source line numbers in runtime stacktraces.
+This step uses the external LLVM tools `llvm-dwarfdump` (and `dsymutil` on
+macOS, which ships with the Xcode command line tools). If those tools are
+not in `$PATH`, LFortran prints a warning and skips this step — the
+executable is still built with the DWARF debug information emitted by
+LLVM, only the line numbers in runtime stacktraces are missing. Install
+the LLVM tools (for example `conda install llvm-tools`) to enable them.
 
 ## Differences from other compilers
 

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -296,14 +296,16 @@ source with the driver from the `LFORTRAN_CC` environment variable
 (default `cc`).
 
 If no driver is selected with `--linker` or `LFORTRAN_LINKER`, LFortran
-uses the standard `CC` environment variable if it is set (conda compiler
-environments set it, and CMake and autotools honor it), and otherwise a
-fixed per-platform default driver (`clang` on macOS, `gcc` on Windows,
-`cc` on Linux and other Unix systems, where it is normally provided by
-the system gcc). LFortran deliberately does not search `$PATH` for a
-driver on every invocation — the selected name is resolved by the shell
-when the link command runs; if it does not exist, LFortran reports that
-the linker command was not found and how to select a different one.
+uses a fixed per-platform default driver (`clang` on macOS, `gcc` on
+Windows MinGW targets, `cc` on Linux and other Unix systems, where it is
+normally provided by the system gcc). LFortran deliberately does not
+search `$PATH` for a driver on every invocation and does not consult the
+standard `CC` environment variable — build tools and CMake often export
+`CC` values (toolchain-internal paths, extra flags, cross compilers) that
+belong to their own context and are not valid link drivers for LFortran.
+The selected name is resolved by the shell when the link command runs;
+if it does not exist, LFortran reports that the linker command was not
+found and how to select a different one.
 
 A non-standard directory containing the driver can be selected with
 `--linker-path` or `LFORTRAN_LINKER_PATH`; that directory is verified
@@ -311,10 +313,12 @@ up front, so a misplaced `--linker-path` fails with an explicit,
 actionable error message instead of a shell error:
 
 ```
-lfortran hw.f90                      # $CC if set, otherwise platform default
+lfortran hw.f90                      # platform default driver
 lfortran hw.f90 --linker=gcc         # use gcc
 export LFORTRAN_LINKER=gcc
 lfortran hw.f90                      # same via environment variable
+export LFORTRAN_LINKER="ccache clang"
+lfortran hw.f90                      # wrappers and extra arguments work
 export LFORTRAN_LINKER_PATH=/usr/local/bin
 export LFORTRAN_LINKER=gcc-13
 lfortran hw.f90                      # use /usr/local/bin/gcc-13

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -322,6 +322,11 @@ need one; WASM targets either need no driver or use user-provided
 toolchains (`EMSDK_PATH`, `WASI_SDK_PATH`). On Windows the default link
 path uses MSVC's `link` instead.
 
+The one exception to "any driver works" is the Metal GPU backend
+(`--gpu=metal`): it compiles its Objective-C runtime with the same
+driver, and only clang can compile Objective-C, so that backend requires
+clang.
+
 ## Debug Line Information
 
 When compiling with `-g`, LFortran additionally generates side files with

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -1964,6 +1964,76 @@ int compile_to_binary_fortran(const std::string &infile,
     return 0;
 }
 
+// Returns true if `path` refers to a regular file that is executable
+bool is_regular_executable(const std::filesystem::path &path)
+{
+    std::error_code ec;
+    std::filesystem::file_status status = std::filesystem::status(path, ec);
+    if (ec || !std::filesystem::is_regular_file(status)) {
+        return false;
+    }
+#ifdef _WIN32
+    // There is no executable permission bit on Windows, existence of a
+    // regular file with a known executable suffix is sufficient
+    return true;
+#else
+    using perms = std::filesystem::perms;
+    return (status.permissions() &
+            (perms::owner_exec | perms::group_exec | perms::others_exec))
+                != perms::none;
+#endif
+}
+
+// Looks up an external program the same way a shell does: if `dir` is
+// non-empty, only that directory is searched; otherwise the directories
+// from the `PATH` environment variable are scanned in order. Returns the
+// first name from `names` for which an executable file was found
+// (on Windows the ".exe" suffix is tried as well), or an empty string
+// if nothing was found.
+std::string find_program(const std::vector<std::string> &names,
+        const std::string &dir)
+{
+    std::vector<std::filesystem::path> dirs;
+    if (!dir.empty()) {
+        dirs.emplace_back(dir);
+    } else {
+        const char *path_env = std::getenv("PATH");
+        if (path_env == nullptr) {
+            return "";
+        }
+        std::string path_list{path_env};
+#ifdef _WIN32
+        const char sep = ';';
+#else
+        const char sep = ':';
+#endif
+        size_t start = 0;
+        while (start < path_list.size()) {
+            size_t end = path_list.find(sep, start);
+            if (end == std::string::npos) {
+                end = path_list.size();
+            }
+            if (end > start) {
+                dirs.emplace_back(path_list.substr(start, end - start));
+            }
+            start = end + 1;
+        }
+    }
+    for (const std::string &name : names) {
+        for (const std::filesystem::path &d : dirs) {
+            if (is_regular_executable(d / name)) {
+                return name;
+            }
+#ifdef _WIN32
+            if (is_regular_executable(d / (name + ".exe"))) {
+                return name + ".exe";
+            }
+#endif
+        }
+    }
+    return "";
+}
+
 // infile is an object file
 // outfile will become the executable
 int link_executable(const std::vector<std::string> &infiles,
@@ -2115,7 +2185,8 @@ int link_executable(const std::vector<std::string> &infiles,
 
             if (!linker_path.empty()) {
                 CC = linker_path;
-            } else if (char *env_path = std::getenv("LFORTRAN_LINKER_PATH")) {
+            } else if (char *env_path = std::getenv("LFORTRAN_LINKER_PATH");
+                    env_path != nullptr && env_path[0] != '\0') {
                 CC = env_path;
             }
 
@@ -2126,13 +2197,65 @@ int link_executable(const std::vector<std::string> &infiles,
 
             if (!linker.empty()) {
                 CC += linker;
-            } else if (char *env_linker = std::getenv("LFORTRAN_LINKER")) {
+            } else if (char *env_linker = std::getenv("LFORTRAN_LINKER");
+                    env_linker != nullptr && env_linker[0] != '\0') {
                 CC += env_linker;
             } else {
                 // TODO: Add support for msvc linker for Windows
                 // TODO: Add support for lld linker
-                // Default linker to be used
-                CC += "clang";
+                // No linker was requested explicitly; probe for an
+                // available C compiler driver. clang is tried first
+                // to preserve the historical default, but the object
+                // files emitted by LFortran can be linked by any
+                // standard C compiler driver.
+                std::string driver;
+                if (compiler_options.gpu_backend == "metal") {
+                    // The Metal backend compiles its Objective-C runtime
+                    // with the same driver, which must be clang: gcc
+                    // cannot compile Objective-C .m files.
+                    driver = find_program({"clang"}, CC);
+                } else {
+                    driver = find_program({"clang", "cc", "gcc"}, CC);
+                }
+                if (driver.empty()) {
+                    std::string searched = CC;
+                    if (!searched.empty() && searched.back() == '/') {
+                        searched.pop_back();
+                    }
+                    std::cerr << "No C compiler driver found for linking "
+                        "(searched for "
+                        << (compiler_options.gpu_backend == "metal"
+                                ? std::string("clang, which is required to "
+                                              "compile the Metal backend's "
+                                              "Objective-C runtime")
+                                : std::string("clang, cc, gcc"))
+                        << " in "
+                        << (searched.empty() ? std::string("$PATH")
+                                             : "'" + searched + "'")
+                        << "). LFortran needs a C compiler driver to link "
+                        "executables; install one (for example with "
+                        "`apt install build-essential`, the Xcode command "
+                        "line tools, or `conda install clang`), "
+                        "or point LFortran at one explicitly with "
+                        "--linker=<CC> / LFORTRAN_LINKER=<CC> and "
+                        "optionally --linker-path=<DIR> / "
+                        "LFORTRAN_LINKER_PATH=<DIR>." << std::endl;
+                    return 10;
+                }
+                CC += driver;
+            }
+
+            if (compiler_options.gpu_backend == "metal"
+                    && CC.find("clang") == std::string::npos) {
+                // The Metal backend compiles its Objective-C runtime (.m)
+                // with the resolved driver; only clang can compile
+                // Objective-C, so an explicitly selected other driver
+                // cannot work here.
+                std::cerr << "The Metal backend requires the clang driver "
+                    "to compile its Objective-C runtime, but the selected "
+                    "driver is '" << CC << "'. Use --linker=clang or "
+                    "LFORTRAN_LINKER=clang." << std::endl;
+                return 10;
             }
 
             if (compiler_options.target != "" &&
@@ -2186,7 +2309,7 @@ int link_executable(const std::vector<std::string> &infiles,
                     + "/../libasr/runtime/lfortran_gpu_metal.m";
                 std::string metal_runtime_obj = LFORTRAN_TEMP_DIR
                     + "/lfortran_gpu_metal_" + LCOMPILERS_UNIQUE_ID + ".o";
-                std::string metal_compile_cmd = "clang -c -O2 -fobjc-arc"
+                std::string metal_compile_cmd = CC + " -c -O2 -fobjc-arc"
                     " -o " + metal_runtime_obj
                     + " " + metal_runtime_src;
                 int metal_err = system(metal_compile_cmd.c_str());
@@ -2276,35 +2399,64 @@ int link_executable(const std::vector<std::string> &infiles,
             std::cerr << "Tip: If there is a linker issue, switch the linker "
                 "using --linker=<CC> option or create an environment "
                 "variable `export LFORTRAN_LINKER=<CC>`, where CC is "
-                "clang or gcc" << std::endl;
-            std::cerr << "Also, if required use --linker-path=<PATH>, "
-                "where PATH has location to look for the linker "
-                "executable" << std::endl;
+                "clang, cc or gcc" << std::endl;
+            std::cerr << "Also, if required use --linker-path=<PATH> or "
+                "`export LFORTRAN_LINKER_PATH=<PATH>`, where PATH has "
+                "location to look for the linker executable. By default "
+                "LFortran searches $PATH for clang, then cc, then gcc."
+                << std::endl;
             return 10;
         }
 
 #ifdef HAVE_RUNTIME_STACKTRACE
         if (compiler_options.emit_debug_info) {
             // TODO: Replace the following hardcoded part
-            std::string cmd = "";
+            // The debug line-information files used for line numbers in
+            // runtime stacktraces are generated by external LLVM tools.
+            // If those are not available, warn and skip this step instead
+            // of failing the whole compilation; the executable is still
+            // built with the DWARF debug information emitted by LLVM.
+            std::string missing_tools;
+            if (find_program({"llvm-dwarfdump"}, "").empty()) {
+                missing_tools = "`llvm-dwarfdump`";
+            }
 #ifdef HAVE_LFORTRAN_MACHO
-            cmd += "dsymutil " + outfile + " && llvm-dwarfdump --debug-line "
-                + outfile + ".dSYM > ";
-#else
-            cmd += "llvm-dwarfdump --debug-line " + outfile + " > ";
+            if (find_program({"dsymutil"}, "").empty()) {
+                if (!missing_tools.empty()) {
+                    missing_tools += " and ";
+                }
+                missing_tools += "`dsymutil` (which ships with the Xcode "
+                    "command line tools)";
+            }
 #endif
-            std::string dwarf_scripts_path = LCompilers::LFortran::get_dwarf_scripts_dir();
-            cmd += file_name + "_ldd.txt && (" + dwarf_scripts_path + "/dwarf_convert.py "
-                + file_name + "_ldd.txt " + file_name + "_lines.txt "
-                + file_name + "_lines.dat && " + dwarf_scripts_path + "/dat_convert.py "
-                + file_name + "_lines.dat)";
-            int status = system(cmd.c_str());
-            if ( status != 0 ) {
-                std::cerr << "Error in creating the files used to generate "
-                    "the debug information. This might be caused because either"
-                    " `llvm-dwarfdump` or `Python` are not available. "
-                    "Please activate the CONDA environment and compile again.\n";
-                return status;
+            if (!missing_tools.empty()) {
+                std::cerr << "warning: skipping generation of debug line "
+                    "information requested by `-g`: " << missing_tools
+                    << " not found in $PATH. Install the LLVM tools (for "
+                    "example `conda install llvm-tools`) and recompile "
+                    "with `-g` to get line numbers in runtime stacktraces."
+                    << std::endl;
+            } else {
+                std::string cmd = "";
+#ifdef HAVE_LFORTRAN_MACHO
+                cmd += "dsymutil " + outfile + " && llvm-dwarfdump --debug-line "
+                    + outfile + ".dSYM > ";
+#else
+                cmd += "llvm-dwarfdump --debug-line " + outfile + " > ";
+#endif
+                std::string dwarf_scripts_path = LCompilers::LFortran::get_dwarf_scripts_dir();
+                cmd += file_name + "_ldd.txt && (" + dwarf_scripts_path + "/dwarf_convert.py "
+                    + file_name + "_ldd.txt " + file_name + "_lines.txt "
+                    + file_name + "_lines.dat && " + dwarf_scripts_path + "/dat_convert.py "
+                    + file_name + "_lines.dat)";
+                int status = system(cmd.c_str());
+                if ( status != 0 ) {
+                    std::cerr << "Error in creating the files used to generate "
+                        "the debug information. This might be caused because either"
+                        " `llvm-dwarfdump` or `Python` are not available. "
+                        "Please activate the CONDA environment and compile again.\n";
+                    return status;
+                }
             }
         }
 #endif

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2292,8 +2292,7 @@ int link_executable(const std::vector<std::string> &infiles,
             // directory name does not make the driver clang. On macOS the
             // system `cc` is the clang driver (a symlink), so it counts as
             // clang there too. Used for the clang-only behavior below: the
-            // Metal backend's Objective-C runtime, the -target flag and
-            // the clang OpenMP runtime.
+            // Metal backend's Objective-C runtime and the -target flag.
             bool driver_is_clang = false;
             for (std::string token : driver_tokens) {
                 size_t slash = token.find_last_of("/\\");
@@ -2358,7 +2357,12 @@ int link_executable(const std::vector<std::string> &infiles,
                 compile_cmd += extra_linker_flags;
             }
             compile_cmd += " -l" + runtime_lib + " -lm";
-            if (compiler_options.openmp && driver_is_clang) {
+            // Deliberately not gated on the driver: -lomp is resolved from
+            // the directory given by --openmp-lib-dir (e.g. conda's
+            // llvm-openmp), which any link driver can consume; gating here
+            // silently dropped OpenMP linking with non-clang default
+            // drivers.
+            if (compiler_options.openmp) {
                 std::string openmp_shared_library = compiler_options.openmp_lib_dir;
                 std::string omp_cmd =  " -L" + openmp_shared_library + " -Wl,-rpath," + openmp_shared_library + " -lomp";
                 if (!openmp_shared_library.empty()) {

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -58,6 +58,10 @@
 #include <string>
 #include <sstream>
 
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
+
 #include <cpp-terminal/terminal.h>
 #include <cpp-terminal/prompt0.h>
 
@@ -2034,6 +2038,28 @@ std::string find_program(const std::vector<std::string> &names,
     return "";
 }
 
+// The C compiler driver used when none was selected explicitly with
+// --linker/LFORTRAN_LINKER or the standard CC environment variable. The
+// choice is a fixed per-platform default so that LFortran never has to
+// search $PATH itself on every invocation; the shell resolves the name in
+// one step when the link command runs. LFortran objects can be linked by
+// any standard C compiler driver, so a different one can always be
+// selected explicitly.
+const char *default_c_driver()
+{
+#if defined(__APPLE__)
+    // Provided by the Xcode command line tools
+    return "clang";
+#elif defined(_WIN32)
+    // Used only for non-MSVC (MinGW) targets; the MSVC target is linked
+    // directly with `link`
+    return "gcc";
+#else
+    // Provided by the system gcc (e.g. the build-essential package)
+    return "cc";
+#endif
+}
+
 // infile is an object file
 // outfile will become the executable
 int link_executable(const std::vector<std::string> &infiles,
@@ -2195,62 +2221,102 @@ int link_executable(const std::vector<std::string> &infiles,
                 CC += "/";
             }
 
+            // TODO: Add support for msvc linker for Windows
+            // TODO: Add support for lld linker
+            // Select the C compiler driver driving the link, in order:
+            // --linker, LFORTRAN_LINKER, the standard CC variable (set by
+            // conda environments and honored by CMake and autotools), and
+            // finally the fixed per-platform default. The Metal backend
+            // compiles its Objective-C runtime with the same driver and
+            // must use clang; gcc cannot compile Objective-C .m files.
+            std::string driver;
             if (!linker.empty()) {
-                CC += linker;
+                driver = linker;
             } else if (char *env_linker = std::getenv("LFORTRAN_LINKER");
                     env_linker != nullptr && env_linker[0] != '\0') {
-                CC += env_linker;
+                driver = env_linker;
+            } else if (char *env_cc = std::getenv("CC");
+                    env_cc != nullptr && env_cc[0] != '\0') {
+                driver = env_cc;
+            } else if (compiler_options.gpu_backend == "metal") {
+                driver = "clang";
             } else {
-                // TODO: Add support for msvc linker for Windows
-                // TODO: Add support for lld linker
-                // No linker was requested explicitly; probe for an
-                // available C compiler driver. clang is tried first
-                // to preserve the historical default, but the object
-                // files emitted by LFortran can be linked by any
-                // standard C compiler driver.
-                std::string driver;
-                if (compiler_options.gpu_backend == "metal") {
-                    // The Metal backend compiles its Objective-C runtime
-                    // with the same driver, which must be clang: gcc
-                    // cannot compile Objective-C .m files.
-                    driver = find_program({"clang"}, CC);
-                } else {
-                    driver = find_program({"clang", "cc", "gcc"}, CC);
-                }
-                if (driver.empty()) {
-                    std::string searched = CC;
-                    if (!searched.empty() && searched.back() == '/') {
-                        searched.pop_back();
-                    }
-                    std::cerr << "No C compiler driver found for linking "
-                        "(searched for "
-                        << (compiler_options.gpu_backend == "metal"
-                                ? std::string("clang, which is required to "
-                                              "compile the Metal backend's "
-                                              "Objective-C runtime")
-                                : std::string("clang, cc, gcc"))
-                        << " in "
-                        << (searched.empty() ? std::string("$PATH")
-                                             : "'" + searched + "'")
-                        << "). LFortran needs a C compiler driver to link "
-                        "executables; install one (for example with "
-                        "`apt install build-essential`, the Xcode command "
-                        "line tools, or `conda install clang`), "
-                        "or point LFortran at one explicitly with "
-                        "--linker=<CC> / LFORTRAN_LINKER=<CC> and "
-                        "optionally --linker-path=<DIR> / "
-                        "LFORTRAN_LINKER_PATH=<DIR>." << std::endl;
-                    return 10;
-                }
-                CC += driver;
+                driver = default_c_driver();
             }
 
-            if (compiler_options.gpu_backend == "metal"
-                    && CC.find("clang") == std::string::npos) {
+            // The driver string may contain arguments in addition to the
+            // program name, e.g. `CC="ccache clang"` or `CC="gcc -m32"`;
+            // split it so the program name and clang detection work on
+            // tokens, not on the whole string.
+            std::istringstream driver_stream(driver);
+            std::vector<std::string> driver_tokens;
+            for (std::string token; driver_stream >> token;) {
+                driver_tokens.push_back(token);
+            }
+            if (driver_tokens.empty()) {
+                // `driver` was effectively empty (e.g. a whitespace-only
+                // `CC` value); fall back to the platform default so the
+                // link command is not malformed.
+                driver = default_c_driver();
+                driver_tokens.push_back(driver);
+            }
+
+            if (!CC.empty()) {
+                // A linker directory was requested explicitly; validate
+                // the selection here so that a wrong --linker-path fails
+                // with a clear error instead of a confusing shell message.
+                // Only the first token is the program name; the rest are
+                // arguments. Without a directory, the driver is resolved
+                // by the shell when the link command runs, so no $PATH
+                // scan is needed.
+                std::string searched = CC;
+                if (searched.back() == '/') {
+                    searched.pop_back();
+                }
+                if (find_program({driver_tokens[0]}, searched).empty()) {
+                    std::cerr << "No C compiler driver found for linking: '"
+                        << driver_tokens[0] << "' is not present in '"
+                        << searched
+                        << "'. Check --linker / LFORTRAN_LINKER and "
+                        "--linker-path / LFORTRAN_LINKER_PATH. LFortran "
+                        "needs a C compiler driver (for example clang, cc "
+                        "or gcc) to link executables; leave these options "
+                        "unset to use the CC environment variable or the "
+                        "default driver '"
+                        << default_c_driver() << "'." << std::endl;
+                    return 10;
+                }
+            }
+            CC += driver;
+
+            // True when a token of the driver is a clang program (clang,
+            // clang-14, `ccache clang`, ...), after stripping any directory
+            // from the token; an incidental "clang" inside a --linker-path
+            // directory name does not make the driver clang. On macOS the
+            // system `cc` is the clang driver (a symlink), so it counts as
+            // clang there too. Used for the clang-only behavior below: the
+            // Metal backend's Objective-C runtime, the -target flag and
+            // the clang OpenMP runtime.
+            bool driver_is_clang = false;
+            for (std::string token : driver_tokens) {
+                size_t slash = token.find_last_of("/\\");
+                if (slash != std::string::npos) {
+                    token = token.substr(slash + 1);
+                }
+                if (LCompilers::startswith(token, "clang")
+#ifdef __APPLE__
+                        || token == "cc"
+#endif
+                        ) {
+                    driver_is_clang = true;
+                    break;
+                }
+            }
+
+            if (compiler_options.gpu_backend == "metal" && !driver_is_clang) {
                 // The Metal backend compiles its Objective-C runtime (.m)
-                // with the resolved driver; only clang can compile
-                // Objective-C, so an explicitly selected other driver
-                // cannot work here.
+                // with the resolved driver, and only clang can compile
+                // Objective-C, so any other driver cannot work here.
                 std::cerr << "The Metal backend requires the clang driver "
                     "to compile its Objective-C runtime, but the selected "
                     "driver is '" << CC << "'. Use --linker=clang or "
@@ -2258,8 +2324,7 @@ int link_executable(const std::vector<std::string> &infiles,
                 return 10;
             }
 
-            if (compiler_options.target != "" &&
-                    CC.find("clang" ) != std::string::npos) {
+            if (compiler_options.target != "" && driver_is_clang) {
                 options = " -target " + compiler_options.target;
             }
 
@@ -2296,7 +2361,7 @@ int link_executable(const std::vector<std::string> &infiles,
                 compile_cmd += extra_linker_flags;
             }
             compile_cmd += " -l" + runtime_lib + " -lm";
-            if (compiler_options.openmp && CC.find("clang" ) != std::string::npos) {
+            if (compiler_options.openmp && driver_is_clang) {
                 std::string openmp_shared_library = compiler_options.openmp_lib_dir;
                 std::string omp_cmd =  " -L" + openmp_shared_library + " -Wl,-rpath," + openmp_shared_library + " -lomp";
                 if (!openmp_shared_library.empty()) {
@@ -2396,6 +2461,23 @@ int link_executable(const std::vector<std::string> &infiles,
         int err = system(compile_cmd.c_str());
         if (err) {
             std::cerr << "The command '" + compile_cmd + "' failed." << std::endl;
+#ifndef _WIN32
+            if (WIFEXITED(err) && WEXITSTATUS(err) == 127) {
+                // Exit 127 is the shell's "command not found": the external
+                // command itself does not exist (the C compiler driver for
+                // the final link, emcc / WASI clang for WASM targets, ...),
+                // so report that precisely instead of only hinting at
+                // linker issues below.
+                std::cerr << "error: the linker/compiler command was not "
+                    "found. LFortran invokes an external command to produce "
+                    "the executable; for the LLVM backend the final link "
+                    "uses a C compiler driver (for example clang, cc or "
+                    "gcc), which can be selected with --linker=<CC>, "
+                    "LFORTRAN_LINKER=<CC> or the standard CC environment "
+                    "variable; WASM targets need their toolchain "
+                    "(EMSDK_PATH / WASI_SDK_PATH)." << std::endl;
+            }
+#endif
             std::cerr << "Tip: If there is a linker issue, switch the linker "
                 "using --linker=<CC> option or create an environment "
                 "variable `export LFORTRAN_LINKER=<CC>`, where CC is "
@@ -2403,7 +2485,8 @@ int link_executable(const std::vector<std::string> &infiles,
             std::cerr << "Also, if required use --linker-path=<PATH> or "
                 "`export LFORTRAN_LINKER_PATH=<PATH>`, where PATH has "
                 "location to look for the linker executable. By default "
-                "LFortran searches $PATH for clang, then cc, then gcc."
+                "LFortran uses the platform C compiler driver ('"
+                << default_c_driver() << "' on this platform)."
                 << std::endl;
             return 10;
         }
@@ -2413,50 +2496,48 @@ int link_executable(const std::vector<std::string> &infiles,
             // TODO: Replace the following hardcoded part
             // The debug line-information files used for line numbers in
             // runtime stacktraces are generated by external LLVM tools.
-            // If those are not available, warn and skip this step instead
+            // This step is optional: if it fails for any reason (the tools
+            // or Python are not installed, ...), warn and continue instead
             // of failing the whole compilation; the executable is still
             // built with the DWARF debug information emitted by LLVM.
-            std::string missing_tools;
-            if (find_program({"llvm-dwarfdump"}, "").empty()) {
-                missing_tools = "`llvm-dwarfdump`";
-            }
+            std::string cmd = "";
 #ifdef HAVE_LFORTRAN_MACHO
-            if (find_program({"dsymutil"}, "").empty()) {
-                if (!missing_tools.empty()) {
-                    missing_tools += " and ";
-                }
-                missing_tools += "`dsymutil` (which ships with the Xcode "
-                    "command line tools)";
-            }
-#endif
-            if (!missing_tools.empty()) {
-                std::cerr << "warning: skipping generation of debug line "
-                    "information requested by `-g`: " << missing_tools
-                    << " not found in $PATH. Install the LLVM tools (for "
-                    "example `conda install llvm-tools`) and recompile "
-                    "with `-g` to get line numbers in runtime stacktraces."
-                    << std::endl;
-            } else {
-                std::string cmd = "";
-#ifdef HAVE_LFORTRAN_MACHO
-                cmd += "dsymutil " + outfile + " && llvm-dwarfdump --debug-line "
-                    + outfile + ".dSYM > ";
+            cmd += "dsymutil " + outfile + " && llvm-dwarfdump --debug-line "
+                + outfile + ".dSYM > ";
 #else
-                cmd += "llvm-dwarfdump --debug-line " + outfile + " > ";
+            cmd += "llvm-dwarfdump --debug-line " + outfile + " > ";
 #endif
-                std::string dwarf_scripts_path = LCompilers::LFortran::get_dwarf_scripts_dir();
-                cmd += file_name + "_ldd.txt && (" + dwarf_scripts_path + "/dwarf_convert.py "
-                    + file_name + "_ldd.txt " + file_name + "_lines.txt "
-                    + file_name + "_lines.dat && " + dwarf_scripts_path + "/dat_convert.py "
-                    + file_name + "_lines.dat)";
-                int status = system(cmd.c_str());
-                if ( status != 0 ) {
-                    std::cerr << "Error in creating the files used to generate "
-                        "the debug information. This might be caused because either"
-                        " `llvm-dwarfdump` or `Python` are not available. "
-                        "Please activate the CONDA environment and compile again.\n";
-                    return status;
-                }
+            std::string dwarf_scripts_path = LCompilers::LFortran::get_dwarf_scripts_dir();
+            cmd += file_name + "_ldd.txt && (" + dwarf_scripts_path + "/dwarf_convert.py "
+                + file_name + "_ldd.txt " + file_name + "_lines.txt "
+                + file_name + "_lines.dat && " + dwarf_scripts_path + "/dat_convert.py "
+                + file_name + "_lines.dat)";
+            int status = system(cmd.c_str());
+            if ( status != 0 ) {
+                // Remove partial outputs the failed step may have created:
+                // the shell creates the `>` redirect file even when the
+                // external tool is missing, and dsymutil may already have
+                // produced the .dSYM bundle before a later step failed.
+                std::error_code ec;
+                std::filesystem::remove(file_name + "_ldd.txt", ec);
+                std::filesystem::remove(file_name + "_lines.txt", ec);
+                std::filesystem::remove(file_name + "_lines.dat", ec);
+#ifdef HAVE_LFORTRAN_MACHO
+                std::filesystem::remove_all(outfile + ".dSYM", ec);
+#endif
+                std::cerr << "warning: could not generate the debug line "
+                    "information requested by `-g`, continuing without it. "
+                    "This step needs the external LLVM tools "
+                    "(`llvm-dwarfdump`"
+#ifdef HAVE_LFORTRAN_MACHO
+                    ", `dsymutil` (which ships with the Xcode command line "
+                    "tools)"
+#endif
+                    ") and Python in $PATH. Install them (for example with "
+                    "`conda install llvm-tools`) and recompile with `-g` to "
+                    "get line numbers in runtime stacktraces. The "
+                    "executable itself was built successfully."
+                    << std::endl;
             }
         }
 #endif

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2039,12 +2039,14 @@ std::string find_program(const std::vector<std::string> &names,
 }
 
 // The C compiler driver used when none was selected explicitly with
-// --linker/LFORTRAN_LINKER or the standard CC environment variable. The
-// choice is a fixed per-platform default so that LFortran never has to
-// search $PATH itself on every invocation; the shell resolves the name in
-// one step when the link command runs. LFortran objects can be linked by
-// any standard C compiler driver, so a different one can always be
-// selected explicitly.
+// --linker/LFORTRAN_LINKER. The choice is a fixed per-platform default so
+// that LFortran never has to search $PATH itself on every invocation; the
+// shell resolves the name in one step when the link command runs. LFortran
+// objects can be linked by any standard C compiler driver, so a different
+// one can always be selected explicitly. The standard CC variable is
+// deliberately not consulted: build tools and CMake export CC values (full
+// toolchain-internal paths, command arguments, cross compilers) that fit
+// their own context, not LFortran's final link step.
 const char *default_c_driver()
 {
 #if defined(__APPLE__)
@@ -2224,20 +2226,16 @@ int link_executable(const std::vector<std::string> &infiles,
             // TODO: Add support for msvc linker for Windows
             // TODO: Add support for lld linker
             // Select the C compiler driver driving the link, in order:
-            // --linker, LFORTRAN_LINKER, the standard CC variable (set by
-            // conda environments and honored by CMake and autotools), and
-            // finally the fixed per-platform default. The Metal backend
-            // compiles its Objective-C runtime with the same driver and
-            // must use clang; gcc cannot compile Objective-C .m files.
+            // --linker, LFORTRAN_LINKER, and finally the fixed per-platform
+            // default (clang for the Metal backend, which compiles its
+            // Objective-C runtime with the same driver). The standard CC
+            // environment variable is not used: see default_c_driver().
             std::string driver;
             if (!linker.empty()) {
                 driver = linker;
             } else if (char *env_linker = std::getenv("LFORTRAN_LINKER");
                     env_linker != nullptr && env_linker[0] != '\0') {
                 driver = env_linker;
-            } else if (char *env_cc = std::getenv("CC");
-                    env_cc != nullptr && env_cc[0] != '\0') {
-                driver = env_cc;
             } else if (compiler_options.gpu_backend == "metal") {
                 driver = "clang";
             } else {
@@ -2281,8 +2279,7 @@ int link_executable(const std::vector<std::string> &infiles,
                         "--linker-path / LFORTRAN_LINKER_PATH. LFortran "
                         "needs a C compiler driver (for example clang, cc "
                         "or gcc) to link executables; leave these options "
-                        "unset to use the CC environment variable or the "
-                        "default driver '"
+                        "unset to use the default driver '"
                         << default_c_driver() << "'." << std::endl;
                     return 10;
                 }
@@ -2472,9 +2469,8 @@ int link_executable(const std::vector<std::string> &infiles,
                     "found. LFortran invokes an external command to produce "
                     "the executable; for the LLVM backend the final link "
                     "uses a C compiler driver (for example clang, cc or "
-                    "gcc), which can be selected with --linker=<CC>, "
-                    "LFORTRAN_LINKER=<CC> or the standard CC environment "
-                    "variable; WASM targets need their toolchain "
+                    "gcc), which can be selected with --linker=<CC> or "
+                    "LFORTRAN_LINKER=<CC>; WASM targets need their toolchain "
                     "(EMSDK_PATH / WASI_SDK_PATH)." << std::endl;
             }
 #endif

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -339,7 +339,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--separate-compilation", compiler_options.separate_compilation, "Generate object code into .o files")->group(group_backend_codegen_options);
         app.add_flag("--static", opts.static_link, "Create a static executable")->group(group_backend_codegen_options);
         app.add_flag("--shared", opts.shared_link, "Create a shared executable")->group(group_backend_codegen_options);
-        app.add_flag("--linker", opts.linker, "Specify the linker to be used, available options: clang or gcc")->capture_default_str()->group(group_backend_codegen_options);
+        app.add_flag("--linker", opts.linker, "Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; by default $PATH is searched for clang, then cc, then gcc")->capture_default_str()->group(group_backend_codegen_options);
         app.add_flag("--linker-path", opts.linker_path, "Use the linker from this path")->capture_default_str()->group(group_backend_codegen_options);
         app.add_option("--target", compiler_options.target, "Generate code for the given target")->capture_default_str()->group(group_backend_codegen_options);
         app.add_option("--march", compiler_options.march, "Generate code for the selected instruction-set architecture (`native` for the host)")->group(group_backend_codegen_options);

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -339,7 +339,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--separate-compilation", compiler_options.separate_compilation, "Generate object code into .o files")->group(group_backend_codegen_options);
         app.add_flag("--static", opts.static_link, "Create a static executable")->group(group_backend_codegen_options);
         app.add_flag("--shared", opts.shared_link, "Create a shared executable")->group(group_backend_codegen_options);
-        app.add_flag("--linker", opts.linker, "Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; by default $PATH is searched for clang, then cc, then gcc")->capture_default_str()->group(group_backend_codegen_options);
+        app.add_flag("--linker", opts.linker, "Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; defaults to the CC environment variable if set, otherwise the platform C compiler driver (clang on macOS, gcc on Windows, cc otherwise)")->capture_default_str()->group(group_backend_codegen_options);
         app.add_flag("--linker-path", opts.linker_path, "Use the linker from this path")->capture_default_str()->group(group_backend_codegen_options);
         app.add_option("--target", compiler_options.target, "Generate code for the given target")->capture_default_str()->group(group_backend_codegen_options);
         app.add_option("--march", compiler_options.march, "Generate code for the selected instruction-set architecture (`native` for the host)")->group(group_backend_codegen_options);

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -339,7 +339,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--separate-compilation", compiler_options.separate_compilation, "Generate object code into .o files")->group(group_backend_codegen_options);
         app.add_flag("--static", opts.static_link, "Create a static executable")->group(group_backend_codegen_options);
         app.add_flag("--shared", opts.shared_link, "Create a shared executable")->group(group_backend_codegen_options);
-        app.add_flag("--linker", opts.linker, "Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; defaults to the CC environment variable if set, otherwise the platform C compiler driver (clang on macOS, gcc on Windows, cc otherwise)")->capture_default_str()->group(group_backend_codegen_options);
+        app.add_flag("--linker", opts.linker, "Specify the linker (C compiler driver) to be used, e.g. clang, cc or gcc; defaults to the platform C compiler driver (clang on macOS, gcc on Windows MinGW targets, cc otherwise)")->capture_default_str()->group(group_backend_codegen_options);
         app.add_flag("--linker-path", opts.linker_path, "Use the linker from this path")->capture_default_str()->group(group_backend_codegen_options);
         app.add_option("--target", compiler_options.target, "Generate code for the given target")->capture_default_str()->group(group_backend_codegen_options);
         app.add_option("--march", compiler_options.march, "Generate code for the selected instruction-set architecture (`native` for the host)")->group(group_backend_codegen_options);

--- a/test_lfortran_cmdline
+++ b/test_lfortran_cmdline
@@ -123,14 +123,37 @@ if [[ $FC == "lfortran" ]]; then
     ./a.out
 
     cd $(mktemp -d)
-    echo "Testing explicit error when no C compiler driver is available"
-    mkdir bin
-    ln -s "$(command -v lfortran)" bin/lfortran
-    if PATH="$(pwd)/bin" lfortran $f -o a.out 2> no_driver_err.txt; then
-        echo "Expected failure when no C compiler driver is in PATH"
+    echo "Testing driver selection via the standard CC environment variable"
+    CC=cc $FC $f -o a.out
+    [ -x "a.out" ]
+    ./a.out
+
+    cd $(mktemp -d)
+    echo "Testing a CC value with arguments (e.g. ccache-style wrappers)"
+    if ! CC="$(command -v cc) -Qunused-arguments" $FC $f -o a.out 2> cc_args_err.txt; then
+        echo "Expected success when CC contains the driver plus arguments"
+        cat cc_args_err.txt
+        exit 1
+    fi
+    [ -x "a.out" ]
+    ./a.out
+
+    cd $(mktemp -d)
+    echo "Testing explicit error when the linker is not in LFORTRAN_LINKER_PATH"
+    mkdir empty_dir
+    if LFORTRAN_LINKER_PATH="$(pwd)/empty_dir" LFORTRAN_LINKER=cc $FC $f -o a.out 2> no_driver_err.txt; then
+        echo "Expected failure when the linker is not present in LFORTRAN_LINKER_PATH"
         exit 1
     fi
     grep "No C compiler driver found" no_driver_err.txt
+
+    cd $(mktemp -d)
+    echo "Testing targeted error when the selected linker does not exist"
+    if LFORTRAN_LINKER=lfortran-nonexistent-driver-xyz $FC $f -o a.out 2> not_found_err.txt; then
+        echo "Expected failure when the selected linker does not exist"
+        exit 1
+    fi
+    grep "command was not found" not_found_err.txt
 fi
 
 echo "All tests succeeded"

--- a/test_lfortran_cmdline
+++ b/test_lfortran_cmdline
@@ -123,16 +123,10 @@ if [[ $FC == "lfortran" ]]; then
     ./a.out
 
     cd $(mktemp -d)
-    echo "Testing driver selection via the standard CC environment variable"
-    CC=cc $FC $f -o a.out
-    [ -x "a.out" ]
-    ./a.out
-
-    cd $(mktemp -d)
-    echo "Testing a CC value with arguments (e.g. ccache-style wrappers)"
-    if ! CC="$(command -v cc) -Qunused-arguments" $FC $f -o a.out 2> cc_args_err.txt; then
-        echo "Expected success when CC contains the driver plus arguments"
-        cat cc_args_err.txt
+    echo "Testing an LFORTRAN_LINKER value with arguments (e.g. ccache-style wrappers)"
+    if ! LFORTRAN_LINKER="$(command -v cc) -pipe" $FC $f -o a.out 2> linker_args_err.txt; then
+        echo "Expected success when LFORTRAN_LINKER contains the driver plus arguments"
+        cat linker_args_err.txt
         exit 1
     fi
     [ -x "a.out" ]

--- a/test_lfortran_cmdline
+++ b/test_lfortran_cmdline
@@ -148,6 +148,30 @@ if [[ $FC == "lfortran" ]]; then
         exit 1
     fi
     grep "command was not found" not_found_err.txt
+
+    cd $(mktemp -d)
+    echo "Testing --openmp link flags are passed to a non-clang named driver"
+    # A driver stub records its arguments and succeeds, so the link command
+    # can be inspected without a real OpenMP runtime being installed. The
+    # stub is deliberately not called `clang`/`cc`: -lomp must be added
+    # regardless of the driver name, since --openmp-lib-dir points at it.
+    cat > drv.sh <<'EOF'
+#!/bin/sh
+for a in "$@"; do echo "$a" >> "$LFORTRAN_TEST_DRV_ARGS"; done
+exit 0
+EOF
+    chmod +x drv.sh
+    mkdir omplib
+    export LFORTRAN_TEST_DRV_ARGS="$(pwd)/drv_args.txt"
+    touch "$LFORTRAN_TEST_DRV_ARGS"
+    if ! LFORTRAN_LINKER="$(pwd)/drv.sh" $FC $f -o a.out --openmp "--openmp-lib-dir=$(pwd)/omplib"; then
+        echo "Expected the driver stub link to succeed"
+        exit 1
+    fi
+    grep -x -- "-lomp" "$LFORTRAN_TEST_DRV_ARGS"
+    grep -x -- "-L$(pwd)/omplib" "$LFORTRAN_TEST_DRV_ARGS"
+    grep -x -- "-Wl,-rpath,$(pwd)/omplib" "$LFORTRAN_TEST_DRV_ARGS"
+    unset LFORTRAN_TEST_DRV_ARGS
 fi
 
 echo "All tests succeeded"

--- a/test_lfortran_cmdline
+++ b/test_lfortran_cmdline
@@ -172,6 +172,38 @@ EOF
     grep -x -- "-L$(pwd)/omplib" "$LFORTRAN_TEST_DRV_ARGS"
     grep -x -- "-Wl,-rpath,$(pwd)/omplib" "$LFORTRAN_TEST_DRV_ARGS"
     unset LFORTRAN_TEST_DRV_ARGS
+
+    # The -g debug line-information step is compiled in only for builds with
+    # runtime stacktrace support. Probe with the real tools first: if the
+    # sidecar file appears, this build takes the -g step, so the negative
+    # test below applies; otherwise skip (e.g. such a build, or missing
+    # llvm tools/python here).
+    if command -v llvm-dwarfdump > /dev/null 2>&1 && command -v cc > /dev/null 2>&1; then
+        cd $(mktemp -d)
+        $FC $f -o g_probe.out -g 2> /dev/null || true
+        if [ -f g_probe_lines.dat ]; then
+            cd $(mktemp -d)
+            echo "Testing -g warns and continues when LLVM tools are not in PATH"
+            # Run lfortran with a PATH that only contains the compiler
+            # itself (a symlinked copy, so tool directories living next to
+            # it do not leak in) and an absolute-path driver, so only the
+            # optional llvm-dwarfdump/dsymutil step is missing.
+            ln -s "$(command -v $FC)" drvbin_lfortran
+            mkdir -p onlybin && mv drvbin_lfortran onlybin/lfortran
+            real_cc="$(command -v cc)"
+            if ! PATH="$(pwd)/onlybin" LFORTRAN_LINKER="$real_cc" lfortran $f -o a.out -g 2> g_warn_err.txt; then
+                echo "Expected -g to succeed when llvm-dwarfdump is missing"
+                cat g_warn_err.txt
+                exit 1
+            fi
+            grep "continuing without it" g_warn_err.txt
+            [ ! -f a_ldd.txt ]
+            [ ! -f a_lines.dat ]
+            [ ! -d a.out.dSYM ]
+            [ -x "a.out" ]
+            ./a.out
+        fi
+    fi
 fi
 
 echo "All tests succeeded"

--- a/test_lfortran_cmdline
+++ b/test_lfortran_cmdline
@@ -115,4 +115,22 @@ cd $(mktemp -d)
 echo "Testing invalid command-line usage"
 ! $FC -invalidflag $f1 2>&1 | grep "unrecognized command line option"
 
+if [[ $FC == "lfortran" ]]; then
+    cd $(mktemp -d)
+    echo "Testing explicit linker override via LFORTRAN_LINKER"
+    LFORTRAN_LINKER=cc $FC $f -o a.out
+    [ -x "a.out" ]
+    ./a.out
+
+    cd $(mktemp -d)
+    echo "Testing explicit error when no C compiler driver is available"
+    mkdir bin
+    ln -s "$(command -v lfortran)" bin/lfortran
+    if PATH="$(pwd)/bin" lfortran $f -o a.out 2> no_driver_err.txt; then
+        echo "Expected failure when no C compiler driver is in PATH"
+        exit 1
+    fi
+    grep "No C compiler driver found" no_driver_err.txt
+fi
+
 echo "All tests succeeded"

--- a/test_lfortran_cmdline
+++ b/test_lfortran_cmdline
@@ -176,33 +176,35 @@ EOF
     # The -g debug line-information step is compiled in only for builds with
     # runtime stacktrace support. Probe with the real tools first: if the
     # sidecar file appears, this build takes the -g step, so the negative
-    # test below applies; otherwise skip (e.g. such a build, or missing
-    # llvm tools/python here).
-    if command -v llvm-dwarfdump > /dev/null 2>&1 && command -v cc > /dev/null 2>&1; then
+    # test below applies; otherwise skip (no such build, or llvm tools and
+    # python missing here).
+    cd $(mktemp -d)
+    $FC $f -o g_probe.out -g 2> /dev/null || true
+    if [ -f g_probe_lines.dat ]; then
         cd $(mktemp -d)
-        $FC $f -o g_probe.out -g 2> /dev/null || true
-        if [ -f g_probe_lines.dat ]; then
-            cd $(mktemp -d)
-            echo "Testing -g warns and continues when LLVM tools are not in PATH"
-            # Run lfortran with a PATH that only contains the compiler
-            # itself (a symlinked copy, so tool directories living next to
-            # it do not leak in) and an absolute-path driver, so only the
-            # optional llvm-dwarfdump/dsymutil step is missing.
-            ln -s "$(command -v $FC)" drvbin_lfortran
-            mkdir -p onlybin && mv drvbin_lfortran onlybin/lfortran
-            real_cc="$(command -v cc)"
-            if ! PATH="$(pwd)/onlybin" LFORTRAN_LINKER="$real_cc" lfortran $f -o a.out -g 2> g_warn_err.txt; then
-                echo "Expected -g to succeed when llvm-dwarfdump is missing"
-                cat g_warn_err.txt
-                exit 1
-            fi
-            grep "continuing without it" g_warn_err.txt
-            [ ! -f a_ldd.txt ]
-            [ ! -f a_lines.dat ]
-            [ ! -d a.out.dSYM ]
-            [ -x "a.out" ]
-            ./a.out
+        echo "Testing -g warns and continues when llvm-dwarfdump fails"
+        # Shadow llvm-dwarfdump with a failing stub instead of stripping
+        # $PATH: gcc's collect2 resolves `ld` through $PATH, so a minimal
+        # PATH breaks the final link itself; the stub keeps the link (and
+        # on macOS the real dsymutil, so the .dSYM cleanup is exercised
+        # too) while making only the optional step fail.
+        mkdir shadowbin
+        cat > shadowbin/llvm-dwarfdump <<'EOF'
+#!/bin/sh
+exit 127
+EOF
+        chmod +x shadowbin/llvm-dwarfdump
+        if ! PATH="$(pwd)/shadowbin:$PATH" $FC $f -o a.out -g 2> g_warn_err.txt; then
+            echo "Expected -g to succeed when llvm-dwarfdump fails"
+            cat g_warn_err.txt
+            exit 1
         fi
+        grep "continuing without it" g_warn_err.txt
+        [ ! -f a_ldd.txt ]
+        [ ! -f a_lines.dat ]
+        [ ! -d a.out.dSYM ]
+        [ -x "a.out" ]
+        ./a.out
     fi
 fi
 


### PR DESCRIPTION
Instead of defaulting to the literal `clang` driver, LFortran now uses a fixed
per-platform default C compiler driver for the final link (`clang` on macOS,
`cc` on Linux and other Unix systems, `gcc` on Windows MinGW targets) and never
scans `$PATH` itself on every invocation. Selection order: `--linker` >
`LFORTRAN_LINKER` > platform default.

The objects emitted by LFortran's LLVM codegen can be linked by any standard
C compiler driver — there is no clang-specific ABI coupling. This removes the
hard clang dependency that forced conda-forge to add clang to lfortran's run
requirements (conda-forge/lfortran-feedstock#141).

`--linker`/`LFORTRAN_LINKER` values are tokenized (e.g.
`LFORTRAN_LINKER="ccache clang"`), and clang-only steps (Metal's Objective-C
runtime, `-target`) are detected from the driver program
name — any token starting with `clang`, or `cc` on macOS — not from incidental
"clang" substrings in a `--linker-path` directory. An explicit `--linker-path`
is verified up front with a clear error; a missing default driver is reported
precisely via the shell's 127 exit. The `-g` debug line-information step no
longer probes `$PATH`: it warns, removes partial outputs, and continues when
LLVM/Python tools are absent. Metal keeps its clang requirement with a clear
error.

Refs #12616 (first stage; lld self-sufficiency is a follow-up PR).

The OpenMP link flag `-lomp` is deliberately not gated on the driver: it is
resolved from the `--openmp-lib-dir` the user (or the llvm_omp test backend) passes,
which any link driver can consume; gating it broke the `llvm_omp` CI backend on Linux
(`undefined reference to 'omp_get_thread_num'` and similar).
