### PR TITLE
fix: honor reshape order for pointer-array sources in LLVM backend

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -812,6 +812,7 @@ RUN(NAME arrays_reshape_42 LABELS gfortran llvm)
 RUN(NAME arrays_reshape_43 LABELS gfortran llvm)
 RUN(NAME arrays_reshape_44 LABELS gfortran llvm)
 RUN(NAME arrays_reshape_45 LABELS llvm) # gfortran segfaults on reshape () of polymorphic allocatable array
+RUN(NAME arrays_reshape_46 LABELS gfortran llvm)
 RUN(NAME array_reshape_pad_01 LABELS gfortran llvm)
 RUN(NAME arrays_elemental_15 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray fortran)
 RUN(NAME arrays_elemental_16 LABELS gfortran llvm)

--- a/integration_tests/arrays_reshape_46.f90
+++ b/integration_tests/arrays_reshape_46.f90
@@ -1,0 +1,36 @@
+subroutine test_reshape_2d(original, reshaped)
+  implicit none
+  integer, intent(in) :: original(2,2)
+  integer, intent(out) :: reshaped(2,2)
+  reshaped = reshape(original, shape=[2,2], order=[2,1])
+end subroutine test_reshape_2d
+
+subroutine test_reshape_1d(source, reshaped)
+  implicit none
+  integer, intent(in) :: source(4)
+  integer, intent(out) :: reshaped(2,2)
+  reshaped = reshape(source, [2,2], order=[2,1])
+end subroutine test_reshape_1d
+
+program arrays_reshape_46
+    ! Test that the order argument of reshape is honored when the source
+    ! array is a dummy argument (issue #12655).
+    implicit none
+    integer :: original(2,2) = reshape([1, 2, 3, 4], [2,2])
+    integer :: reshaped(2,2)
+
+    ! reshape with order in the main program
+    reshaped = reshape(original, shape=[2,2], order=[2,1])
+    if (sum(abs(reshaped - original)) /= 2) error stop
+
+    ! same reshape inside a subroutine (source is a dummy argument)
+    reshaped = 0
+    call test_reshape_2d(original, reshaped)
+    if (sum(abs(reshaped - original)) /= 2) error stop
+    if (any(reshaped /= reshape([1, 3, 2, 4], [2,2]))) error stop
+
+    ! 1d dummy source
+    reshaped = 0
+    call test_reshape_1d([1, 2, 3, 4], reshaped)
+    if (any(reshaped /= reshape([1, 3, 2, 4], [2,2]))) error stop
+end program arrays_reshape_46

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4931,7 +4931,8 @@ public:
             case ASR::PointerArray: {
                 ASR::array_physical_typeType result_ptype = ASRUtils::extract_physical_type(
                     ASRUtils::expr_type(const_cast<ASR::expr_t*>(&(x.base))));
-                if (result_ptype == ASR::array_physical_typeType::DescriptorArray &&
+                if ((result_ptype == ASR::array_physical_typeType::DescriptorArray ||
+                     x.m_order != nullptr) &&
                     !ASRUtils::is_character(*x_m_array_type)) {
                     ASR::ttype_t* desc_input_type = ASRUtils::duplicate_type(al, x_m_array_type,
                         nullptr, ASR::array_physical_typeType::DescriptorArray, true);
@@ -4964,6 +4965,13 @@ public:
                         shape_type, shape, asr_shape_type, module.get(),
                         const_cast<ASR::expr_t*>(x.m_array), asr_data_type,
                         result_desc_type, order, x.m_order);
+                    // If the result type is not a descriptor, extract the data
+                    // pointer from the descriptor, since the consumer expects
+                    // a raw pointer.
+                    if (result_ptype != ASR::array_physical_typeType::DescriptorArray) {
+                        llvm::Value* data_ptr = arr_descr->get_pointer_to_data(result_desc_type, tmp);
+                        tmp = llvm_utils->CreateLoad2(llvm_data_type->getPointerTo(), data_ptr);
+                    }
                     break;
                 }
                 llvm::Type* type_of_array = llvm_utils->get_type_from_ttype_t_util(


### PR DESCRIPTION
## Summary

Fixes #12655.

`reshape(a, shape, order=[...])` silently ignored the `order` argument whenever the source array `a` was a dummy argument:

```fortran
subroutine s(a)
  integer, intent(in) :: a(4)
  print *, reshape(a, [2,2], order=[2,1])  ! printed 1 2 3 4 instead of 1 3 2 4
end subroutine
```

## Rationale

A dummy argument source has the `PointerArray` physical type. In `visit_ArrayReshape` in `asr_to_llvm.cpp`, the `PointerArray` case only used the descriptor-based `SimpleCMODescriptor::reshape` (which implements `order`) when the result was a `DescriptorArray`; every other result type fell into a fallback that flat-memcpys the source into a fresh allocation, dropping `m_order` on the floor. The `FixedSizeArray` and `DescriptorArray` source cases both handle `order`, which is why the same reshape worked in the main program but not in a subroutine.

The fix routes the `PointerArray` source through the existing descriptor-based reshape whenever `order` is present, and then extracts the raw data pointer when the result is not a descriptor array — mirroring what the `DescriptorArray` source case already does for non-descriptor results.

## Verification

- New integration test `integration_tests/arrays_reshape_46.f90` (labels `gfortran llvm`) covers the issue's MWE plus a 1-D dummy source. Verified it fails on `main` (`ERROR STOP`) and passes on this branch.
- `cd integration_tests && ./run_tests.py -j4`: 3942/3942 passed.
- `./run_tests.py --no-llvm`: TESTS PASSED (LLVM-dump reference tests skipped locally only because the local LLVM 18 emits opaque-pointer IR that differs from the committed references).
- `gfortran` and `lfortran` now produce identical output for the issue's reproducer (`2` / `2`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4GzXmkvEkLbngKFSToBVR)_