### PR TITLE
Keep host Blocks when a GPU launch is declined

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -5035,6 +5035,7 @@ RUN(NAME gpu_metal_205 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_206 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_207 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_208 LABELS gfortran llvm metal cuda_cpu)
+RUN(NAME gpu_metal_209 LABELS gfortran llvm metal cuda_cpu)
 
 RUN(NAME gpu_kernel_source_01 LABELS gfortran llvm)
 RUN(NAME gpu_kernel_source_02 LABELS gfortran llvm)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -5034,6 +5034,7 @@ RUN(NAME gpu_metal_204 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_205 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_206 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_207 LABELS gfortran llvm metal cuda_cpu)
+RUN(NAME gpu_metal_208 LABELS gfortran llvm metal cuda_cpu)
 
 RUN(NAME gpu_kernel_source_01 LABELS gfortran llvm)
 RUN(NAME gpu_kernel_source_02 LABELS gfortran llvm)

--- a/integration_tests/gpu_metal_208.f90
+++ b/integration_tests/gpu_metal_208.f90
@@ -1,0 +1,33 @@
+program gpu_metal_208
+! A do concurrent that both contains a block and captures a derived type the
+! device cannot lay out. The offload pass used to move the block into an
+! unattached kernel scope and then decline the launch, leaving the host loop
+! with a BlockCall whose symbol was gone. The loop must stay on the host and
+! still compute the right answer.
+implicit none
+
+type :: label_t
+    character(len=:), allocatable :: name
+    real :: scale
+end type
+
+type(label_t) :: m
+real :: a(8)
+integer :: i
+
+m%name = "scale by two"
+m%scale = 2.0
+
+do concurrent (i = 1:8)
+    block
+        real :: s
+        s = m%scale
+        a(i) = real(i) * s
+    end block
+end do
+
+do i = 1, 8
+    if (abs(a(i) - real(i) * 2.0) > 1e-6) error stop
+end do
+print *, "PASSED"
+end program

