### PR TITLE
Add `-s` option to forward Emscripten settings to the `emcc` link

### DIFF
--- a/doc/man/lfortran.md
+++ b/doc/man/lfortran.md
@@ -68,6 +68,7 @@ LFortran is a modern interactive Fortran compiler based on LLVM.
 - `--continue-compilation`: Collect error messages and continue compilation after encountering semantic errors
 - `--error-format TEXT=human`: Control how errors are produced (human, short)
 - `--backend TEXT=llvm`: Select a backend (llvm, cpp, x86, wasm, fortran)
+- `-s TEXT`: Pass an Emscripten -s setting to the LLVM->WASM (emscripten) link, repeatable, e.g. -sMODULARIZE -sEXPORT_ES6
 - `--device-compiler TEXT=nvcc`: Toolchain driver used to compile and link GPU device code
 - `--openmp`: Enable OpenMP
 - `--separate-compilation`: Generate object code into .o files

--- a/doc/src/usage.md
+++ b/doc/src/usage.md
@@ -198,6 +198,31 @@ compilation options, output options, link options and so on.
 * `-o <value>`, Specify the file to place the compiler's output into
 * `--static`, Create a static executable
 
+### WebAssembly output
+
+Linking for `--target=wasm32-wasi` needs a WASI SDK (`WASI_SDK_PATH`).
+Linking for `--target=wasm32-unknown-emscripten` needs an `emcc` driver:
+it is found via `LFORTRAN_EMCC` (explicitly), an emsdk checkout in
+`EMSDK_PATH`, or plain `emcc` from `$PATH` (Homebrew or apt installs work).
+The same lookup is used at LFortran build time, but only when WASM target
+support is enabled (`-DWITH_TARGET_WASM=yes`): it cross-compiles the
+emscripten runtime object, so such a build needs one of the `emcc` locations
+above or `WASI_SDK_PATH` (a normal native build needs neither).
+
+LFortran passes fixed Emscripten settings to `emcc`
+(`-sSTACK_SIZE=50mb -sINITIAL_MEMORY=256mb`). Additional `-s` settings can
+be given with `-s` (repeatable); they are passed to `emcc` after the
+defaults, so they can override them. The `-sKEY=VALUE`, `-s KEY=VALUE` and
+`-s=KEY=VALUE` spellings are equivalent; settings are only applied for
+`--target=wasm32-unknown-emscripten` with the LLVM-based link (otherwise
+LFortran warns and ignores them). Example — produce an ES module that
+exports a factory function, as needed when running in a browser worker:
+
+```sh
+lfortran --target=wasm32-unknown-emscripten app.f -o app.mjs \
+    -sMODULARIZE -sEXPORT_ES6
+```
+
 ### Compiler debugging
 
 A number of command-line options select various text outputs useful

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -5091,3 +5091,42 @@ RUN(NAME allocatable_scalar_assign_01 LABELS gfortran llvm)
 RUN(NAME struct_tbp_codegen LABELS gfortran llvm c)
 RUN(NAME decl_order_01 LABELS gfortran llvm)
 RUN(NAME decl_order_02 LABELS gfortran llvm)
