### PR TITLE
Give repeated ENTRY body copies their own labels

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4022,6 +4022,7 @@ RUN(NAME entry_18 LABELS gfortran llvm EXTRA_ARGS --implicit-typing --implicit-i
 RUN(NAME entry_19 LABELS gfortran llvm)
 RUN(NAME entry_20 LABELS gfortran llvm)
 RUN(NAME entry_21 LABELS gfortran llvm)
+RUN(NAME entry_22 LABELS gfortran llvm)
 
 RUN(NAME character_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME character_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/entry_22.f90
+++ b/integration_tests/entry_22.f90
@@ -1,0 +1,47 @@
+! Test that a statement label inside the part of a subprogram that is shared
+! between the main entry point and an ENTRY does not confuse code generation.
+! The body after the ENTRY is emitted once per entry point, so the label is
+! defined more than once.
+program entry_22
+    implicit none
+    integer :: r, m(2,2)
+
+    call sub(3, r)
+    if (r /= 12) error stop
+    call ent(4, r)
+    if (r /= 20) error stop
+
+    m = reshape([1, 2, 3, 4], [2, 2])
+    call sn510(2, m, r)
+    if (r /= 10) error stop
+    call en856(2, m, r)
+    if (r /= 10) error stop
+
+    print *, "OK"
+end program
+
+subroutine sub(n, r)
+    implicit none
+    integer :: n, r, i
+    entry ent(n, r)
+    r = 0
+    do 10 i = 1, n
+        r = r + i
+10  continue
+    if (r > 0) go to 20
+    r = -1
+20  r = r * 2
+end subroutine
+
+! A labeled DO loop whose terminating statement is not CONTINUE, nested in an
+! unlabeled DO loop, reachable from two entry points.
+subroutine sn510(n, a, r)
+    implicit none
+    integer :: n, r, a(2,2), i, j
+    entry en856(n, a, r)
+    r = 0
+    do i = 1, n
+    do 70020 j = 1, n
+70020 r = r + a(i,j)
+    end do
+end subroutine

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -5772,6 +5772,84 @@ public:
         }
     }
 
