### PR TITLE
build: fix 'nix develop', bump nixpkgs version

### DIFF
--- a/ci/nix/flake.lock
+++ b/ci/nix/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1762756533,
-        "narHash": "sha256-HiRDeUOD1VLklHeOmaKDzf+8Hb7vSWPVFcWwaTrpm+U=",
+        "lastModified": 1788187754,
+        "narHash": "sha256-bu1QxmXKmPuvBLN7bHP355OV9Qo13x9WCiRDH62CqRM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c2448301fb856e351aab33e64c33a3fc8bcf637d",
+        "rev": "5dfba6236110080a54247d6460bc2ff5dda939cc",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/ci/nix/flake.nix
+++ b/ci/nix/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "LFortran devShell";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
 
   outputs = { self, nixpkgs }: 
     let
@@ -66,6 +66,23 @@
             ];
           };
 
+          # nixpkgs provides xeus 5, but xeus-zmq 4 requires xeus 6.
+          xeus_6_0 = llvmPkgs.stdenv.mkDerivation rec {
+            pname = "xeus";
+            version = "6.0.5";
+
+            src = pkgs.fetchFromGitHub {
+              owner = "jupyter-xeus";
+              repo = "xeus";
+              rev = "${version}";
+              hash = "sha256-nbjq4dzrukVsZI6X3lWpr9oCZV5IUu/vkqSNKD7o3vo=";
+            };
+
+            nativeBuildInputs = with pkgs; [ cmake ];
+            buildInputs = with pkgs; [ libuuid ];
+            propagatedBuildInputs = with pkgs; [ nlohmann_json ];
+          };
+
           # nixpkgs version is 1.3.0, i.e. too old for us
           # this is largely copied from nixpkgs:
           xeus_zmq_4_0 = llvmPkgs.stdenv.mkDerivation rec {
@@ -76,7 +93,7 @@
               owner = "jupyter-xeus";
               repo = "xeus-zmq";
               rev = "${version}";
-              hash = "sha256-aofA7e764TUHQwcc14yCXWqyHncbUmEO9+QcQ0ryDbY=";
+              hash = "sha256-Ux8klPh33XWFu9eu+GTk5ZcqIcoP/GM4/J1uaz9xRHI=";
             };
 
             nativeBuildInputs = with pkgs; [ cmake ];
@@ -85,10 +102,9 @@
               cppzmq
               libuuid
               openssl
-              xeus
               xtl
               zeromq
-            ];
+            ] ++ [ xeus_6_0 ];
 
             propagatedBuildInputs = with pkgs; [ nlohmann_json ];
           };
@@ -127,7 +143,7 @@
             openssl
 
             pandoc
-            xeus
+            xeus_6_0
             xeus_zmq_4_0
             nlohmann_json
 
@@ -155,4 +171,3 @@
       );
     };
 }
-

--- a/ci/nix/flake.nix
+++ b/ci/nix/flake.nix
@@ -102,7 +102,6 @@
               cppzmq
               libuuid
               openssl
-              xtl
               zeromq
             ] ++ [ xeus_6_0 ];
 


### PR DESCRIPTION
I contributed the current Nix development environment late last year in #8816.

It later broke with this PR: #11565, which bumped xeus-zmq from 3.0.0 to 4.0.0, without bumping its dependency xeus from 5 (implicit due to nixpkgs) to 6. The provided hash for xeus-zmq at the 4.0.0 git tag also didn't match the content I downloaded today.

I doubt the Nix environment was tested in that PR, which honestly I don't blame anyone for

The updates were related to this feature: #11554. Incidentally, I was present for @anutosh491's [FOSDEM talk](https://archive.fosdem.org/2026/schedule/event/QX3RPH-building_interactive_cc_workflows_in_jupyter_through_clang-repl/) on this earlier this year! Fun!

Anyway: **this PR fixes both issues**, and also updates the base nixpkgs from 25.05 to 26.05.
I managed to build various configurations of the compiler, as well as a functioning Jupyter kernel in the enviroment (although I did not dig into in-browser kernels).

I couldn't get a statically linked (`-DLFORTRAN_STATIC_BIN=yes`) version of the compiler with Jupyter support built, but I don't think that is an issue with the Nix environment. Will investigate further and open an issue.