+# Compiles with GFortran only; the llvm_wasm_emcc check below runs it with
+# LFortran and an emcc link (see #12603).
+RUN(NAME emscripten_modularize_01 LABELS gfortran)
+
+# Emscripten -s settings are forwarded to the emcc link (see #12603):
+# -sMODULARIZE -sEXPORT_ES6 turns the output into an ES module exporting a
+# factory; the loader runs it under node to verify main() executed.
+# The -s flags come before the source file on purpose: that is the argument
+# order from the issue, which a greedy option parser could silently break.
+# -s=STACK_SIZE=64mb covers the `-s=KEY=VALUE` spelling (raw emcc silently
+# ignores it at link time unless the driver normalizes it); the loader then
+# checks the baked value differs from the 50mb default.
+if (LFORTRAN_BACKEND STREQUAL "llvm_wasm_emcc")
+    find_program(WASM_EXEC_RUNTIME node)
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/emscripten_modularize_01.mjs
+        COMMAND ${CMAKE_Fortran_COMPILER} --target=wasm32-unknown-emscripten
+            -sMODULARIZE -sEXPORT_ES6 -s=STACK_SIZE=64mb
+            ${CMAKE_CURRENT_SOURCE_DIR}/emscripten_modularize_01.f90
+            -o ${CMAKE_CURRENT_BINARY_DIR}/emscripten_modularize_01.mjs
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/emscripten_modularize_01.f90
+    )
+    # The target must keep the test's name: `run_tests.py -t <name>` runs
+    # `make <name>`. The RUN(gfortran) registration above never creates a
+    # target under this backend, so the name is free here.
+    add_custom_target(emscripten_modularize_01 ALL
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/emscripten_modularize_01.mjs)
+    if (WASM_EXEC_RUNTIME)
+        add_test(NAME emscripten_modularize_01
+            COMMAND ${WASM_EXEC_RUNTIME}
+                ${CMAKE_CURRENT_SOURCE_DIR}/emscripten_modularize_01_loader.mjs
+                ${CMAKE_CURRENT_BINARY_DIR}/emscripten_modularize_01.mjs)
+        set_tests_properties(emscripten_modularize_01 PROPERTIES
+            LABELS "llvm_wasm_emcc")
+    else()
+        message(WARNING "node not found: emscripten_modularize_01 will be "
+            "compiled but not run")
+    endif()
+endif()

--- a/integration_tests/emscripten_modularize_01.f90
+++ b/integration_tests/emscripten_modularize_01.f90
@@ -1,0 +1,9 @@
+program emscripten_modularize_01
+    integer :: i, s
+    s = 0
+    do i = 1, 10
+        s = s + i
+    end do
+    if (s /= 55) error stop
+    print *, "PASS"
+end program

--- a/integration_tests/emscripten_modularize_01_loader.mjs
+++ b/integration_tests/emscripten_modularize_01_loader.mjs
@@ -1,0 +1,24 @@
+// Run an `-sMODULARIZE -sEXPORT_ES6` build (see #12603): call the exported
+// module factory; main() runs at startup, so an `error stop` fails the test
+// with a non-zero exit code. Assert the expected stdout as well, so a
+// toolchain that stops invoking main() at factory call cannot pass silently.
+// Finally assert the STACK_SIZE=64mb sentinel, proving the `-s=KEY=VALUE`
+// spelling reached emcc instead of being silently ignored.
+// Usage: node loader.mjs <module.mjs>.
+import { readFile } from "node:fs/promises";
+let out = "";
+const write = process.stdout.write.bind(process.stdout);
+process.stdout.write = (chunk, ...args) => { out += String(chunk); return write(chunk, ...args); };
+const url = new URL(process.argv[2], `file://${process.cwd()}/`);
+const { default: createModule } = await import(url.href);
+await createModule();
+process.stdout.write = write;
+if (!out.includes("PASS")) {
+    console.error("error: main() did not produce the expected output");
+    process.exit(1);
+}
+const moduleText = await readFile(url, "utf8");
+if (!moduleText.includes("67108864")) {
+    console.error("error: -s=STACK_SIZE=64mb was not applied");
+    process.exit(1);
+}

