### PR TITLE
ci: pin the WASM host environment

### DIFF
--- a/environment-wasm-host.yml
+++ b/environment-wasm-host.yml
@@ -3,7 +3,7 @@ channels:
   - https://prefix.dev/emscripten-forge-4x
   - https://prefix.dev/conda-forge
 dependencies:
-  - xeus-lite
-  - xeus
-  - nlohmann_json
-  - llvm
+  - xeus-lite==5.0.0
+  - xeus==6.0.5
+  - nlohmann_json==3.12.0
+  - llvm==22.1.8


### PR DESCRIPTION
## Summary

`environment-wasm-host.yml` listed all four of its dependencies with no
versions. The environment is resolved fresh on every CI run, so an upload to
emscripten-forge changes the WASM toolchain with no commit to point at.

That happened today. emscripten-forge published `llvm 23.1.0`, and
**Build xlfortran JupyterLite kernel and run tests** began failing on every
pull request, including ones nowhere near codegen — for example #12631
("Get Formal Metal offloading working"), which fails with 171 occurrences of
`does not have terminator`. The last passing run of that job (#12279, finished
2026-08-29T23:27Z) resolved `llvm 22.1.8`.

The kernel emits malformed IR against llvm 23, so almost every
`FortranEvaluator` doctest fails — 50 of 54 test cases.

## Change

Pin all four dependencies to what that last passing run resolved:

| package | version |
| --- | --- |
| `llvm` | 22.1.8 |
| `xeus` | 6.0.5 |
| `xeus-lite` | 5.0.0 |
| `nlohmann_json` | 3.12.0 |

This uses the `==` style already applied to `emscripten_emscripten-wasm32` in
`environment-wasm-build.yml`. Bumping the toolchain becomes a reviewable,
revertable commit instead of something that happens on its own.

## Scope

This stops the build from breaking by itself. It does **not** make the kernel
work with llvm 23 — that is a separate change, and worth its own issue, since
llvm 23 will need to be adopted eventually.

## Verification

`micromamba create -f environment-wasm-host.yml --platform=emscripten-wasm32
--dry-run` resolves to exactly the package set of the last passing CI run:

```
+ emscripten-abi       4.0.9  h267e887_9  prefix.dev/emscripten-forge-4x
+ llvm                22.1.8  hd68d874_0  prefix.dev/emscripten-forge-4x
+ nlohmann_json       3.12.0  h0b0027f_0  prefix.dev/emscripten-forge-4x
+ nlohmann_json-abi   3.12.0  h0f90c79_2  prefix.dev/conda-forge
+ xeus                 6.0.5  h0b0027f_0  prefix.dev/emscripten-forge-4x
+ xeus-lite            5.0.0  h0b0027f_0  prefix.dev/emscripten-forge-4x
```

The JupyterLite CI job on this PR is the real check.
