### PR TITLE
fix: support NULL() as an actual argument

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4178,6 +4178,7 @@ RUN(NAME optional_10 LABELS gfortran llvm)
 RUN(NAME optional_11 LABELS gfortran llvm)
 RUN(NAME optional_12 LABELS gfortran llvm)
 RUN(NAME optional_13 LABELS gfortran llvm)
+RUN(NAME optional_14 LABELS gfortran llvm)
 RUN(NAME optional_string_arg_01 LABELS gfortran llvm)
 
 RUN(NAME end_name_match LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/optional_14.f90
+++ b/integration_tests/optional_14.f90
@@ -1,0 +1,32 @@
+program optional_14
+! NULL() as an actual argument corresponding to a non-pointer non-allocatable
+! optional dummy argument means the dummy argument is not present (F2018
+! 15.5.2.13). For a pointer dummy argument it is a disassociated pointer.
+implicit none
+integer, pointer :: p => null()
+
+if (init(null()) /= -99) error stop
+if (init(42) /= 42) error stop
+if (init() /= -99) error stop
+
+call check_ptr(null(), .false.)
+call check_ptr(p, .false.)
+
+contains
+
+    integer function init(i)
+    integer, intent(in), optional :: i
+    if (present(i)) then
+        init = i
+    else
+        init = -99
+    end if
+    end function
+
+    subroutine check_ptr(q, expected)
+    integer, pointer, intent(in) :: q
+    logical, intent(in) :: expected
+    if (associated(q) .neqv. expected) error stop
+    end subroutine
+
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -7745,7 +7745,7 @@ public:
         Allocator& al,
         bool& nopass
     ) {
-        visit_expr_list(x.m_args, x.n_args, args);
+        visit_expr_list(x.m_args, x.n_args, args, original_sym, x.n_member);
         ASR::symbol_t* f2 = ASRUtils::symbol_get_past_external(original_sym);
 
         // we handle kwargs here

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -18219,7 +18219,7 @@ public:
             }
             Vec<ASR::call_arg_t> args;
             Vec<ASR::call_arg_t> args_with_mdt;
-            visit_expr_list(x.m_args, x.n_args, args);
+            visit_expr_list(x.m_args, x.n_args, args, f2, x.n_member);
             if (x.n_member >= 1) {
                 args_with_mdt.reserve(al, x.n_args + 1);
                 ASR::call_arg_t v_expr_call_arg;
@@ -21003,11 +21003,78 @@ public:
         (void)iface_type;
     }
 
-    void visit_expr_list(AST::fnarg_t *ast_list, size_t n, Vec<ASR::call_arg_t>& call_args) {
+    // True if `e` is a reference to the intrinsic `NULL()` without a `mold`
+    // argument, whose type therefore has to come from the context it is used in.
+    bool is_bare_null_intrinsic(AST::expr_t* e) {
+        if( !AST::is_a<AST::FuncCallOrArray_t>(*e) ) {
+            return false;
+        }
+        AST::FuncCallOrArray_t* f = AST::down_cast<AST::FuncCallOrArray_t>(e);
+        if( to_lower(f->m_func) != "null" || f->n_args != 0 ||
+            f->n_keywords != 0 || f->n_member != 0 ) {
+            return false;
+        }
+        // `null` may be shadowed by a user defined symbol
+        return current_scope->resolve_symbol("null") == nullptr;
+    }
+
+    // The dummy argument of `proc` that the `i`-th actual argument of a call
+    // corresponds to, or nullptr if it cannot be determined here (for example
+    // for a generic procedure, which is resolved later on).
+    ASR::Variable_t* get_dummy_argument(ASR::symbol_t* proc, size_t i) {
+        if( proc == nullptr ) {
+            return nullptr;
+        }
+        proc = ASRUtils::symbol_get_past_external(proc);
+        if( !ASR::is_a<ASR::Function_t>(*proc) ) {
+            return nullptr;
+        }
+        ASR::Function_t* f = ASR::down_cast<ASR::Function_t>(proc);
+        if( i >= f->n_args || !ASR::is_a<ASR::Var_t>(*f->m_args[i]) ) {
+            return nullptr;
+        }
+        ASR::symbol_t* dummy = ASRUtils::symbol_get_past_external(
+            ASR::down_cast<ASR::Var_t>(f->m_args[i])->m_v);
+        if( !ASR::is_a<ASR::Variable_t>(*dummy) ) {
+            return nullptr;
+        }
+        return ASR::down_cast<ASR::Variable_t>(dummy);
+    }
+
+    // `proc` is the procedure being called (if already resolved) and
+    // `dummy_offset` the number of its leading dummy arguments that `ast_list`
+    // does not supply (the passed object of a type bound call). Both are only
+    // used to give a bare `NULL()` actual argument its meaning.
+    void visit_expr_list(AST::fnarg_t *ast_list, size_t n, Vec<ASR::call_arg_t>& call_args,
+            ASR::symbol_t* proc = nullptr, size_t dummy_offset = 0) {
         call_args.reserve(al, n);
         for (size_t i = 0; i < n; i++) {
             LCOMPILERS_ASSERT(ast_list[i].m_end != nullptr);
+            ASR::Variable_t* null_dummy = nullptr;
+            if( is_bare_null_intrinsic(ast_list[i].m_end) ) {
+                null_dummy = get_dummy_argument(proc, i + dummy_offset);
+            }
+            if( null_dummy != nullptr &&
+                null_dummy->m_presence == ASR::presenceType::Optional &&
+                !ASRUtils::is_pointer(null_dummy->m_type) &&
+                !ASRUtils::is_allocatable(null_dummy->m_type) ) {
+                // F2018 15.5.2.13: a `NULL()` actual argument corresponding to a
+                // non-pointer non-allocatable optional dummy argument means that
+                // the dummy argument is not present.
+                ASR::call_arg_t call_arg;
+                call_arg.loc = ast_list[i].m_end->base.loc;
+                call_arg.m_value = nullptr;
+                call_args.push_back(al, call_arg);
+                continue;
+            }
+            ASR::ttype_t* prev_variable_type = current_variable_type_;
+            if( null_dummy != nullptr ) {
+                // Otherwise `NULL()` is a disassociated pointer of the type of
+                // the dummy argument it is passed to.
+                current_variable_type_ = null_dummy->m_type;
+            }
             this->visit_expr(*ast_list[i].m_end);
+            current_variable_type_ = prev_variable_type;
             ASR::expr_t *expr = ASRUtils::EXPR(tmp);
             if (ASR::is_a<ASR::Var_t>(*expr) &&
                     ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(expr))) {


### PR DESCRIPTION
A bare `NULL()` takes its type from the context it appears in, but in an actual argument list there was no context, so `create_NullPointerConstant` hit `AssertFailed: current_variable_type_ != nullptr`.

`visit_expr_list` now takes the procedure being called and uses the corresponding dummy argument to give `NULL()` its meaning:

- for a non-pointer, non-allocatable optional dummy argument the actual argument is absent (F2018 15.5.2.13), so it is passed as an absent argument, matching what `present()` reports in gfortran and flang
- otherwise `NULL()` is a disassociated pointer of the dummy argument's type

Adds integration test `optional_14`.