--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2040,6 +2040,13 @@ int link_executable(const std::vector<std::string> &infiles,
 #endif
     std::vector<std::string> mlir_temp_object_files;
 
+    if (!compiler_options.emcc_settings.empty()
+            && ((backend != Backend::llvm && backend != Backend::mlir)
+                || !LCompilers::endswith(t, "emscripten"))) {
+        std::cerr << "warning: -s Emscripten settings are only used when "
+            "linking with --target=wasm32-unknown-emscripten" << std::endl;
+    }
+
     size_t dot_index = outfile.find_last_of(".");
     std::string file_name = outfile.substr(0, dot_index);
     std::string extra_linker_flags;
@@ -2085,15 +2092,41 @@ int link_executable(const std::vector<std::string> &infiles,
                 runtime_lib = "lfortran_runtime_wasm_wasi.o";
                 compile_cmd = CC + options + " -o " + outfile + " ";
             } else if (LCompilers::endswith(t, "emscripten")) {
-                char* emsdk_path = std::getenv("EMSDK_PATH");
-                if (emsdk_path == nullptr) {
-                    std::cerr << "EMSDK_PATH must be defined to use llvm->wasm\n";
-                    return 11;
+                // Locate the emcc driver: an explicit LFORTRAN_EMCC wins,
+                // then the emsdk checkout layout from EMSDK_PATH, and
+                // otherwise plain `emcc` from $PATH (Homebrew, apt, pip),
+                // which the shell resolves for us when the command runs.
+                char *env_emcc = std::getenv("LFORTRAN_EMCC");
+                char *emsdk_path = std::getenv("EMSDK_PATH");
+                if (env_emcc != nullptr && env_emcc[0] != '\0') {
+                    CC = env_emcc;
+                } else if (emsdk_path != nullptr && emsdk_path[0] != '\0') {
+                    CC = std::string(emsdk_path) + "/upstream/emscripten/emcc";
+                } else {
+                    CC = "emcc";
                 }
-                CC = std::string(emsdk_path) + "/upstream/emscripten/emcc";
                 options = " --target=wasm32-unknown-emscripten -sSTACK_SIZE=50mb -sINITIAL_MEMORY=256mb";
                 if (!compiler_options.emcc_embed.empty()) {
                     options += " --embed-file " + compiler_options.emcc_embed;
+                }
+                // User-supplied -s settings are appended last so that they
+                // override the defaults above (emcc applies settings left to
+                // right); tolerate the full `-sFOO` spelling as a value and
+                // normalize the `-s=FOO` spelling, which emcc would otherwise
+                // silently ignore.
+                for (auto &s : compiler_options.emcc_settings) {
+                    std::string setting = s;
+                    if (!setting.empty() && setting.front() == '=') {
+                        setting.erase(0, 1);
+                    }
+                    if (setting.empty()) {
+                        continue;
+                    }
+                    if (LCompilers::startswith(setting, "-s")) {
+                        options += " " + setting;
+                    } else {
+                        options += " -s" + setting;
+                    }
                 }
                 runtime_lib = "lfortran_runtime_wasm_emcc.o";
                 compile_cmd = CC + options + " -o " + outfile +

--- a/src/bin/lfortran_command_line_parser.cpp
+++ b/src/bin/lfortran_command_line_parser.cpp
@@ -349,6 +349,7 @@ namespace LCompilers::CommandLineInterface {
         app.add_flag("--print-c-include-dir", opts.print_c_include_dir, "Print the directory containing ISO_Fortran_binding.h")->group(group_backend_codegen_options);
         app.add_flag("--wasm-html", compiler_options.wasm_html, "Generate HTML file using emscripten for LLVM->WASM")->group(group_backend_codegen_options);
         app.add_option("--emcc-embed", compiler_options.emcc_embed, "Embed a given file/directory using emscripten for LLVM->WASM")->group(group_backend_codegen_options);
+        app.add_option("-s", compiler_options.emcc_settings, "Pass an Emscripten -s setting (repeatable, e.g. -sMODULARIZE -sEXPORT_ES6) to the LLVM->WASM (emscripten) link")->allow_extra_args(false)->group(group_backend_codegen_options);
         app.add_flag("--mlir-gpu-offloading", compiler_options.po.enable_gpu_offloading, "Enables gpu offloading using MLIR backend")->group(group_backend_codegen_options);
         app.add_option("--gpu", compiler_options.gpu_backend, "Enable GPU offloading for do concurrent (metal)")->capture_default_str()->group(group_backend_codegen_options);
         app.add_option("--device-compiler", compiler_options.device_compiler, "Toolchain driver used to compile and link GPU device code")->capture_default_str()->group(group_backend_codegen_options);

--- a/src/libasr/utils.h
+++ b/src/libasr/utils.h
@@ -166,6 +166,7 @@ struct CompilerOptions {
     bool time_report = false;
     int32_t fpe_traps = 0; // Bitmask of LCOMPILERS_FE_* flags
     std::string emcc_embed;
+    std::vector<std::string> emcc_settings; // -s Emscripten settings
     std::vector<std::string> import_paths;
     Platform platform;
     bool detect_leaks = false;

--- a/src/runtime/legacy/CMakeLists.txt
+++ b/src/runtime/legacy/CMakeLists.txt
@@ -34,16 +34,32 @@ set_target_properties(lfortran_runtime_static PROPERTIES
 
 if(WITH_TARGET_WASM)
 
-    if ((NOT (DEFINED ENV{EMSDK_PATH})) AND (NOT (DEFINED ENV{WASI_SDK_PATH})))
-        message(FATAL_ERROR "Atleast one of `EMSDK_PATH` or `WASI_SDK_PATH` must be available to target `WASM`")
+    # Locate the emcc driver for the emscripten runtime object, using the
+    # same precedence as the lfortran link step: an explicit LFORTRAN_EMCC,
+    # then the emsdk checkout layout from EMSDK_PATH, then plain `emcc`
+    # from $PATH (Homebrew, apt, pip installs).
+    set(LFORTRAN_EMCC_CANDIDATE "")
+    if (DEFINED ENV{LFORTRAN_EMCC} AND NOT "$ENV{LFORTRAN_EMCC}" STREQUAL "")
+        set(LFORTRAN_EMCC_CANDIDATE "$ENV{LFORTRAN_EMCC}")
+    elseif (DEFINED ENV{EMSDK_PATH} AND NOT "$ENV{EMSDK_PATH}" STREQUAL "")
+        set(LFORTRAN_EMCC_CANDIDATE "$ENV{EMSDK_PATH}/upstream/emscripten/emcc")
+    else()
+        find_program(EMCC_FROM_PATH emcc)
+        if (EMCC_FROM_PATH)
+            set(LFORTRAN_EMCC_CANDIDATE "${EMCC_FROM_PATH}")
+        endif()
     endif()
 
-    if (DEFINED ENV{EMSDK_PATH})
+    if ((NOT LFORTRAN_EMCC_CANDIDATE) AND (NOT (DEFINED ENV{WASI_SDK_PATH})))
+        message(FATAL_ERROR "At least one of `emcc` (via LFORTRAN_EMCC, EMSDK_PATH or PATH) or `WASI_SDK_PATH` must be available to target `WASM`")
+    endif()
+
+    if (LFORTRAN_EMCC_CANDIDATE)
         add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_emcc.o
-            COMMAND $ENV{EMSDK_PATH}/upstream/emscripten/emcc -I${libasr_SOURCE_DIR}/.. -DCOMPILE_TO_WASM
+            COMMAND ${LFORTRAN_EMCC_CANDIDATE} -I${libasr_SOURCE_DIR}/.. -I${libasr_BINARY_DIR}/.. -DCOMPILE_TO_WASM
                 -c --target=wasm32-unknown-emscripten ${SRC} -o ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_emcc.o
             COMMENT "Cross compiling lfortran_intrinscs.c to ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_emcc.o"
-            DEPENDS ${SRC})
+            DEPENDS ${SRC} ${libasr_BINARY_DIR}/config.h)
         add_custom_target(lfortran_runtime_wasm_emcc ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_emcc.o)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_emcc.o
             DESTINATION ${CMAKE_INSTALL_LIBDIR})
@@ -53,10 +69,10 @@ if(WITH_TARGET_WASM)
 
     if (DEFINED ENV{WASI_SDK_PATH})
         add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_wasi.o
-            COMMAND $ENV{WASI_SDK_PATH}/bin/clang -I${libasr_SOURCE_DIR}/.. -DCOMPILE_TO_WASM
+            COMMAND $ENV{WASI_SDK_PATH}/bin/clang -I${libasr_SOURCE_DIR}/.. -I${libasr_BINARY_DIR}/.. -DCOMPILE_TO_WASM
                 -D_WASI_EMULATED_PROCESS_CLOCKS -c --target=wasm32-wasi ${SRC} -o ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_wasi.o
             COMMENT "Cross compiling lfortran_intrinscs.c to ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_wasi.o"
-            DEPENDS ${SRC})
+            DEPENDS ${SRC} ${libasr_BINARY_DIR}/config.h)
         add_custom_target(lfortran_runtime_wasm_wasi ALL DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_wasi.o)
         install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/lfortran_runtime_wasm_wasi.o
             DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/test_lfortran_cmdline
+++ b/test_lfortran_cmdline
@@ -115,4 +115,28 @@ cd $(mktemp -d)
 echo "Testing invalid command-line usage"
 ! $FC -invalidflag $f1 2>&1 | grep "unrecognized command line option"
 
+if [[ "$(basename "$FC")" == "lfortran" ]]; then
+    # -s Emscripten settings must not swallow following arguments (#12603):
+    # flags-first order is the one a greedy option parser would break.
+    # On a native target the settings are ignored with a warning - assert
+    # the warning too so an unexpected stderr from elsewhere cannot slip in.
+    cd $(mktemp -d)
+    $FC -sMODULARIZE -sEXPORT_ES6 $f -o a.out 2> s_err.txt
+    [ -f "a.out" ]
+    [ -x "a.out" ]
+    grep "only used when linking with --target=wasm32-unknown-emscripten" s_err.txt
+    ./a.out
+
+    # The space-separated value form (`-s VALUE` immediately before the
+    # source file) is the spelling emcc users write, and precisely the one
+    # `allow_extra_args(false)` protects; without it the parser eats the
+    # file name as a second -s value and drops into the REPL instead.
+    cd $(mktemp -d)
+    $FC -s MODULARIZE $f -o a.out 2> s_err.txt
+    [ -f "a.out" ]
+    [ -x "a.out" ]
+    grep "only used when linking with --target=wasm32-unknown-emscripten" s_err.txt
+    ./a.out
+fi
+
 echo "All tests succeeded"


### PR DESCRIPTION
Fixes #12603

`--target=wasm32-unknown-emscripten` now accepts user-provided Emscripten `-s` settings. This means you can produce a modularized ES module in a single invocation:

```bash
lfortran --target=wasm32-unknown-emscripten -sMODULARIZE -sEXPORT_ES6 app.f -o app.mjs
```

Previously, this required compiling with `lfortran -c` and then invoking `emcc` manually.

This also fixes the `emcc` discovery issue mentioned in #12603. We no longer assume that `emcc` is located at `$EMSDK_PATH/upstream/emscripten/emcc`. It is now looked up in this order:

1. `LFORTRAN_EMCC`
2. `EMSDK_PATH`
3. `emcc` on `$PATH`

This means installations where `emcc` is provided by Homebrew, apt, etc. work as well.

Tested locally with:

```text
./run_tests.py -b llvm_wasm_emcc -t emscripten_modularize_01
```

using emcc 6.0.8 and Node. The gfortran label keeps this as a differential test.

The third commit also fixes out-of-source builds of the wasm runtime object. The in-source CI build was masking a missing include for the generated `libasr/config.h`, so this showed up when trying the same build out of tree.