--- a/integration_tests/gpu_metal_209.f90
+++ b/integration_tests/gpu_metal_209.f90
@@ -1,0 +1,34 @@
+program gpu_metal_209
+! Nested BLOCK inside a do concurrent that captures a derived type the device
+! cannot lay out. The inner block reads an outer-block local. A declined
+! launch used to restore a snapshot whose inner Vars still pointed at the
+! original Block, which had been moved into an unattached kernel scope.
+implicit none
+
+type :: label_t
+    character(len=:), allocatable :: name
+    real :: scale
+end type
+
+type(label_t) :: m
+real :: a(8)
+integer :: i
+
+m%name = "scale by two"
+m%scale = 2.0
+
+do concurrent (i = 1:8)
+    block
+        real :: s
+        s = m%scale
+        block
+            a(i) = real(i) * s
+        end block
+    end block
+end do
+
+do i = 1, 8
+    if (abs(a(i) - real(i) * 2.0) > 1e-6) error stop
+end do
+print *, "PASSED"
+end program

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4264,7 +4264,8 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
             }
             return ASRUtils::make_Array_t_util(al, tnew->base.base.loc,
                 duplicated_element_type, dimsp, dimsn, ASR::abiType::Source,
-                false, physical_type, override_physical_type);
+                false, physical_type, override_physical_type, false, true,
+                tnew->m_memory_space);
         }
         case ASR::ttypeType::Integer: {
             ASR::Integer_t* tnew = ASR::down_cast<ASR::Integer_t>(t);

--- a/src/libasr/pass/gpu_offload.cpp
+++ b/src/libasr/pass/gpu_offload.cpp
@@ -127,14 +127,24 @@ class GpuReplaceSymbols : public ASR::BaseExprReplacer<GpuReplaceSymbols> {
 public:
     SymbolTable &kernel_scope;
     std::set<SymbolTable*> skip_scopes;
+    // Snapshot restore walks nested Block tables whose parent is the outer
+    // snapshot, not the host. Look up through that chain so an inner Var of
+    // an outer-block local is retargeted at the copy, not left pointing at
+    // the original Block that the kernel path is about to move.
+    bool resolve_through_parents = false;
     GpuReplaceSymbols(SymbolTable &scope) : kernel_scope(scope) {}
+
+    ASR::symbol_t *lookup_symbol(const std::string &name) {
+        return resolve_through_parents ? kernel_scope.resolve_symbol(name)
+                                       : kernel_scope.get_symbol(name);
+    }
 
     void replace_Var(ASR::Var_t *x) {
         std::string name = ASRUtils::symbol_name(x->m_v);
         for (auto *ss : skip_scopes) {
             if (ss->get_symbol(name)) return;
         }
-        ASR::symbol_t *new_sym = kernel_scope.get_symbol(name);
+        ASR::symbol_t *new_sym = lookup_symbol(name);
         if (new_sym) {
             x->m_v = new_sym;
         }
@@ -148,7 +158,7 @@ public:
         current_expr = current_expr_copy;
         // Replace the member symbol to point to kernel scope's ExternalSymbol
         std::string mem_name = ASRUtils::symbol_name(x->m_m);
-        ASR::symbol_t *new_mem = kernel_scope.get_symbol(mem_name);
+        ASR::symbol_t *new_mem = lookup_symbol(mem_name);
         if (new_mem) {
             x->m_m = new_mem;
         }
@@ -157,7 +167,7 @@ public:
     void replace_FunctionCall(ASR::FunctionCall_t *x) {
         // Remap m_name to kernel scope symbol
         std::string name = ASRUtils::symbol_name(x->m_name);
-        ASR::symbol_t *new_sym = kernel_scope.get_symbol(name);
+        ASR::symbol_t *new_sym = lookup_symbol(name);
         if (!new_sym && ASR::is_a<ASR::ExternalSymbol_t>(*x->m_name)) {
             // Try sanitized ExternalSymbol name (handles disambiguated
             // functions where different modules define same-named functions)
@@ -165,14 +175,14 @@ public:
             for (char &c : sanitized) {
                 if (c == '~' || c == '@') c = '_';
             }
-            new_sym = kernel_scope.get_symbol(sanitized);
+            new_sym = lookup_symbol(sanitized);
             if (!new_sym) {
                 // ExternalSymbol name differs from resolved function name;
                 // try the underlying function's name (e.g., "construct"
                 // instead of "~mytype_t@construct").
                 std::string resolved_name = ASRUtils::symbol_name(
                     ASRUtils::symbol_get_past_external(x->m_name));
-                new_sym = kernel_scope.get_symbol(resolved_name);
+                new_sym = lookup_symbol(resolved_name);
             }
         }
         if (new_sym) {
@@ -180,7 +190,7 @@ public:
         }
         if (x->m_original_name) {
             std::string orig_name = ASRUtils::symbol_name(x->m_original_name);
-            ASR::symbol_t *new_orig = kernel_scope.get_symbol(orig_name);
+            ASR::symbol_t *new_orig = lookup_symbol(orig_name);
             if (new_orig) {
                 x->m_original_name = new_orig;
             }
@@ -5164,13 +5174,18 @@ public:
 
         // duplicate_Block copies the symbol table but leaves Var nodes in the
         // body pointing at the original Variables. Point them at the copies
-        // so the kernel owns a self-contained block.
+        // so the restored host block is self-contained. Nested blocks resolve
+        // through the snapshot parent chain: an inner use of an outer-block
+        // local must find the outer copy, not the original that the kernel
+        // path is about to move.
         remap_block_to_own_scope = [&](ASR::Block_t *block) {
             GpuReplaceSymbolsVisitor body_v(*block->m_symtab);
+            body_v.replacer.resolve_through_parents = true;
             for (size_t j = 0; j < block->n_body; j++) {
                 body_v.visit_stmt(*block->m_body[j]);
             }
             GpuReplaceSymbols type_replacer(*block->m_symtab);
+            type_replacer.resolve_through_parents = true;
             for (auto &item : block->m_symtab->get_scope()) {
                 if (ASR::is_a<ASR::Block_t>(*item.second)) {
                     remap_block_to_own_scope(

--- a/src/libasr/pass/gpu_offload.cpp
+++ b/src/libasr/pass/gpu_offload.cpp
@@ -5150,7 +5150,111 @@ public:
             }
         }
 
-        // Move Block symbols referenced by BlockCall into kernel scope.
+        // The kernel mutates Block symbols in place (VLA host capture
+        // depends on that). Snapshot a pristine copy first so a declined
+        // launch can put the host loop back.
+        struct BlockBackup {
+            ASR::Block_t *orig;
+            ASR::symbol_t *pristine;
+            std::string name;
+        };
+        std::vector<BlockBackup> block_backups;
+        std::function<void(ASR::Block_t*)> retarget_block_calls_in;
+        std::function<void(ASR::Block_t*)> remap_block_to_own_scope;
+
+        // duplicate_Block copies the symbol table but leaves Var nodes in the
+        // body pointing at the original Variables. Point them at the copies
+        // so the kernel owns a self-contained block.
+        remap_block_to_own_scope = [&](ASR::Block_t *block) {
+            GpuReplaceSymbolsVisitor body_v(*block->m_symtab);
+            for (size_t j = 0; j < block->n_body; j++) {
+                body_v.visit_stmt(*block->m_body[j]);
+            }
+            GpuReplaceSymbols type_replacer(*block->m_symtab);
+            for (auto &item : block->m_symtab->get_scope()) {
+                if (ASR::is_a<ASR::Block_t>(*item.second)) {
+                    remap_block_to_own_scope(
+                        ASR::down_cast<ASR::Block_t>(item.second));
+                    continue;
+                }
+                if (ASR::is_a<ASR::AssociateBlock_t>(*item.second)) {
+                    ASR::AssociateBlock_t *ab =
+                        ASR::down_cast<ASR::AssociateBlock_t>(item.second);
+                    for (size_t j = 0; j < ab->n_body; j++) {
+                        body_v.visit_stmt(*ab->m_body[j]);
+                    }
+                    continue;
+                }
+                if (!ASR::is_a<ASR::Variable_t>(*item.second)) continue;
+                ASR::Variable_t *var =
+                    ASR::down_cast<ASR::Variable_t>(item.second);
+                if (!ASR::is_a<ASR::Array_t>(*var->m_type)) continue;
+                ASR::Array_t *arr = ASR::down_cast<ASR::Array_t>(var->m_type);
+                for (size_t d = 0; d < arr->n_dims; d++) {
+                    if (arr->m_dims[d].m_start) {
+                        type_replacer.current_expr = &(arr->m_dims[d].m_start);
+                        type_replacer.replace_expr(arr->m_dims[d].m_start);
+                    }
+                    if (arr->m_dims[d].m_length) {
+                        type_replacer.current_expr = &(arr->m_dims[d].m_length);
+                        type_replacer.replace_expr(arr->m_dims[d].m_length);
+                    }
+                }
+            }
+        };
+
+        retarget_block_calls_in = [&](ASR::Block_t *block) {
+            std::function<void(ASR::stmt_t**, size_t)> walk =
+                [&](ASR::stmt_t **stmts, size_t n_stmts) {
+                for (size_t i = 0; i < n_stmts; i++) {
+                    if (ASR::is_a<ASR::BlockCall_t>(*stmts[i])) {
+                        ASR::BlockCall_t *bc =
+                            ASR::down_cast<ASR::BlockCall_t>(stmts[i]);
+                        if (!ASR::is_a<ASR::Block_t>(*bc->m_m)) continue;
+                        ASR::Block_t *inner =
+                            ASR::down_cast<ASR::Block_t>(bc->m_m);
+                        ASR::symbol_t *local =
+                            block->m_symtab->get_symbol(inner->m_name);
+                        if (local && ASR::is_a<ASR::Block_t>(*local)
+                                && local != (ASR::symbol_t*)block) {
+                            bc->m_m = local;
+                            retarget_block_calls_in(
+                                ASR::down_cast<ASR::Block_t>(local));
+                        }
+                        continue;
+                    }
+                    if (ASR::is_a<ASR::DoLoop_t>(*stmts[i])) {
+                        ASR::DoLoop_t *dl =
+                            ASR::down_cast<ASR::DoLoop_t>(stmts[i]);
+                        walk(dl->m_body, dl->n_body);
+                    } else if (ASR::is_a<ASR::If_t>(*stmts[i])) {
+                        ASR::If_t *ifs =
+                            ASR::down_cast<ASR::If_t>(stmts[i]);
+                        walk(ifs->m_body, ifs->n_body);
+                        walk(ifs->m_orelse, ifs->n_orelse);
+                    } else if (ASR::is_a<ASR::WhileLoop_t>(*stmts[i])) {
+                        ASR::WhileLoop_t *wl =
+                            ASR::down_cast<ASR::WhileLoop_t>(stmts[i]);
+                        walk(wl->m_body, wl->n_body);
+                    }
+                }
+            };
+            walk(block->m_body, block->n_body);
+        };
+
+        auto snapshot_block = [&](ASR::Block_t *orig) {
+            for (const BlockBackup &b : block_backups) {
+                if (b.orig == orig) return;
+            }
+            ASRUtils::SymbolDuplicator dup(al);
+            ASR::symbol_t *pristine = dup.duplicate_Block(orig, orig_scope);
+            if (pristine == nullptr) return;
+            ASR::Block_t *p = ASR::down_cast<ASR::Block_t>(pristine);
+            retarget_block_calls_in(p);
+            remap_block_to_own_scope(p);
+            block_backups.push_back({orig, pristine, orig->m_name});
+        };
+
         // This helper processes a block and recursively handles any nested
         // BlockCall statements, since GpuReplaceSymbolsVisitor does not
         // descend into BlockCall/AssociateBlockCall automatically.
@@ -5404,6 +5508,33 @@ public:
                 }
             }
         };
+        std::function<void(ASR::stmt_t**, size_t)> snapshot_blocks =
+            [&](ASR::stmt_t **stmts, size_t n_stmts) {
+            for (size_t i = 0; i < n_stmts; i++) {
+                if (ASR::is_a<ASR::BlockCall_t>(*stmts[i])) {
+                    ASR::BlockCall_t *bc =
+                        ASR::down_cast<ASR::BlockCall_t>(stmts[i]);
+                    if (ASR::is_a<ASR::Block_t>(*bc->m_m)) {
+                        snapshot_block(
+                            ASR::down_cast<ASR::Block_t>(bc->m_m));
+                    }
+                } else if (ASR::is_a<ASR::DoLoop_t>(*stmts[i])) {
+                    ASR::DoLoop_t *dl =
+                        ASR::down_cast<ASR::DoLoop_t>(stmts[i]);
+                    snapshot_blocks(dl->m_body, dl->n_body);
+                } else if (ASR::is_a<ASR::If_t>(*stmts[i])) {
+                    ASR::If_t *ifs =
+                        ASR::down_cast<ASR::If_t>(stmts[i]);
+                    snapshot_blocks(ifs->m_body, ifs->n_body);
+                    snapshot_blocks(ifs->m_orelse, ifs->n_orelse);
+                } else if (ASR::is_a<ASR::WhileLoop_t>(*stmts[i])) {
+                    ASR::WhileLoop_t *wl =
+                        ASR::down_cast<ASR::WhileLoop_t>(stmts[i]);
+                    snapshot_blocks(wl->m_body, wl->n_body);
+                }
+            }
+        };
+        snapshot_blocks(nest.body, nest.n_body);
         move_blocks_to_kernel(body_copy.p, body_copy.n);
 
         // Add copied loop body (already remapped)
@@ -5464,6 +5595,40 @@ public:
                     call_args.p, call_args.n, reason)) {
                 report_not_offloaded(x.base.base.loc,
                     "the gpu backend does not support " + reason);
+                std::function<void(ASR::stmt_t**, size_t)> restore =
+                    [&](ASR::stmt_t **stmts, size_t n_stmts) {
+                    for (size_t i = 0; i < n_stmts; i++) {
+                        if (ASR::is_a<ASR::BlockCall_t>(*stmts[i])) {
+                            ASR::BlockCall_t *bc =
+                                ASR::down_cast<ASR::BlockCall_t>(stmts[i]);
+                            for (const BlockBackup &b : block_backups) {
+                                if (bc->m_m == (ASR::symbol_t*)b.orig) {
+                                    bc->m_m = b.pristine;
+                                    break;
+                                }
+                            }
+                        } else if (ASR::is_a<ASR::DoLoop_t>(*stmts[i])) {
+                            ASR::DoLoop_t *dl =
+                                ASR::down_cast<ASR::DoLoop_t>(stmts[i]);
+                            restore(dl->m_body, dl->n_body);
+                        } else if (ASR::is_a<ASR::If_t>(*stmts[i])) {
+                            ASR::If_t *ifs =
+                                ASR::down_cast<ASR::If_t>(stmts[i]);
+                            restore(ifs->m_body, ifs->n_body);
+                            restore(ifs->m_orelse, ifs->n_orelse);
+                        } else if (ASR::is_a<ASR::WhileLoop_t>(*stmts[i])) {
+                            ASR::WhileLoop_t *wl =
+                                ASR::down_cast<ASR::WhileLoop_t>(stmts[i]);
+                            restore(wl->m_body, wl->n_body);
+                        }
+                    }
+                };
+                restore(nest.body, nest.n_body);
+                for (const BlockBackup &b : block_backups) {
+                    if (!orig_scope->get_symbol(b.name)) {
+                        orig_scope->add_symbol(b.name, b.pristine);
+                    }
+                }
                 return;
             }
         }


### PR DESCRIPTION
Follow-up to #12650. Replaces #12652, which is closed unmerged.

## Summary

A declined GPU kernel launch no longer steals Block symbols from the host loop, nested Block snapshots remap through their parent chain, and `duplicate_type` keeps `memory_space` on Array.

## Scope

- `gpu_offload` snapshots a loop Block before moving it into the kernel. If `gpu_launch_is_supported` rejects the launch, the snapshot is put back in the host scope and the loop's BlockCalls are retargeted at it.
- Snapshot Vars are remapped through the snapshot parent chain, so an inner Block that uses an outer-block local points at the copy, not at the original that was moved into an unattached kernel.
- `duplicate_type` passes `Array.m_memory_space` through `make_Array_t_util`.
- `gpu_metal_208` is a `do concurrent` that both contains a `block` and captures a derived type with an allocatable character component.
- `gpu_metal_209` is the nested case: inner block reads an outer-block local, launch is declined.

## Verification

Debug build (WITH_LFORTRAN_ASSERT, so ASR is verified after every pass):

- `gpu_metal_209` failed before the nested remap (`Var::m_v s cannot point outside of its symbol table`) and passes after, with `--gpu=metal` and `--gpu=cuda_cpu`
- `gpu_metal_209` via `integration_tests/run_tests.py -t gpu_metal_209 -b gfortran llvm metal cuda_cpu`: all passed
- `gpu_metal_208` with `--gpu=metal` and `--gpu=cuda_cpu`: warning, host run, PASSED
- `gpu_metal_197`, `198`, `199` with `--gpu=metal`: still offload and pass
- `gpu_metal_45`, `47` with `--gpu=metal`: still offload and pass
- `gpu_metal_206` with `--gpu=metal`: still declines and passes
- gfortran on `gpu_metal_208` and `gpu_metal_209`: PASSED

## Rationale

#12650's keep-the-loop-on-the-host path built a kernel, moved the original Block into that kernel's table, then returned without installing the kernel. The host BlockCall pointed at a symbol that was no longer in scope. Snapshotting before the move keeps the host tree intact on the way out.

A nested Block's Vars are not in the inner table. Looking up only there left an inner use of an outer-block local pointing at the moved original. Resolving through the snapshot parent chain retargets it at the copy.

`memory_space` is the field that tells Metal which qualifier to emit. A duplicator that drops it puts a device array back in Global.