+    // A subprogram with ENTRY points is lowered into one master procedure whose
+    // body holds several overlapping copies of the original body: one starting
+    // at the main entry point and one starting at each ENTRY.  A user statement
+    // label that lands in more than one copy would be defined more than once,
+    // while the backends create exactly one basic block per label id.  Keep the
+    // id in the first copy that defines it -- branches from anywhere else still
+    // reach that copy, which is what the backends did before -- and give the
+    // later copies fresh ids so that each of them branches within itself.
+    //
+    // `copies` lists, in body order, the half-open ranges each copy occupies in
+    // `stmts` and in `trailing_stmts`.
+    void renumber_repeated_entry_labels(std::vector<ASR::stmt_t*> &stmts,
+            std::vector<ASR::stmt_t*> &trailing_stmts,
+            const std::vector<std::pair<std::pair<size_t, size_t>,
+                                        std::pair<size_t, size_t>>> &copies) {
+        class LabelVisitor : public ASR::BaseWalkVisitor<LabelVisitor> {
+            public:
+            enum Mode { FindMax, CollectTargets, Rewrite };
+            Allocator &al;
+            Mode mode = FindMax;
+            int64_t next_label = 0;
+            std::set<int64_t> claimed;
+            std::map<int64_t, int64_t> remap;
+
+            LabelVisitor(Allocator &al_) : al(al_) {}
+
+            void visit_GoToTarget(const ASR::GoToTarget_t &x) {
+                ASR::GoToTarget_t *t = const_cast<ASR::GoToTarget_t*>(&x);
+                if (mode == CollectTargets) {
+                    if (!claimed.insert(t->m_id).second
+                            && remap.find(t->m_id) == remap.end()) {
+                        remap[t->m_id] = ++next_label;
+                    }
+                } else {
+                    rewrite(t->m_id, t->m_name);
+                }
+            }
+
+            void visit_GoTo(const ASR::GoTo_t &x) {
+                ASR::GoTo_t *g = const_cast<ASR::GoTo_t*>(&x);
+                if (mode != CollectTargets) {
+                    rewrite(g->m_target_id, g->m_name);
+                }
+            }
+
+            void rewrite(int64_t &id, char *&name) {
+                if (mode == FindMax) {
+                    next_label = std::max(next_label, id);
+                    return;
+                }
+                auto it = remap.find(id);
+                if (it != remap.end()) {
+                    id = it->second;
+                    name = s2c(al, std::to_string(it->second));
+                }
+            }
+        };
+
+        LabelVisitor v(al);
+        for (auto &s: stmts) v.visit_stmt(*s);
+        for (auto &s: trailing_stmts) v.visit_stmt(*s);
+
+        for (auto &copy: copies) {
+            v.remap.clear();
+            for (LabelVisitor::Mode mode: {LabelVisitor::CollectTargets,
+                    LabelVisitor::Rewrite}) {
+                if (mode == LabelVisitor::Rewrite && v.remap.empty()) break;
+                v.mode = mode;
+                for (size_t i = copy.first.first; i < copy.first.second; i++) {
+                    v.visit_stmt(*stmts[i]);
+                }
+                for (size_t i = copy.second.first; i < copy.second.second; i++) {
+                    v.visit_stmt(*trailing_stmts[i]);
+                }
+            }
+        }
+    }
+
     template <typename T>
     void populate_master_function(const T& x, const Location &loc, std::string master_function_name) {
         // populate master function
@@ -5819,7 +5897,14 @@ public:
         current_body = &master_function_body;
         SymbolTable* old_scope = current_scope;
         current_scope = master_function->m_symtab;
+        // Record where each copy of the body starts and ends, so that statement
+        // labels repeated across copies can be told apart afterwards.
+        std::vector<std::pair<std::pair<size_t, size_t>, std::pair<size_t, size_t>>> copies;
+        size_t stmt_start = stmt_vector.size();
+        size_t trailing_start = after_return_stmt_entry_function.size();
         visit_stmts_helper(subroutine_stmt_vector, stmt_vector, original_function_name, master_function->m_return_var, after_return_stmt_entry_function, false, true);
+        copies.push_back({{stmt_start, stmt_vector.size()},
+            {trailing_start, after_return_stmt_entry_function.size()}});
 
         // handle entry functions
         for (auto &it: entry_functions[original_function_name]) {
@@ -5827,8 +5912,13 @@ public:
             stmt_vector.push_back(go_to_target_stmt); go_to_target++;
             // check if it is last entry function
             bool is_last = it.first == entry_functions[original_function_name].rbegin()->first;
+            stmt_start = stmt_vector.size();
+            trailing_start = after_return_stmt_entry_function.size();
             visit_stmts_helper(it.second, stmt_vector, original_function_name, master_function->m_return_var, after_return_stmt_entry_function, is_last);
+            copies.push_back({{stmt_start, stmt_vector.size()},
+                {trailing_start, after_return_stmt_entry_function.size()}});
         }
+        renumber_repeated_entry_labels(stmt_vector, after_return_stmt_entry_function, copies);
         for (auto &it: stmt_vector) {
             master_function_body.push_back(al, it);
         }


### PR DESCRIPTION
## Summary

Fixes #12561.

A subprogram with `ENTRY` points is lowered into a single master procedure whose body holds one copy of the original body per entry point. Because an `ENTRY`'s copy is a suffix of the main copy, a user statement label that falls after the `ENTRY` is emitted once per copy — while the backends create exactly one basic block per label id. The block was therefore started again after it had already been terminated, and LLVM rejected the module:

```
asr_to_llvm: module failed verification. Error:
Terminator found in the middle of a basic block!
label %goto_target14
```

The fix keeps the label id in the first copy that defines it — so branches from the other copies still reach the same block the backends picked before, which is what makes `entry_12`/`entry_13` (where the main copy branches to a label that only the `ENTRY`'s copy defines) keep working — and renumbers the label in the later copies so that each copy branches within itself.

## Scope

- `src/lfortran/semantics/ast_body_visitor.cpp`: record the statement range each body copy occupies in `populate_master_function`, then renumber labels that are repeated across copies.
- `integration_tests/entry_22.f90`: new test.

## Verification

The reduced reproducer, and the code from the issue verbatim:

```console
$ lfortran integration_tests/entry_22.f90 -o a.out && ./a.out
OK
$ lfortran --implicit-typing --implicit-interface entry01.f -o a.out && ./a.out
iret = 10 pass          # matches gfortran and flang
```

`integration_tests/entry_22.f90` fails to compile on `main` with the error above and passes on this branch. Locally, on macOS/arm64:

- `integration_tests/run_tests.py -j16`: `100% tests passed, 0 tests failed out of 3924`
- `./run_tests.py`: `TESTS PASSED` (no reference output changed)
- `ctest`: `100% tests passed, 0 tests failed out of 16`

## Note

While reducing this I found a **separate, pre-existing** bug in the same lowering that is not addressed here: control flow falls out of one body copy into the next instead of returning, so

```fortran
subroutine sub(r)
integer :: r
r = 1
entry ent(r)
r = r + 10
end subroutine
```

called as `sub` gives `21` instead of `11` (the main copy runs `r = r + 10`, then falls into the `ENTRY`'s copy and runs it again). That reproduces on `main` today, needs no statement labels, and is unrelated to the label duplication fixed here, so it belongs in its own issue and PR.