### PR TITLE
tests: move conditional_expr_purity_1 ahead of the program

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -203,6 +203,29 @@ contains
 
 end module
 
+! Program units placed after `program continue_compilation_1` below are not
+! reached by the body visitor: the program itself fails semantic analysis, and
+! that stops the body visitor from descending into the units that follow it.
+! Any module whose expected errors are raised while visiting bodies (as opposed
+! to while building the symbol table) must therefore be placed here, ahead of
+! the program, or its `! {Error}` annotations become dead.
+
+! An arm of a conditional expression is an ordinary expression, so a call in
+! it is still a call made by the enclosing procedure (15.7).
+module conditional_expr_purity_1
+    implicit none
+contains
+    integer function conditional_expr_impure()
+        print *, "side effect"
+        conditional_expr_impure = 1
+    end function
+
+    pure integer function conditional_expr_pure(c)
+        logical, intent(in) :: c
+        conditional_expr_pure = ( c ? 1 : conditional_expr_impure() )  ! {Error} Call to impure procedure 'conditional_expr_impure' is not allowed inside a PURE procedure
+    end function
+end module
+
 
 ! Only put declarations and statements here, no subroutines (those go above).
 program continue_compilation_1
@@ -1142,20 +1165,4 @@ contains
       real, intent(in) :: x(:)
       real :: res(size(x))
     end function foo
-end module
-
-! An arm of a conditional expression is an ordinary expression, so a call in
-! it is still a call made by the enclosing procedure (15.7).
-module conditional_expr_purity_1
-    implicit none
-contains
-    integer function conditional_expr_impure()
-        print *, "side effect"
-        conditional_expr_impure = 1
-    end function
-
-    pure integer function conditional_expr_pure(c)
-        logical, intent(in) :: c
-        conditional_expr_pure = ( c ? 1 : conditional_expr_impure() )  ! {Error} Call to impure procedure 'conditional_expr_impure' is not allowed inside a PURE procedure
-    end function
 end module

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "73b2a5b2cb5b2f4f7edff6899eb22479d74bdb5244a661a641d95321",
+    "infile_hash": "129610c0fe794040828dd3e3865b034db8761661dc9da02e98e20f2e",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "bb0de76faa70dc2c1578b45d6c35d235d07d4e150410bb5c13124101",
+    "stderr_hash": "815e59189d35afc92f7b1d6744193d1bec6ccd73fe101a126cab698e",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -1,19 +1,19 @@
 syntax error: use statement must appear before all other declarations and statements
-   --> tests/errors/continue_compilation_1.f90:927:9
+   --> tests/errors/continue_compilation_1.f90:950:9
     |
-927 |         use iso_fortran_env, only: int32
+950 |         use iso_fortran_env, only: int32
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 syntax error: implicit statement must appear before declaration and executable statements
-   --> tests/errors/continue_compilation_1.f90:928:9
+   --> tests/errors/continue_compilation_1.f90:951:9
     |
-928 |         implicit none
+951 |         implicit none
     |         ^^^^^^^^^^^^^^ 
 
 syntax error: Token 'foo' (of type 'identifier') is unexpected here
-    --> tests/errors/continue_compilation_1.f90:1138:7
+    --> tests/errors/continue_compilation_1.f90:1161:7
      |
-1138 |       foo    end type t_recovery
+1161 |       foo    end type t_recovery
      |       ^^^ 
 
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
@@ -193,446 +193,440 @@ semantic error: Interface 'sub_test' is referenced but not defined
     |         ^^^^^^^^^^^^^^^^^^^ Referenced here
 
 semantic error: Implicit typing is not allowed, enable it by using --implicit-typing 
-   --> tests/errors/continue_compilation_1.f90:210:5 - 212:49
+   --> tests/errors/continue_compilation_1.f90:233:5 - 235:49
     |
-210 |        implicit integer(a-f), real(e-z)
+233 |        implicit integer(a-f), real(e-z)
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
 ...
     |
-212 |        ! Put declarations below without empty lines
+235 |        ! Put declarations below without empty lines
     | ...^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: arguments of `repeat` intrinsic must be scalar
-   --> tests/errors/continue_compilation_1.f90:233:38
+   --> tests/errors/continue_compilation_1.f90:256:38
     |
-233 |     character(3), parameter :: ar1 = repeat(["abc", "#^1", "123"], [1, 2, 3])
+256 |     character(3), parameter :: ar1 = repeat(["abc", "#^1", "123"], [1, 2, 3])
     |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Cannot convert LOGICAL to REAL
-   --> tests/errors/continue_compilation_1.f90:236:20
+   --> tests/errors/continue_compilation_1.f90:259:20
     |
-236 |     real :: adwf = .true.
+259 |     real :: adwf = .true.
     |                    ^^^^^^ 
 
 semantic error: Symbol is already declared in the same scope
-   --> tests/errors/continue_compilation_1.f90:240:31
+   --> tests/errors/continue_compilation_1.f90:263:31
     |
-240 |     integer , dimension(3) :: array
+263 |     integer , dimension(3) :: array
     |                               ^^^^^ redeclaration
     |
-239 |     double precision array
+262 |     double precision array
     |                      ~~~~~ original declaration
 
 semantic error: Array members must me of the same type as the struct
-   --> tests/errors/continue_compilation_1.f90:244:53
+   --> tests/errors/continue_compilation_1.f90:267:53
     |
-244 |     type(MyClass), parameter :: myclass_array(2) = [1, MyClass(10)]
+267 |     type(MyClass), parameter :: myclass_array(2) = [1, MyClass(10)]
     |                                                     ^ 
 
 semantic error: Initialization of `myclass_array2` must reduce to a compile time constant.
-   --> tests/errors/continue_compilation_1.f90:245:66
+   --> tests/errors/continue_compilation_1.f90:268:66
     |
-245 |     type(MyClass), parameter :: myclass_array2(2) = [MyClass(1), MyClass(q1)]
+268 |     type(MyClass), parameter :: myclass_array2(2) = [MyClass(1), MyClass(q1)]
     |                                                                  ^^^^^^^^^^^ 
 
 semantic error: Syntax error in CHARACTER declaration: only 'len' and 'kind' are allowed as type parameters
-   --> tests/errors/continue_compilation_1.f90:246:5
+   --> tests/errors/continue_compilation_1.f90:269:5
     |
-246 |     character(width=10) :: str_c_1
+269 |     character(width=10) :: str_c_1
     |     ^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Syntax error in CHARACTER declaration: can't use a keyword argument more than once
-   --> tests/errors/continue_compilation_1.f90:247:5
+   --> tests/errors/continue_compilation_1.f90:270:5
     |
-247 |     character(len=10, len=20) :: str_c_2
+270 |     character(len=10, len=20) :: str_c_2
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Syntax error in CHARACTER declaration: positional type parameters cannot follow a keyword argument
-   --> tests/errors/continue_compilation_1.f90:248:5
+   --> tests/errors/continue_compilation_1.f90:271:5
     |
-248 |     character(len=10, 1) :: str_c_3
+271 |     character(len=10, 1) :: str_c_3
     |     ^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Syntax error in CHARACTER declaration: using only 'len' keyword argument after a positional type is invalid
-   --> tests/errors/continue_compilation_1.f90:249:5
+   --> tests/errors/continue_compilation_1.f90:272:5
     |
-249 |     character(1, len=20) :: str_c_4
+272 |     character(1, len=20) :: str_c_4
     |     ^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Allocatable array 'z_01' must have a deferred shape or assumed rank
-   --> tests/errors/continue_compilation_1.f90:250:5
+   --> tests/errors/continue_compilation_1.f90:273:5
     |
-250 |     character(:), allocatable :: z_01(2)
+273 |     character(:), allocatable :: z_01(2)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Expecting a scalar integer or parameter annotated integer variable 
-   --> tests/errors/continue_compilation_1.f90:252:26
+   --> tests/errors/continue_compilation_1.f90:275:26
     |
-252 |     logical :: mask_size(size(arr_size))
+275 |     logical :: mask_size(size(arr_size))
     |                          ^^^^^^^^^^^^^^ 
 
 semantic error: `protected` attribute is only allowed in specification part of a module
-   --> tests/errors/continue_compilation_1.f90:253:5
+   --> tests/errors/continue_compilation_1.f90:276:5
     |
-253 |     integer, protected :: protected_attr_var
+276 |     integer, protected :: protected_attr_var
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `protected` attribute is only allowed in specification part of a module
-   --> tests/errors/continue_compilation_1.f90:254:5
+   --> tests/errors/continue_compilation_1.f90:277:5
     |
-254 |     integer, parameter, protected :: protected_parameter_var
+277 |     integer, parameter, protected :: protected_parameter_var
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Variable `n` cannot appear in the expression as it is not a constant
-   --> tests/errors/continue_compilation_1.f90:259:27
+   --> tests/errors/continue_compilation_1.f90:282:27
     |
-259 |       integer :: elements(n)
+282 |       integer :: elements(n)
     |                           ^ 
 
 semantic error: Derived type `bspline_3d` is not defined
-   --> tests/errors/continue_compilation_1.f90:261:5
+   --> tests/errors/continue_compilation_1.f90:284:5
     |
-261 |     type(bspline_3d) :: s3_in_program
+284 |     type(bspline_3d) :: s3_in_program
     |     ^^^^^^^^^^^^^^^^ Type used here is not defined in any scope
 
 semantic error: BOZ literal constant cannot be used in binary operations
-   --> tests/errors/continue_compilation_1.f90:263:19
+   --> tests/errors/continue_compilation_1.f90:286:19
     |
-263 |     integer::tt = b'01' * 3
+286 |     integer::tt = b'01' * 3
     |                   ^^^^^^^^^ 
 
 semantic error: An 'allocatable' variable cannot have an initialization expression
-   --> tests/errors/continue_compilation_1.f90:265:29
+   --> tests/errors/continue_compilation_1.f90:288:29
     |
-265 |     integer, allocatable :: allocate_int = 1
+288 |     integer, allocatable :: allocate_int = 1
     |                             ^^^^^^^^^^^^^^^^ 
 
 semantic error: An 'allocatable' variable cannot have an initialization expression
-   --> tests/errors/continue_compilation_1.f90:266:34
+   --> tests/errors/continue_compilation_1.f90:289:34
     |
-266 |     character(:), allocatable :: allocate_char = "H"
+289 |     character(:), allocatable :: allocate_char = "H"
     |                                  ^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Transformational intrinsic is not permitted in an initialization expression
-   --> tests/errors/continue_compilation_1.f90:270:42
+   --> tests/errors/continue_compilation_1.f90:293:42
     |
-270 |     integer, parameter :: param_minloc = minloc(param_arr, 1, [.false., .false., .false.])
+293 |     integer, parameter :: param_minloc = minloc(param_arr, 1, [.false., .false., .false.])
     |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Variable `uninitialized_param_local` with parameter attribute is not initialised
-   --> tests/errors/continue_compilation_1.f90:278:5
+   --> tests/errors/continue_compilation_1.f90:301:5
     |
-278 |     type(MyClass), parameter :: uninitialized_param_local
+301 |     type(MyClass), parameter :: uninitialized_param_local
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Symbol not found: `non_existent_symbol`
-   --> tests/errors/continue_compilation_1.f90:279:5
+   --> tests/errors/continue_compilation_1.f90:302:5
     |
-279 |     type(MyClass) :: err_obj1 = non_existent_symbol
+302 |     type(MyClass) :: err_obj1 = non_existent_symbol
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Named initialization not supported with: my_func
-   --> tests/errors/continue_compilation_1.f90:280:5
+   --> tests/errors/continue_compilation_1.f90:303:5
     |
-280 |     type(MyClass) :: err_obj2 = my_func
+303 |     type(MyClass) :: err_obj2 = my_func
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Initialization with non-constant variable `non_parameter_var` is not allowed
-   --> tests/errors/continue_compilation_1.f90:282:5
+   --> tests/errors/continue_compilation_1.f90:305:5
     |
-282 |     type(MyClass) :: err_obj3 = non_parameter_var
+305 |     type(MyClass) :: err_obj3 = non_parameter_var
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
     |
-281 |     integer :: non_parameter_var = 5
+304 |     integer :: non_parameter_var = 5
     |                ~~~~~~~~~~~~~~~~~~~~~ declared here
 
 semantic error: Parameter `myclass_array` has no initialization value
-   --> tests/errors/continue_compilation_1.f90:283:5
+   --> tests/errors/continue_compilation_1.f90:306:5
     |
-283 |     type(MyClass) :: err_obj4 = myclass_array
+306 |     type(MyClass) :: err_obj4 = myclass_array
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Symbol not found: `uninitialized_param_local`
-   --> tests/errors/continue_compilation_1.f90:284:5
+   --> tests/errors/continue_compilation_1.f90:307:5
     |
-284 |     type(MyClass) :: err_obj5 = uninitialized_param_local
+307 |     type(MyClass) :: err_obj5 = uninitialized_param_local
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: CLASS variable 'inst_tt' must be dummy, allocatable or pointer
-   --> tests/errors/continue_compilation_1.f90:295:5
+   --> tests/errors/continue_compilation_1.f90:318:5
     |
-295 |     class(type_t) :: inst_tt
+318 |     class(type_t) :: inst_tt
     |     ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Result of `erfc` underflows its kind
-   --> tests/errors/continue_compilation_1.f90:296:40
+   --> tests/errors/continue_compilation_1.f90:319:40
     |
-296 |     real(8), parameter :: erfc_param = erfc(40.12_8)
+319 |     real(8), parameter :: erfc_param = erfc(40.12_8)
     |                                        ^^^^^^^^^^^^^ 
 
 semantic error: Contiguous attribute can only be applied to declared variables
-   --> tests/errors/continue_compilation_1.f90:298:19
+   --> tests/errors/continue_compilation_1.f90:321:19
     |
-298 |     contiguous :: contig_not_declared
+321 |     contiguous :: contig_not_declared
     |                   ^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Contiguous attribute can only be applied to variables
-   --> tests/errors/continue_compilation_1.f90:299:19
+   --> tests/errors/continue_compilation_1.f90:322:19
     |
-299 |     contiguous :: MyClass
+322 |     contiguous :: MyClass
     |                   ^^^^^^^ 
 
 semantic error: ‘shape’ argument of ‘reshape’ intrinsic has negative element (-2)
-   --> tests/errors/continue_compilation_1.f90:302:53
+   --> tests/errors/continue_compilation_1.f90:325:53
     |
-302 |     integer, parameter :: qval(2) = reshape([7, 8], -[z])
+325 |     integer, parameter :: qval(2) = reshape([7, 8], -[z])
     |                                                     ^^^^ 
 
 semantic error: LEN parameters in parameterized derived types are not supported yet
-   --> tests/errors/continue_compilation_1.f90:305:9
+   --> tests/errors/continue_compilation_1.f90:328:9
     |
-305 |         integer, len :: n
+328 |         integer, len :: n
     |         ^^^^^^^^^^^^^^^^^ 
 
 semantic error: Intent attribute can only be applied to procedure arguments
-   --> tests/errors/continue_compilation_1.f90:614:14
+   --> tests/errors/continue_compilation_1.f90:637:14
     |
-614 |     integer, intent(out) :: out_intent
+637 |     integer, intent(out) :: out_intent
     |              ^^^^^^^^^^^ 
 
 semantic error: Intent attribute can only be applied to procedure arguments
-   --> tests/errors/continue_compilation_1.f90:615:14
+   --> tests/errors/continue_compilation_1.f90:638:14
     |
-615 |     integer, intent(in) :: in_intent
+638 |     integer, intent(in) :: in_intent
     |              ^^^^^^^^^^ 
 
 semantic error: Parameterized derived type 'container' parameter 'ik' has no default value and must be specified
-   --> tests/errors/continue_compilation_1.f90:626:5
+   --> tests/errors/continue_compilation_1.f90:649:5
     |
-626 |     type(container(4)) :: obj1
+649 |     type(container(4)) :: obj1
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Parameterized derived type 'container' parameter 'rk' has no default value and must be specified
-   --> tests/errors/continue_compilation_1.f90:627:5
+   --> tests/errors/continue_compilation_1.f90:650:5
     |
-627 |     type(container) :: obj2
+650 |     type(container) :: obj2
     |     ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: The shapes of the `array` and `mask` arguments of the `MinLoc` intrinsic must be the same
-   --> tests/errors/continue_compilation_1.f90:630:47
+   --> tests/errors/continue_compilation_1.f90:653:47
     |
-630 |     integer :: minloc_shape_mismatch = minloc([2, 1, 3], 1, [.true., .false.])
+653 |     integer :: minloc_shape_mismatch = minloc([2, 1, 3], 1, [.true., .false.])
     |                                               ^^^^^^^^^     ^^^^^^^^^^^^^^^^^ `array` has shape [3], but `mask` has shape [2]
 
 semantic error: The shapes of the `array` and `mask` arguments of the `MaxLoc` intrinsic must be the same
-   --> tests/errors/continue_compilation_1.f90:631:47
+   --> tests/errors/continue_compilation_1.f90:654:47
     |
-631 |     integer :: maxloc_shape_mismatch = maxloc([2, 1, 3], 1, [.true., .false.])
+654 |     integer :: maxloc_shape_mismatch = maxloc([2, 1, 3], 1, [.true., .false.])
     |                                               ^^^^^^^^^     ^^^^^^^^^^^^^^^^^ `array` has shape [3], but `mask` has shape [2]
 
 semantic error: variable cannot appear in character length expression
-   --> tests/errors/continue_compilation_1.f90:638:21
+   --> tests/errors/continue_compilation_1.f90:661:21
     |
-638 |     character(len = char_len_var) :: char_nonconst
+661 |     character(len = char_len_var) :: char_nonconst
     |                     ^^^^^^^^^^^^ 
 
 semantic error: type mismatch in initialization: `string` cannot be assigned to `integer`
-   --> tests/errors/continue_compilation_1.f90:643:32
+   --> tests/errors/continue_compilation_1.f90:666:32
     |
-643 |     integer, parameter :: n2 = "abc"
+666 |     integer, parameter :: n2 = "abc"
     |                                ^^^^^ 
 
 semantic error: Pointer initialization target `ptr_src_no_target` must have the `target` attribute
-   --> tests/errors/continue_compilation_1.f90:645:5
+   --> tests/errors/continue_compilation_1.f90:668:5
     |
-645 |     type(MyClass), pointer :: ptr_requires_target => ptr_src_no_target
+668 |     type(MyClass), pointer :: ptr_requires_target => ptr_src_no_target
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
     |
-644 |     type(MyClass) :: ptr_src_no_target
+667 |     type(MyClass) :: ptr_src_no_target
     |                      ~~~~~~~~~~~~~~~~~ declared here
 
 semantic error: Type mismatch in pointer initialization of `ptr_type_mismatch`
-   --> tests/errors/continue_compilation_1.f90:647:5
+   --> tests/errors/continue_compilation_1.f90:670:5
     |
-647 |     type(MyClass), pointer :: ptr_type_mismatch => ptr_tgt_base
+670 |     type(MyClass), pointer :: ptr_type_mismatch => ptr_tgt_base
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
     |
-646 |     type(Base), target :: ptr_tgt_base
+669 |     type(Base), target :: ptr_tgt_base
     |                           ~~~~~~~~~~~~ target declared here
 
 semantic error: Dimensions specified for 'm' after its initialization
-   --> tests/errors/continue_compilation_1.f90:654:18
+   --> tests/errors/continue_compilation_1.f90:677:18
     |
-654 |     dimension :: m(3)
+677 |     dimension :: m(3)
     |                  ^^^^ 
 
 semantic error: Cannot convert LOGICAL to REAL
-   --> tests/errors/continue_compilation_1.f90:687:24
+   --> tests/errors/continue_compilation_1.f90:710:24
     |
-687 |         real :: adwf = .true.
+710 |         real :: adwf = .true.
     |                        ^^^^^^ 
 
 warning: Assuming implicit save attribute for variable declaration
-   --> tests/errors/continue_compilation_1.f90:691:23
+   --> tests/errors/continue_compilation_1.f90:714:23
     |
-691 |         integer(4) :: arr1(3) = [2471095, 820012001, 39024800]
+714 |         integer(4) :: arr1(3) = [2471095, 820012001, 39024800]
     |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add explicit save attribute or parameter attribute or initialize in a separate statement
 
 semantic error: Allocatable array 'x' must have a deferred shape or assumed rank
-   --> tests/errors/continue_compilation_1.f90:717:9
+   --> tests/errors/continue_compilation_1.f90:740:9
     |
-717 |         integer,allocatable  :: x(3)
+740 |         integer,allocatable  :: x(3)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Pointer array 'y' must have a deferred shape or assumed rank
-   --> tests/errors/continue_compilation_1.f90:718:9
+   --> tests/errors/continue_compilation_1.f90:741:9
     |
-718 |         integer,pointer  :: y(3)
+741 |         integer,pointer  :: y(3)
     |         ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: COMMON block array bounds must be constant expressions
-   --> tests/errors/continue_compilation_1.f90:729:20
+   --> tests/errors/continue_compilation_1.f90:752:20
     |
-729 |         integer :: arr(n:10)
+752 |         integer :: arr(n:10)
     |                    ^^^^^^^^^ 
 
 semantic error: COMMON block array bounds must be constant expressions
-   --> tests/errors/continue_compilation_1.f90:736:20
+   --> tests/errors/continue_compilation_1.f90:759:20
     |
-736 |         integer :: arr(1:n)
+759 |         integer :: arr(1:n)
     |                    ^^^^^^^^ 
 
 semantic error: Variable `a` cannot have both the OPTIONAL and VALUE attribute because procedure `bindc_optional_value` is BIND(C)
-   --> tests/errors/continue_compilation_1.f90:748:37
+   --> tests/errors/continue_compilation_1.f90:771:37
     |
-748 |     subroutine bindc_optional_value(a) bind(c)
+771 |     subroutine bindc_optional_value(a) bind(c)
     |                                     ^ 
 
 semantic error: Function `c_loc` is not permitted in an initialization expression
-   --> tests/errors/continue_compilation_1.f90:810:13
+   --> tests/errors/continue_compilation_1.f90:833:13
     |
-810 |             type(c_ptr) :: ptr = c_loc(target_value)
+833 |             type(c_ptr) :: ptr = c_loc(target_value)
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: length specifier is only valid for character type
-   --> tests/errors/continue_compilation_1.f90:869:20
+   --> tests/errors/continue_compilation_1.f90:892:20
     |
-869 |         integer :: i*2
+892 |         integer :: i*2
     |                    ^^^ 
 
 semantic error: Derived type `t_pair_local` is not defined
-   --> tests/errors/continue_compilation_1.f90:910:9
+   --> tests/errors/continue_compilation_1.f90:933:9
     |
-910 |         type(t_pair_local) :: x
+933 |         type(t_pair_local) :: x
     |         ^^^^^^^^^^^^^^^^^^ Type used here is not defined in any scope
 
 semantic error: equivalence array bounds and subscripts must be constant
-   --> tests/errors/continue_compilation_1.f90:935:22
+   --> tests/errors/continue_compilation_1.f90:958:22
     |
-935 |         equivalence (a(i), b(1))  ! {Error} equivalence array bounds and subscripts must be constant
+958 |         equivalence (a(i), b(1))  ! {Error} equivalence array bounds and subscripts must be constant
     |                      ^^^^ unsupported equivalence
 
 semantic error: equivalence between a common block variable and this array element is not implemented
-   --> tests/errors/continue_compilation_1.f90:942:9
+   --> tests/errors/continue_compilation_1.f90:965:9
     |
-942 |         equivalence (cs, arr(2))  ! {Error} equivalence between a common block variable and this array element is not implemented
+965 |         equivalence (cs, arr(2))  ! {Error} equivalence between a common block variable and this array element is not implemented
     |         ^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
 
 semantic error: equivalence between a common block variable and this array element is not implemented
-   --> tests/errors/continue_compilation_1.f90:949:9
+   --> tests/errors/continue_compilation_1.f90:972:9
     |
-949 |         equivalence (first, alias(1))  ! {Error} equivalence between a common block variable and this array element is not implemented
+972 |         equivalence (first, alias(1))  ! {Error} equivalence between a common block variable and this array element is not implemented
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
 
 semantic error: a conditional expression is not allowed in a constant expression
-    --> tests/errors/continue_compilation_1.f90:1103:36
+    --> tests/errors/continue_compilation_1.f90:1126:36
      |
-1103 |         integer, parameter :: cx = ( .true. ? 1 : 0 )  ! {Error} a conditional expression is not allowed in a constant expression
+1126 |         integer, parameter :: cx = ( .true. ? 1 : 0 )  ! {Error} a conditional expression is not allowed in a constant expression
      |                                    ^^^^^^^^^^^^^^^^^^ an initialization expression shall be a constant expression (Fortran 2023 C1012)
      |
-1103 |         integer, parameter :: cx = ( .true. ? 1 : 0 )  ! {Error} a conditional expression is not allowed in a constant expression
+1126 |         integer, parameter :: cx = ( .true. ? 1 : 0 )  ! {Error} a conditional expression is not allowed in a constant expression
      |                                    ~~~~~~~~~~~~~~~~~~ help: Fortran 2023 10.1.12 does not list a conditional expression among the permitted primaries; use `merge`, which is permitted here
 
 semantic error: a conditional expression is not allowed in a constant expression
-    --> tests/errors/continue_compilation_1.f90:1104:25
+    --> tests/errors/continue_compilation_1.f90:1127:25
      |
-1104 |         integer :: cy = ( .true. ? 1 : 0 )  ! {Error} a conditional expression is not allowed in a constant expression
+1127 |         integer :: cy = ( .true. ? 1 : 0 )  ! {Error} a conditional expression is not allowed in a constant expression
      |                         ^^^^^^^^^^^^^^^^^^ an initialization expression shall be a constant expression (Fortran 2023 C1012)
      |
-1104 |         integer :: cy = ( .true. ? 1 : 0 )  ! {Error} a conditional expression is not allowed in a constant expression
+1127 |         integer :: cy = ( .true. ? 1 : 0 )  ! {Error} a conditional expression is not allowed in a constant expression
      |                         ~~~~~~~~~~~~~~~~~~ help: Fortran 2023 10.1.12 does not list a conditional expression among the permitted primaries; use `merge`, which is permitted here
 
 semantic error: a conditional expression is not allowed in a constant expression
-    --> tests/errors/continue_compilation_1.f90:1109:24
+    --> tests/errors/continue_compilation_1.f90:1132:24
      |
-1109 |         integer(kind = ( .true. ? 4 : 8 )) :: ck  ! {Error} a conditional expression is not allowed in a constant expression
+1132 |         integer(kind = ( .true. ? 4 : 8 )) :: ck  ! {Error} a conditional expression is not allowed in a constant expression
      |                        ^^^^^^^^^^^^^^^^^^ a kind type parameter shall be a constant expression (Fortran 2023 C701)
      |
-1109 |         integer(kind = ( .true. ? 4 : 8 )) :: ck  ! {Error} a conditional expression is not allowed in a constant expression
+1132 |         integer(kind = ( .true. ? 4 : 8 )) :: ck  ! {Error} a conditional expression is not allowed in a constant expression
      |                        ~~~~~~~~~~~~~~~~~~ help: Fortran 2023 10.1.12 does not list a conditional expression among the permitted primaries; use `merge`, which is permitted here
 
 semantic error: a conditional expression is not allowed in a constant expression
-    --> tests/errors/continue_compilation_1.f90:1110:26
+    --> tests/errors/continue_compilation_1.f90:1133:26
      |
-1110 |         character(kind = ( .true. ? 1 : 4 ), len = 2) :: cc  ! {Error} a conditional expression is not allowed in a constant expression
+1133 |         character(kind = ( .true. ? 1 : 4 ), len = 2) :: cc  ! {Error} a conditional expression is not allowed in a constant expression
      |                          ^^^^^^^^^^^^^^^^^^ a kind type parameter shall be a constant expression (Fortran 2023 C701)
      |
-1110 |         character(kind = ( .true. ? 1 : 4 ), len = 2) :: cc  ! {Error} a conditional expression is not allowed in a constant expression
+1133 |         character(kind = ( .true. ? 1 : 4 ), len = 2) :: cc  ! {Error} a conditional expression is not allowed in a constant expression
      |                          ~~~~~~~~~~~~~~~~~~ help: Fortran 2023 10.1.12 does not list a conditional expression among the permitted primaries; use `merge`, which is permitted here
 
 semantic error: a conditional expression is not allowed in a specification expression
-    --> tests/errors/continue_compilation_1.f90:1116:25
+    --> tests/errors/continue_compilation_1.f90:1139:25
      |
-1116 |         character(len = ( n>0 ? n : 1 )) :: cs  ! {Error} a conditional expression is not allowed in a specification expression
+1139 |         character(len = ( n>0 ? n : 1 )) :: cs  ! {Error} a conditional expression is not allowed in a specification expression
      |                         ^^^^^^^^^^^^^^^ a type parameter value shall be a specification expression (Fortran 2023 C704)
      |
-1116 |         character(len = ( n>0 ? n : 1 )) :: cs  ! {Error} a conditional expression is not allowed in a specification expression
+1139 |         character(len = ( n>0 ? n : 1 )) :: cs  ! {Error} a conditional expression is not allowed in a specification expression
      |                         ~~~~~~~~~~~~~~~ help: Fortran 2023 10.1.11 does not list a conditional expression among the permitted primaries; use `merge`, which is permitted here
 
 semantic error: a conditional expression is not allowed in a specification expression
-    --> tests/errors/continue_compilation_1.f90:1117:24
+    --> tests/errors/continue_compilation_1.f90:1140:24
      |
-1117 |         integer :: ca( ( n>0 ? n : 1 ) )  ! {Error} a conditional expression is not allowed in a specification expression
+1140 |         integer :: ca( ( n>0 ? n : 1 ) )  ! {Error} a conditional expression is not allowed in a specification expression
      |                        ^^^^^^^^^^^^^^^ an array bound shall be a specification expression
      |
-1117 |         integer :: ca( ( n>0 ? n : 1 ) )  ! {Error} a conditional expression is not allowed in a specification expression
+1140 |         integer :: ca( ( n>0 ? n : 1 ) )  ! {Error} a conditional expression is not allowed in a specification expression
      |                        ~~~~~~~~~~~~~~~ help: Fortran 2023 10.1.11 does not list a conditional expression among the permitted primaries; use `merge`, which is permitted here
 
 semantic error: kind 2 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1125:19
+    --> tests/errors/continue_compilation_1.f90:1148:19
      |
-1125 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
+1148 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: kind 3 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1126:19
+    --> tests/errors/continue_compilation_1.f90:1149:19
      |
-1126 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+1149 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: kind 8 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1127:19
+    --> tests/errors/continue_compilation_1.f90:1150:19
      |
-1127 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
+1150 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: Symbol 'undeclared_proc' not declared
-   --> tests/errors/continue_compilation_1.f90:640:9
+   --> tests/errors/continue_compilation_1.f90:663:9
     |
-640 |         module procedure undeclared_proc  ! {Error} Symbol 'undeclared_proc' not declared
+663 |         module procedure undeclared_proc  ! {Error} Symbol 'undeclared_proc' not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Derived type 't_recovery' not declared
-    --> tests/errors/continue_compilation_1.f90:1141:7
+    --> tests/errors/continue_compilation_1.f90:1164:7
      |
-1141 |       class(t_recovery), intent(in) :: self
+1164 |       class(t_recovery), intent(in) :: self
      |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
-
-semantic error: Symbol 'bad_op' not declared
- --> tests/errors/continue_compilation_1.f90:1:2
-  |
-1 | ! If you need a function, put it into the module below and remove the same
-  |  ^ 
 
 semantic error: Symbol 'bad_op' not declared
  --> tests/errors/continue_compilation_1.f90:1:2
@@ -700,1387 +694,1393 @@ semantic error: Interface mismatch in procedure pointer assignment at (1): 'dumm
 183 |         pf2 => dummy_func
     |         ^^^^^^^^^^^^^^^^^ (1)
 
-semantic error: Intrinsic 'not_real' is not recognized
-   --> tests/errors/continue_compilation_1.f90:268:14
+semantic error: Call to impure procedure 'conditional_expr_impure' is not allowed inside a PURE procedure
+   --> tests/errors/continue_compilation_1.f90:225:43
     |
-268 |     call sub(not_real)
+225 |         conditional_expr_pure = ( c ? 1 : conditional_expr_impure() )  ! {Error} Call to impure procedure 'conditional_expr_impure' is not allowed inside a PURE procedure
+    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: Intrinsic 'not_real' is not recognized
+   --> tests/errors/continue_compilation_1.f90:291:14
+    |
+291 |     call sub(not_real)
     |              ^^^^^^^^ 'not_real' is not a known intrinsic function
 
 semantic error: Format specifier in print statement must be of type default character
-   --> tests/errors/continue_compilation_1.f90:326:11
+   --> tests/errors/continue_compilation_1.f90:349:11
     |
-326 |     print 1+2
+349 |     print 1+2
     |           ^^^ 
 
 semantic error: Array index 10 is out of bounds (1 to 3) in dimension 1
-   --> tests/errors/continue_compilation_1.f90:328:14
+   --> tests/errors/continue_compilation_1.f90:351:14
     |
-328 |     print *, a(10)
+351 |     print *, a(10)
     |              ^^^^^ 
 
 semantic error: Assignment to loop variable `i` is not allowed
-   --> tests/errors/continue_compilation_1.f90:335:8
+   --> tests/errors/continue_compilation_1.f90:358:8
     |
-335 |        i = i + 1
+358 |        i = i + 1
     |        ^ 
 
 semantic error:  first argument of `maskl` must be less than or equal to the BIT_SIZE of INTEGER(KIND=4)
-   --> tests/errors/continue_compilation_1.f90:339:13
+   --> tests/errors/continue_compilation_1.f90:362:13
     |
-339 |     print*, maskl(63)
+362 |     print*, maskl(63)
     |             ^^^^^^^^^ 
 
 semantic error: first argument of `maskr` must be less than or equal to the BIT_SIZE of INTEGER(KIND=4)
-   --> tests/errors/continue_compilation_1.f90:341:13
+   --> tests/errors/continue_compilation_1.f90:364:13
     |
-341 |     print*, maskr(63)
+364 |     print*, maskr(63)
     |             ^^^^^^^^^ 
 
 semantic error: first argument of `maskl` must be nonnegative
-   --> tests/errors/continue_compilation_1.f90:343:13
+   --> tests/errors/continue_compilation_1.f90:366:13
     |
-343 |     print*, maskl(-24)
+366 |     print*, maskl(-24)
     |             ^^^^^^^^^^ 
 
 semantic error: first argument of `maskr` must be nonnegative
-   --> tests/errors/continue_compilation_1.f90:345:13
+   --> tests/errors/continue_compilation_1.f90:368:13
     |
-345 |     print*, maskr(-24)
+368 |     print*, maskr(-24)
     |             ^^^^^^^^^^ 
 
 semantic error: The argument `matrix_a` in `matmul` must be of type Integer, Real, Complex or Logical
-   --> tests/errors/continue_compilation_1.f90:347:21
+   --> tests/errors/continue_compilation_1.f90:370:21
     |
-347 |     print *, matmul(a1, b1)
+370 |     print *, matmul(a1, b1)
     |                     ^^ 
 
 semantic error: The argument `matrix_b` in `matmul` must be of type Integer, Real or Complex if first matrix is of numeric type
-   --> tests/errors/continue_compilation_1.f90:349:25
+   --> tests/errors/continue_compilation_1.f90:372:25
     |
-349 |     print *, matmul(b1, a1)
+372 |     print *, matmul(b1, a1)
     |                         ^^ 
 
 semantic error: The argument `matrix_b` in `matmul` must be of type Logical if first matrix is of Logical type
-   --> tests/errors/continue_compilation_1.f90:351:25
+   --> tests/errors/continue_compilation_1.f90:374:25
     |
-351 |     print *, matmul(a2, b1)
+374 |     print *, matmul(a2, b1)
     |                         ^^ 
 
 semantic error: `matmul` accepts arrays of rank 1 or 2 only, provided an array with rank, 3
-   --> tests/errors/continue_compilation_1.f90:353:21
+   --> tests/errors/continue_compilation_1.f90:376:21
     |
-353 |     print *, matmul(a3, b1)
+376 |     print *, matmul(a3, b1)
     |                     ^^ 
 
 semantic error: `matmul` accepts arrays of rank 1 or 2 only, provided an array with rank, 4
-   --> tests/errors/continue_compilation_1.f90:355:25
+   --> tests/errors/continue_compilation_1.f90:378:25
     |
-355 |     print *, matmul(b1, b4)
+378 |     print *, matmul(b1, b4)
     |                         ^^ 
 
 semantic error: The argument `matrix_b` in `matmul` must be of rank 2, provided an array with rank, 1
-   --> tests/errors/continue_compilation_1.f90:357:24
+   --> tests/errors/continue_compilation_1.f90:380:24
     |
-357 |     print *, matmul(a, b)
+380 |     print *, matmul(a, b)
     |                        ^ 
 
 semantic error: `transpose` accepts arrays of rank 2 only, provided an array with rank, 1
-   --> tests/errors/continue_compilation_1.f90:359:24
+   --> tests/errors/continue_compilation_1.f90:382:24
     |
-359 |     print *, transpose(a)
+382 |     print *, transpose(a)
     |                        ^ 
 
 semantic error: Type and kind of the relevant arguments of Mergebits must be the same
-   --> tests/errors/continue_compilation_1.f90:361:14
+   --> tests/errors/continue_compilation_1.f90:384:14
     |
-361 |     print *, merge_bits(8, 12_8, 2)
+384 |     print *, merge_bits(8, 12_8, 2)
     |              ^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Type and kind of the relevant arguments of Mergebits must be the same
-   --> tests/errors/continue_compilation_1.f90:363:14
+   --> tests/errors/continue_compilation_1.f90:386:14
     |
-363 |     print *, merge_bits(a5, b5, c5)
+386 |     print *, merge_bits(a5, b5, c5)
     |              ^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Second argument of modulo cannot be 0
-   --> tests/errors/continue_compilation_1.f90:379:14
+   --> tests/errors/continue_compilation_1.f90:402:14
     |
-379 |     print *, modulo(1, 0)
+402 |     print *, modulo(1, 0)
     |              ^^^^^^^^^^^^ 
 
 semantic error: Procedure 'my_func' accepts 2 arguments, but 3 were provided
-   --> tests/errors/continue_compilation_1.f90:381:5
+   --> tests/errors/continue_compilation_1.f90:404:5
     |
-381 |     call my_func(y=1, x=2, z=1)
+404 |     call my_func(y=1, x=2, z=1)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ incorrect number of arguments to 'my_func'
 
 semantic error: Result of `nint` overflows its kind(4)
-   --> tests/errors/continue_compilation_1.f90:384:13
+   --> tests/errors/continue_compilation_1.f90:407:13
     |
-384 |     print*, nint(1e12_8)
+407 |     print*, nint(1e12_8)
     |             ^^^^^^^^^^^^ 
 
 semantic error: Result of `nint` overflows its kind(4)
-   --> tests/errors/continue_compilation_1.f90:385:13
+   --> tests/errors/continue_compilation_1.f90:408:13
     |
-385 |     print*, nint(1000000000000.0000000000000000d0)
+408 |     print*, nint(1000000000000.0000000000000000d0)
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Invalid argument `hello` supplied
-   --> tests/errors/continue_compilation_1.f90:387:5
+   --> tests/errors/continue_compilation_1.f90:410:5
     |
-387 |     OPEN(file="numbers", hello="world")
+410 |     OPEN(file="numbers", hello="world")
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Cannot assign to a constant variable
-   --> tests/errors/continue_compilation_1.f90:389:5
+   --> tests/errors/continue_compilation_1.f90:412:5
     |
-389 |     i1 = 3
+412 |     i1 = 3
     |     ^^^^^^ assignment here
     |
-219 |     integer, parameter :: i1 = 2
+242 |     integer, parameter :: i1 = 2
     |                           ~~~~~~ declared as constant
 
 semantic error: Expected 0 or 1 arguments, got 2 arguments instead.
-   --> tests/errors/continue_compilation_1.f90:391:5
+   --> tests/errors/continue_compilation_1.f90:414:5
     |
-391 |     call FLUSH(1, 2)
+414 |     call FLUSH(1, 2)
     |     ^^^^^^^^^^^^^^^^ 
 
 semantic error: `kind` argument of `verify` intrinsic must be a scalar
-   --> tests/errors/continue_compilation_1.f90:393:39
+   --> tests/errors/continue_compilation_1.f90:416:39
     |
-393 |     print*, verify(string, set, kind= [4, 4] )
+416 |     print*, verify(string, set, kind= [4, 4] )
     |                                       ^^^^^^ 
 
 semantic error: arguments of `and` intrinsic must be scalar
-   --> tests/errors/continue_compilation_1.f90:394:14
+   --> tests/errors/continue_compilation_1.f90:417:14
     |
-394 |     print *, and([1, 2, 3], [1, 2, 3])
+417 |     print *, and([1, 2, 3], [1, 2, 3])
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: The shift argument of 'dshiftl' intrinsic must be less than or equal to the bit size of the integer
-   --> tests/errors/continue_compilation_1.f90:396:28
+   --> tests/errors/continue_compilation_1.f90:419:28
     |
-396 |     print *, dshiftl(1, 2, 34)
+419 |     print *, dshiftl(1, 2, 34)
     |                            ^^ 
 
 semantic error: The shift argument of 'dshiftl' intrinsic must be non-negative integer
-   --> tests/errors/continue_compilation_1.f90:397:28
+   --> tests/errors/continue_compilation_1.f90:420:28
     |
-397 |     print *, dshiftl(1, 2, -2)
+420 |     print *, dshiftl(1, 2, -2)
     |                            ^^ 
 
 semantic error: The shift argument of 'dshiftr' intrinsic must be less than or equal to the bit size of the integer
-   --> tests/errors/continue_compilation_1.f90:399:28
+   --> tests/errors/continue_compilation_1.f90:422:28
     |
-399 |     print *, dshiftr(1, 2, 34)
+422 |     print *, dshiftr(1, 2, 34)
     |                            ^^ 
 
 semantic error: The shift argument of 'dshiftr' intrinsic must be non-negative integer
-   --> tests/errors/continue_compilation_1.f90:400:28
+   --> tests/errors/continue_compilation_1.f90:423:28
     |
-400 |     print *, dshiftr(1, 2, -2)
+423 |     print *, dshiftr(1, 2, -2)
     |                            ^^ 
 
 semantic error: arguments of `selected_int_kind` intrinsic must be scalar
-   --> tests/errors/continue_compilation_1.f90:402:14
+   --> tests/errors/continue_compilation_1.f90:425:14
     |
-402 |     print *, selected_int_kind([1,2,3])
+425 |     print *, selected_int_kind([1,2,3])
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: arguments of `selected_real_kind` intrinsic must be scalar
-   --> tests/errors/continue_compilation_1.f90:403:14
+   --> tests/errors/continue_compilation_1.f90:426:14
     |
-403 |     print *, selected_real_kind([1,2,3])
+426 |     print *, selected_real_kind([1,2,3])
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: arguments of `selected_char_kind` intrinsic must be scalar
-   --> tests/errors/continue_compilation_1.f90:404:14
+   --> tests/errors/continue_compilation_1.f90:427:14
     |
-404 |     print *, selected_char_kind(['c', 'a', 'b'])
+427 |     print *, selected_char_kind(['c', 'a', 'b'])
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `dim` argument of the `Sum` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:413:30
+   --> tests/errors/continue_compilation_1.f90:436:30
     |
-413 |     print *, sum(arr1, dim = 2)
+436 |     print *, sum(arr1, dim = 2)
     |                              ^ Must have 0 < dim <= 1 for array of rank 1
 
 semantic error: `dim` argument of the `Sum` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:414:30
+   --> tests/errors/continue_compilation_1.f90:437:30
     |
-414 |     print *, sum(arr1, dim = -1)
+437 |     print *, sum(arr1, dim = -1)
     |                              ^^ Must have 0 < dim <= 1 for array of rank 1
 
 semantic error: `dim` argument of the `Sum` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:415:44
+   --> tests/errors/continue_compilation_1.f90:438:44
     |
-415 |     print *, sum(arr1, mask = mask1, dim = 2)
+438 |     print *, sum(arr1, mask = mask1, dim = 2)
     |                                            ^ Must have 0 < dim <= 1 for array of rank 1
 
 semantic error: `dim` argument of the `Sum` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:416:44
+   --> tests/errors/continue_compilation_1.f90:439:44
     |
-416 |     print *, sum(arr1, mask = mask1, dim = -1)
+439 |     print *, sum(arr1, mask = mask1, dim = -1)
     |                                            ^^ Must have 0 < dim <= 1 for array of rank 1
 
 semantic error: `dim` argument of the `Product` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:418:34
+   --> tests/errors/continue_compilation_1.f90:441:34
     |
-418 |     print *, product(arr2, dim = 3)
+441 |     print *, product(arr2, dim = 3)
     |                                  ^ Must have 0 < dim <= 2 for array of rank 2
 
 semantic error: `dim` argument of the `Product` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:419:34
+   --> tests/errors/continue_compilation_1.f90:442:34
     |
-419 |     print *, product(arr2, dim = -1)
+442 |     print *, product(arr2, dim = -1)
     |                                  ^^ Must have 0 < dim <= 2 for array of rank 2
 
 semantic error: `dim` argument of the `Product` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:420:48
+   --> tests/errors/continue_compilation_1.f90:443:48
     |
-420 |     print *, product(arr2, mask = mask2, dim = 3)
+443 |     print *, product(arr2, mask = mask2, dim = 3)
     |                                                ^ Must have 0 < dim <= 2 for array of rank 2
 
 semantic error: `dim` argument of the `Product` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:421:48
+   --> tests/errors/continue_compilation_1.f90:444:48
     |
-421 |     print *, product(arr2, mask = mask2, dim = -1)
+444 |     print *, product(arr2, mask = mask2, dim = -1)
     |                                                ^^ Must have 0 < dim <= 2 for array of rank 2
 
 semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:423:34
+   --> tests/errors/continue_compilation_1.f90:446:34
     |
-423 |     print *, iparity(arr3, dim = 4)
+446 |     print *, iparity(arr3, dim = 4)
     |                                  ^ Must have 0 < dim <= 3 for array of rank 3
 
 semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:424:34
+   --> tests/errors/continue_compilation_1.f90:447:34
     |
-424 |     print *, iparity(arr3, dim = -1)
+447 |     print *, iparity(arr3, dim = -1)
     |                                  ^^ Must have 0 < dim <= 3 for array of rank 3
 
 semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:425:48
+   --> tests/errors/continue_compilation_1.f90:448:48
     |
-425 |     print *, iparity(arr3, mask = mask3, dim = 4)
+448 |     print *, iparity(arr3, mask = mask3, dim = 4)
     |                                                ^ Must have 0 < dim <= 3 for array of rank 3
 
 semantic error: `dim` argument of the `Iparity` intrinsic is out of bounds
-   --> tests/errors/continue_compilation_1.f90:426:48
+   --> tests/errors/continue_compilation_1.f90:449:48
     |
-426 |     print *, iparity(arr3, mask = mask3, dim = -1)
+449 |     print *, iparity(arr3, mask = mask3, dim = -1)
     |                                                ^^ Must have 0 < dim <= 3 for array of rank 3
 
 semantic error: Expected logical expression in if statement, but recieved integer(4) instead
-   --> tests/errors/continue_compilation_1.f90:428:9
+   --> tests/errors/continue_compilation_1.f90:451:9
     |
-428 |     if (q1) q1 = 1
+451 |     if (q1) q1 = 1
     |         ^^ integer(4) expression, expected logical
 
 semantic error: Expected logical expression in if statement, but recieved real(4) instead
-   --> tests/errors/continue_compilation_1.f90:429:9
+   --> tests/errors/continue_compilation_1.f90:452:9
     |
-429 |     if (r1) r1 = 1.0
+452 |     if (r1) r1 = 1.0
     |         ^^ real(4) expression, expected logical
 
 semantic error: Expected logical expression in if statement, but recieved string instead
-   --> tests/errors/continue_compilation_1.f90:430:9
+   --> tests/errors/continue_compilation_1.f90:453:9
     |
-430 |     if (c1) c1 = 'a'
+453 |     if (c1) c1 = 'a'
     |         ^^ string expression, expected logical
 
 semantic error: The ranks of the `array` and `mask` arguments of the `Sum` intrinsic must be the same
-   --> tests/errors/continue_compilation_1.f90:435:18
+   --> tests/errors/continue_compilation_1.f90:458:18
     |
-435 |     print *, sum(arr1, mask2)
+458 |     print *, sum(arr1, mask2)
     |                  ^^^^  ^^^^^ `array` is rank 1, but `mask` is rank 2
 
 semantic error: `dim` argument of `Sum` intrinsic must be INTEGER
-   --> tests/errors/continue_compilation_1.f90:436:24
+   --> tests/errors/continue_compilation_1.f90:459:24
     |
-436 |     print *, sum(arr2, mask3, 2)
+459 |     print *, sum(arr2, mask3, 2)
     |                        ^^^^^ 
 
 semantic error: The shapes of the `array` and `mask` arguments of the `Iparity` intrinsic must be the same
-   --> tests/errors/continue_compilation_1.f90:437:22
+   --> tests/errors/continue_compilation_1.f90:460:22
     |
-437 |     print *, iparity(arr2, mask4)
+460 |     print *, iparity(arr2, mask4)
     |                      ^^^^  ^^^^^ `array` has shape [2,3], but `mask` has shape [3,2]
 
 semantic error: `dim` argument of `Iparity` intrinsic must be INTEGER
-   --> tests/errors/continue_compilation_1.f90:438:28
+   --> tests/errors/continue_compilation_1.f90:461:28
     |
-438 |     print *, iparity(arr3, mask5, 3)
+461 |     print *, iparity(arr3, mask5, 3)
     |                            ^^^^^ 
 
 semantic error: Argument to 'present' must be a variable, but got an expression
-   --> tests/errors/continue_compilation_1.f90:441:22
+   --> tests/errors/continue_compilation_1.f90:464:22
     |
-441 |     print *, present(a + 1)
+464 |     print *, present(a + 1)
     |                      ^^^^^ Expected a variable here
 
 semantic error: Argument to 'present' must be an optional dummy argument
-   --> tests/errors/continue_compilation_1.f90:444:22
+   --> tests/errors/continue_compilation_1.f90:467:22
     |
-444 |     print *, present(a)
+467 |     print *, present(a)
     |                      ^ This variable is not 'optional'
 
 semantic error: Different shape for arguments `array` and `mask` for pack intrinsic (3 and 4)
-   --> tests/errors/continue_compilation_1.f90:446:30
+   --> tests/errors/continue_compilation_1.f90:469:30
     |
-446 |     print *, pack([1, 2, 3], [.true., .true., .true., .true.])
+469 |     print *, pack([1, 2, 3], [.true., .true., .true., .true.])
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: reshape accepts arrays for `source` argument, found string instead.
-   --> tests/errors/continue_compilation_1.f90:448:22
+   --> tests/errors/continue_compilation_1.f90:471:22
     |
-448 |     print *, reshape("hello", [2, 3])
+471 |     print *, reshape("hello", [2, 3])
     |                      ^^^^^^^ 
 
 semantic error: reshape accepts arrays for `source` argument, found logical instead.
-   --> tests/errors/continue_compilation_1.f90:449:22
+   --> tests/errors/continue_compilation_1.f90:472:22
     |
-449 |     print *, reshape(.true., [2, 3])
+472 |     print *, reshape(.true., [2, 3])
     |                      ^^^^^^ 
 
 semantic error: reshape accepts arrays for `shape` argument, found string instead.
-   --> tests/errors/continue_compilation_1.f90:450:36
+   --> tests/errors/continue_compilation_1.f90:473:36
     |
-450 |     print *, reshape([1, 2, 3, 4], "hello")
+473 |     print *, reshape([1, 2, 3, 4], "hello")
     |                                    ^^^^^^^ 
 
 semantic error: reshape accepts arrays for `shape` argument, found logical instead.
-   --> tests/errors/continue_compilation_1.f90:451:36
+   --> tests/errors/continue_compilation_1.f90:474:36
     |
-451 |     print *, reshape([1, 2, 3, 4], .false.)
+474 |     print *, reshape([1, 2, 3, 4], .false.)
     |                                    ^^^^^^^ 
 
 semantic error: reshape accepts `source` array with size greater than or equal to size specified by `shape` array
-   --> tests/errors/continue_compilation_1.f90:453:14
+   --> tests/errors/continue_compilation_1.f90:476:14
     |
-453 |     print *, reshape([1, 2, 3, 4], [2, 3])
+476 |     print *, reshape([1, 2, 3, 4], [2, 3])
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `shape` specifies size of 6 which exceeds the `source` array size of 4
 
 semantic error: Division by zero
-   --> tests/errors/continue_compilation_1.f90:456:14
+   --> tests/errors/continue_compilation_1.f90:479:14
     |
-456 |     print *, 1/0
+479 |     print *, 1/0
     |              ^^^ 
 
 semantic error: Division by zero
-   --> tests/errors/continue_compilation_1.f90:457:14
+   --> tests/errors/continue_compilation_1.f90:480:14
     |
-457 |     print *, x/zero
+480 |     print *, x/zero
     |              ^^^^^^ 
 
 semantic error: Type mismatch in binary operator, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:458:14
+   --> tests/errors/continue_compilation_1.f90:481:14
     |
-458 |     print *, v**str
+481 |     print *, v**str
     |              ^  ^^^ type mismatch (real and string)
 
 semantic error: Type mismatch in binary operator, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:459:14
+   --> tests/errors/continue_compilation_1.f90:482:14
     |
-459 |     print *, str**v
+482 |     print *, str**v
     |              ^^^  ^ type mismatch (string and real)
 
 semantic error: The shift argument of 'shiftl' intrinsic must be less than or equal to the bit size of the integer
-   --> tests/errors/continue_compilation_1.f90:461:24
+   --> tests/errors/continue_compilation_1.f90:484:24
     |
-461 |     print *, shiftl(2, 34)
+484 |     print *, shiftl(2, 34)
     |                        ^^ Shift value is 34, but bit size of integer is 32
 
 semantic error: The shift argument of 'shiftl' intrinsic must be non-negative integer
-   --> tests/errors/continue_compilation_1.f90:462:24
+   --> tests/errors/continue_compilation_1.f90:485:24
     |
-462 |     print *, shiftl(2, -3)
+485 |     print *, shiftl(2, -3)
     |                        ^^ 
 
 semantic error: The shift argument of 'shiftr' intrinsic must be less than or equal to the bit size of the integer
-   --> tests/errors/continue_compilation_1.f90:463:24
+   --> tests/errors/continue_compilation_1.f90:486:24
     |
-463 |     print *, shiftr(2, 34)
+486 |     print *, shiftr(2, 34)
     |                        ^^ Shift value is 34, but bit size of integer is 32
 
 semantic error: The shift argument of 'shiftr' intrinsic must be non-negative integer
-   --> tests/errors/continue_compilation_1.f90:464:24
+   --> tests/errors/continue_compilation_1.f90:487:24
     |
-464 |     print *, shiftr(2, -3)
+487 |     print *, shiftr(2, -3)
     |                        ^^ 
 
 semantic error: The shift argument of 'rshift' intrinsic must be less than or equal to the bit size of the integer
-   --> tests/errors/continue_compilation_1.f90:465:24
+   --> tests/errors/continue_compilation_1.f90:488:24
     |
-465 |     print *, rshift(2, 34)
+488 |     print *, rshift(2, 34)
     |                        ^^ Shift value is 34, but bit size of integer is 32
 
 semantic error: The shift argument of 'rshift' intrinsic must be non-negative integer
-   --> tests/errors/continue_compilation_1.f90:466:24
+   --> tests/errors/continue_compilation_1.f90:489:24
     |
-466 |     print *, rshift(2, -3)
+489 |     print *, rshift(2, -3)
     |                        ^^ 
 
 semantic error: Input to `Sum` is expected to be numeric, but got string[:]
-   --> tests/errors/continue_compilation_1.f90:468:18
+   --> tests/errors/continue_compilation_1.f90:491:18
     |
-468 |     print *, sum([c1])
+491 |     print *, sum([c1])
     |                  ^^^^ must be integer, real or complex type
 
 semantic error: Input to `Product` is expected to be numeric, but got string[:]
-   --> tests/errors/continue_compilation_1.f90:469:22
+   --> tests/errors/continue_compilation_1.f90:492:22
     |
-469 |     print *, product([c1])
+492 |     print *, product([c1])
     |                      ^^^^ must be integer, real or complex type
 
 semantic error: Input to `MinVal` is expected to be of integer, real or character type, but got complex[:]
-   --> tests/errors/continue_compilation_1.f90:470:21
+   --> tests/errors/continue_compilation_1.f90:493:21
     |
-470 |     print *, minval([c])
+493 |     print *, minval([c])
     |                     ^^^ must be integer, real or character type
 
 semantic error: Input to `MaxVal` is expected to be of integer, real or character type, but got complex[:]
-   --> tests/errors/continue_compilation_1.f90:471:21
+   --> tests/errors/continue_compilation_1.f90:494:21
     |
-471 |     print *, maxval([c])
+494 |     print *, maxval([c])
     |                     ^^^ must be integer, real or character type
 
 semantic error: Argument to intrinsic `Sum` is expected to be an array, found: integer
-   --> tests/errors/continue_compilation_1.f90:473:14
+   --> tests/errors/continue_compilation_1.f90:496:14
     |
-473 |     print *, sum(q1)
+496 |     print *, sum(q1)
     |              ^^^^^^^ 
 
 semantic error: Argument to intrinsic `Product` is expected to be an array, found: real
-   --> tests/errors/continue_compilation_1.f90:474:14
+   --> tests/errors/continue_compilation_1.f90:497:14
     |
-474 |     print *, product(r1)
+497 |     print *, product(r1)
     |              ^^^^^^^^^^^ 
 
 semantic error: Argument to intrinsic `MinVal` is expected to be an array, found: integer
-   --> tests/errors/continue_compilation_1.f90:475:14
+   --> tests/errors/continue_compilation_1.f90:498:14
     |
-475 |     print *, minval(q1)
+498 |     print *, minval(q1)
     |              ^^^^^^^^^^ 
 
 semantic error: Argument to intrinsic `MaxVal` is expected to be an array, found: real
-   --> tests/errors/continue_compilation_1.f90:476:14
+   --> tests/errors/continue_compilation_1.f90:499:14
     |
-476 |     print *, maxval(r1)
+499 |     print *, maxval(r1)
     |              ^^^^^^^^^^ 
 
 semantic error: 'mask' argument of 'sum' intrinsic must be logical
-   --> tests/errors/continue_compilation_1.f90:478:14
+   --> tests/errors/continue_compilation_1.f90:501:14
     |
-478 |     print *, sum([1, 2, 3], mask = [1, 2, 3])
+501 |     print *, sum([1, 2, 3], mask = [1, 2, 3])
     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Type mismatch in assignment, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:479:5
+   --> tests/errors/continue_compilation_1.f90:502:5
     |
-479 |     z1 = y 
+502 |     z1 = y 
     |     ^^   ^ type mismatch (real and logical)
 
 semantic error: reshape accepts arrays for `pad` argument, found integer instead.
-   --> tests/errors/continue_compilation_1.f90:481:50
+   --> tests/errors/continue_compilation_1.f90:504:50
     |
-481 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], 0)
+504 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], 0)
     |                                                  ^ 
 
 semantic error: reshape accepts arrays for `order` argument, found integer instead.
-   --> tests/errors/continue_compilation_1.f90:482:55
+   --> tests/errors/continue_compilation_1.f90:505:55
     |
-482 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0], 0)
+505 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0], 0)
     |                                                       ^ 
 
 semantic error: `pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type real(4) source type integer(4) instead.
-   --> tests/errors/continue_compilation_1.f90:483:50
+   --> tests/errors/continue_compilation_1.f90:506:50
     |
-483 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [1.2])
+506 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [1.2])
     |                                                  ^^^^^ 
 
 semantic error: `pad` argument of reshape intrinsic must have same type and kind as `source` argument, found pad type integer(8) source type integer(4) instead.
-   --> tests/errors/continue_compilation_1.f90:484:50
+   --> tests/errors/continue_compilation_1.f90:507:50
     |
-484 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0_8])
+507 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], [0_8])
     |                                                  ^^^^^ 
 
 semantic error: reshape accepts `order` array with integer elements
-   --> tests/errors/continue_compilation_1.f90:486:58
+   --> tests/errors/continue_compilation_1.f90:509:58
     |
-486 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [1.0, 2.0])
+509 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [1.0, 2.0])
     |                                                          ^^^^^^^^^^ 
 
 semantic error: reshape accepts `order` array as a permutation of elements from 1 to 2
-   --> tests/errors/continue_compilation_1.f90:487:58
+   --> tests/errors/continue_compilation_1.f90:510:58
     |
-487 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [2, 3])
+510 |     print *, reshape([1, 2, 3, 4, 5, 6], [2, 3], order = [2, 3])
     |                                                          ^^^^^^ 
 
 semantic error: Substring start index must be of type integer
-   --> tests/errors/continue_compilation_1.f90:488:16
+   --> tests/errors/continue_compilation_1.f90:511:16
     |
-488 |     print *, a(b'01':2)
+511 |     print *, a(b'01':2)
     |                ^^^^^ 
 
 semantic error: `mask` argument to `count` intrinsic must be a logical array
-   --> tests/errors/continue_compilation_1.f90:489:20
+   --> tests/errors/continue_compilation_1.f90:512:20
     |
-489 |     print *, count(1)
+512 |     print *, count(1)
     |                    ^ 
 
 semantic error: `mask` argument to `count` intrinsic must be a logical array
-   --> tests/errors/continue_compilation_1.f90:490:20
+   --> tests/errors/continue_compilation_1.f90:513:20
     |
-490 |     print *, count([2])
+513 |     print *, count([2])
     |                    ^^^ 
 
 semantic error: Substring stride must be of type integer
-   --> tests/errors/continue_compilation_1.f90:491:20
+   --> tests/errors/continue_compilation_1.f90:514:20
     |
-491 |     print *, a(1:2:b'10')
+514 |     print *, a(1:2:b'10')
     |                    ^^^^^ 
 
 semantic error: Type mismatch in assignment, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:492:5
+   --> tests/errors/continue_compilation_1.f90:515:5
     |
-492 |     a_real = [logical::]
+515 |     a_real = [logical::]
     |     ^^^^^^   ^^^^^^^^^^^ type mismatch (real[:] and logical[:])
 
 semantic error: Subroutine `dummy_sub` called as a function
-   --> tests/errors/continue_compilation_1.f90:494:14
+   --> tests/errors/continue_compilation_1.f90:517:14
     |
-494 |     print *, dummy_sub()
+517 |     print *, dummy_sub()
     |              ^^^^^^^^^^^ 
 
 semantic error: Input to `Iparity` is expected to be an integer, but got string[:]
-   --> tests/errors/continue_compilation_1.f90:495:22
+   --> tests/errors/continue_compilation_1.f90:518:22
     |
-495 |     print *, iparity(["a", "b"])
+518 |     print *, iparity(["a", "b"])
     |                      ^^^^^^^^^^ must be of integer type
 
 semantic error: The `mask` argument to `parity` must be logical, but got string[:]
-   --> tests/errors/continue_compilation_1.f90:496:21
+   --> tests/errors/continue_compilation_1.f90:519:21
     |
-496 |     print *, parity(["a", "b"])
+519 |     print *, parity(["a", "b"])
     |                     ^^^^^^^^^^ must be logical type
 
 semantic error: Substring end index exceeds the string length
-   --> tests/errors/continue_compilation_1.f90:497:14
+   --> tests/errors/continue_compilation_1.f90:520:14
     |
-497 |     print *, string(1:6)
+520 |     print *, string(1:6)
     |              ^^^^^^^^^^^ 
 
 semantic error: `shape` array in reshape intrinsic should be of constant size
-   --> tests/errors/continue_compilation_1.f90:499:30
+   --> tests/errors/continue_compilation_1.f90:522:30
     |
-499 |     matrix = reshape(source, shape_, pad=[0])
+522 |     matrix = reshape(source, shape_, pad=[0])
     |                              ^^^^^^ not a constant size array
 
 semantic error: Incompatible ranks 2 and 1 in assignment
-   --> tests/errors/continue_compilation_1.f90:499:5
+   --> tests/errors/continue_compilation_1.f90:522:5
     |
-499 |     matrix = reshape(source, shape_, pad=[0])
+522 |     matrix = reshape(source, shape_, pad=[0])
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Complex variable 'c' only has %re, %im, and %kind members, not 'mymember'
-   --> tests/errors/continue_compilation_1.f90:504:14
+   --> tests/errors/continue_compilation_1.f90:527:14
     |
-504 |     print *, c%mymember
+527 |     print *, c%mymember
     |              ^^^^^^^^^^ 
 
 semantic error: Character variable 'c1' only has %len and %kind members, not 'mymember'
-   --> tests/errors/continue_compilation_1.f90:506:14
+   --> tests/errors/continue_compilation_1.f90:529:14
     |
-506 |     print *, c1%mymember
+529 |     print *, c1%mymember
     |              ^^^^^^^^^^^ 
 
 semantic error: Substring end index must be of type integer
-   --> tests/errors/continue_compilation_1.f90:507:23
+   --> tests/errors/continue_compilation_1.f90:530:23
     |
-507 |     print *, string(1:Z'100000003')
+530 |     print *, string(1:Z'100000003')
     |                       ^^^^^^^^^^^^ 
 
 semantic error: Incorrect number of arguments passed to the 'present' intrinsic. It accepts exactly 1 arguments.
-   --> tests/errors/continue_compilation_1.f90:508:14
+   --> tests/errors/continue_compilation_1.f90:531:14
     |
-508 |     print *, present(x,x)
+531 |     print *, present(x,x)
     |              ^^^^^^^^^^^^ 
 
 semantic error: Incorrect number of arguments passed to the 'present' intrinsic. It accepts exactly 1 arguments.
-   --> tests/errors/continue_compilation_1.f90:509:14
+   --> tests/errors/continue_compilation_1.f90:532:14
     |
-509 |     print *, present()
+532 |     print *, present()
     |              ^^^^^^^^^ 
 
 semantic error: Incorrect number of arguments passed to the 'ieor' intrinsic. It accepts exactly 2 arguments.
-   --> tests/errors/continue_compilation_1.f90:510:14
+   --> tests/errors/continue_compilation_1.f90:533:14
     |
-510 |     print *, ieor(x)
+533 |     print *, ieor(x)
     |              ^^^^^^^ 
 
 semantic error: Incorrect number of arguments passed to the 'ieor' intrinsic. It accepts exactly 2 arguments.
-   --> tests/errors/continue_compilation_1.f90:511:14
+   --> tests/errors/continue_compilation_1.f90:534:14
     |
-511 |     print *, ieor()
+534 |     print *, ieor()
     |              ^^^^^^ 
 
 semantic error: Arguments to min0 must be of real, integer or character type
-   --> tests/errors/continue_compilation_1.f90:512:14
+   --> tests/errors/continue_compilation_1.f90:535:14
     |
-512 |     print *, min(c, c)
+535 |     print *, min(c, c)
     |              ^^^^^^^^^ 
 
 semantic error: `exit` statements cannot be outside of loops or blocks
-   --> tests/errors/continue_compilation_1.f90:513:5
+   --> tests/errors/continue_compilation_1.f90:536:5
     |
-513 |     exit
+536 |     exit
     |     ^^^^ 
 
 semantic error: `cycle` statements cannot be outside of loops
-   --> tests/errors/continue_compilation_1.f90:514:5
+   --> tests/errors/continue_compilation_1.f90:537:5
     |
-514 |     cycle
+537 |     cycle
     |     ^^^^^ 
 
 semantic error: Required argument `y` at position 2 is missing in procedure call
-   --> tests/errors/continue_compilation_1.f90:516:18
+   --> tests/errors/continue_compilation_1.f90:539:18
     |
-516 |     call my_func(10)
+539 |     call my_func(10)
     |                  ^^ 
 
 semantic error: Required argument `x` is missing in procedure call
-   --> tests/errors/continue_compilation_1.f90:517:5
+   --> tests/errors/continue_compilation_1.f90:540:5
     |
-517 |     call my_func()
+540 |     call my_func()
     |     ^^^^^^^^^^^^^^ 
 
 semantic error: Required argument `extra_arg` is missing in procedure call
-   --> tests/errors/continue_compilation_1.f90:521:5
+   --> tests/errors/continue_compilation_1.f90:544:5
     |
-521 |     call obj%display()
+544 |     call obj%display()
     |     ^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Shape mismatch in `allocate` statement.
-   --> tests/errors/continue_compilation_1.f90:523:14
+   --> tests/errors/continue_compilation_1.f90:546:14
     |
-523 |     allocate(arr4(5), source=[1, 2, 3])
+546 |     allocate(arr4(5), source=[1, 2, 3])
     |              ^^^^^^^         ^^^^^^^^^ shape mismatch in dimension 1
 
 semantic error: Type mismatch: The `source` argument in `allocate` must have the same type as the allocated variable.
 Expected type: integer[:] allocatable, but got: real.
-   --> tests/errors/continue_compilation_1.f90:524:14
+   --> tests/errors/continue_compilation_1.f90:547:14
     |
-524 |     allocate(arr4(5), source=v)
+547 |     allocate(arr4(5), source=v)
     |              ^^^^^^^         ^ incompatible types in `allocate` statement
 
 semantic error: Dimension mismatch in `allocate` statement.
-   --> tests/errors/continue_compilation_1.f90:525:14
+   --> tests/errors/continue_compilation_1.f90:548:14
     |
-525 |     allocate(arr4(3), source=reshape([1, 2, 3, 4, 5, 6], [2, 3]))
+548 |     allocate(arr4(3), source=reshape([1, 2, 3, 4, 5, 6], [2, 3]))
     |              ^^^^^^^         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mismatch in dimensions between allocated variable and `source`
 
 semantic error: Cannot allocate an array from a scalar source.
-   --> tests/errors/continue_compilation_1.f90:526:14
+   --> tests/errors/continue_compilation_1.f90:549:14
     |
-526 |     allocate(arr4, source=7)
+549 |     allocate(arr4, source=7)
     |              ^^^^ allocated variable is an array, but `source` is a scalar
 
 semantic error: Argument was not specified
-   --> tests/errors/continue_compilation_1.f90:528:5
+   --> tests/errors/continue_compilation_1.f90:551:5
     |
-528 |     call logger % add_log_file(filename=filename)
+551 |     call logger % add_log_file(filename=filename)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 1-th argument not specified for add_log_file
 
 semantic error: Required argument `unit` is missing in procedure call
-   --> tests/errors/continue_compilation_1.f90:529:5
+   --> tests/errors/continue_compilation_1.f90:552:5
     |
-529 |     call logger % add_log_file()
+552 |     call logger % add_log_file()
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `allocate` statement only accepts four keyword arguments: `stat`, `errmsg`, `source` and `mold`
-   --> tests/errors/continue_compilation_1.f90:531:5
+   --> tests/errors/continue_compilation_1.f90:554:5
     |
-531 |     allocate(arr5, status=q1)
+554 |     allocate(arr5, status=q1)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Different `character` lengths 2 and 3 in array constructor
-   --> tests/errors/continue_compilation_1.f90:534:21
+   --> tests/errors/continue_compilation_1.f90:557:21
     |
-534 |     print *, ["aa", "aaa"]
+557 |     print *, ["aa", "aaa"]
     |                     ^^^^^ 
 
 semantic error: Different shape for array assignment on dimension 1(2 and 1)
-   --> tests/errors/continue_compilation_1.f90:535:5
+   --> tests/errors/continue_compilation_1.f90:558:5
     |
-535 |     cc_a3 = cc_temp3(cc_i0:cc_i0)
+558 |     cc_a3 = cc_temp3(cc_i0:cc_i0)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: The argument `mask` must be of rank 2, an array with rank 1 was provided.
-   --> tests/errors/continue_compilation_1.f90:536:25
+   --> tests/errors/continue_compilation_1.f90:559:25
     |
-536 |     print *, pack(arr2, mask1)
+559 |     print *, pack(arr2, mask1)
     |                         ^^^^^ 
 
 semantic error: Variable protected_module_my_class_obj is PROTECTED and cannot appear in LHS of assignment
-   --> tests/errors/continue_compilation_1.f90:539:5
+   --> tests/errors/continue_compilation_1.f90:562:5
     |
-539 |     protected_module_my_class_obj%value = 42
+562 |     protected_module_my_class_obj%value = 42
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Different shape for array assignment on dimension 1(2 and 1)
-   --> tests/errors/continue_compilation_1.f90:540:5
+   --> tests/errors/continue_compilation_1.f90:563:5
     |
-540 |     cc_a4 = cc_temp4(cc_i1+1:cc_i1+1)
+563 |     cc_a4 = cc_temp4(cc_i1+1:cc_i1+1)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Invalid syntax of derived type for array constructor
-   --> tests/errors/continue_compilation_1.f90:541:12
+   --> tests/errors/continue_compilation_1.f90:564:12
     |
-541 |     arr = [type(MyClass) :: v1, v2, v3]
+564 |     arr = [type(MyClass) :: v1, v2, v3]
     |            ^^^^^^^^^^^^^ help: use just the derived type name 'myclass', without the keyword 'type'
 
 semantic error: Class type `NonExistingType` is not defined
-   --> tests/errors/continue_compilation_1.f90:543:11
+   --> tests/errors/continue_compilation_1.f90:566:11
     |
-543 |     arr = [NonExistingType :: v1, v2, v3]
+566 |     arr = [NonExistingType :: v1, v2, v3]
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: DATA statement element count mismatch: 8 elements on left-hand side, 10 values on right-hand side
-   --> tests/errors/continue_compilation_1.f90:546:5
+   --> tests/errors/continue_compilation_1.f90:569:5
     |
-546 |     data j2, x2, (y2(i2), i2=1,3), k2 / 1,2,3,4,5,6,7,3*8 /
+569 |     data j2, x2, (y2(i2), i2=1,3), k2 / 1,2,3,4,5,6,7,3*8 /
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: DO loop label 'q1' already defined
-   --> tests/errors/continue_compilation_1.f90:548:9 - 550:10
+   --> tests/errors/continue_compilation_1.f90:571:9 - 573:10
     |
-548 |        q1: do q1 = 1, 3
+571 |        q1: do q1 = 1, 3
     |            ^^^^^^^^^^^^...
 ...
     |
-550 |        end do q1
+573 |        end do q1
     | ...^^^^^^^^^^ 
 
 semantic error: Assigned format (using integer variable as format specifier) is not supported. Use character variables instead.
-   --> tests/errors/continue_compilation_1.f90:555:5
+   --> tests/errors/continue_compilation_1.f90:578:5
     |
-555 |     WRITE (6, fmt_i1)
+578 |     WRITE (6, fmt_i1)
     |     ^^^^^^^^^^^^^^^^^ 
 
 semantic error: Assigned format (using integer variable as format specifier) is not supported. Use character variables instead.
-   --> tests/errors/continue_compilation_1.f90:560:5
+   --> tests/errors/continue_compilation_1.f90:583:5
     |
-560 |     print fmt_i2, "test"
+583 |     print fmt_i2, "test"
     |     ^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Assigned format (using integer variable as format specifier) is not supported. Use character variables instead.
-   --> tests/errors/continue_compilation_1.f90:565:5
+   --> tests/errors/continue_compilation_1.f90:588:5
     |
-565 |     read (5, fmt_i3)
+588 |     read (5, fmt_i3)
     |     ^^^^^^^^^^^^^^^^ 
 
 semantic error: Type mismatch in argument `p`: expected a procedure but got `integer`
-   --> tests/errors/continue_compilation_1.f90:568:21
+   --> tests/errors/continue_compilation_1.f90:591:21
     |
-568 |     call proc_param(42)
+591 |     call proc_param(42)
     |                     ^^ 
 
 semantic error: `end` must be a literal integer label
-   --> tests/errors/continue_compilation_1.f90:571:18
+   --> tests/errors/continue_compilation_1.f90:594:18
     |
-571 |     read (*, end=x) x
+594 |     read (*, end=x) x
     |                  ^ 
 
 semantic error: `end` must be a literal integer label
-   --> tests/errors/continue_compilation_1.f90:572:18
+   --> tests/errors/continue_compilation_1.f90:595:18
     |
-572 |     read (*, end=9011.0) x
+595 |     read (*, end=9011.0) x
     |                  ^^^^^^ 
 
 semantic error: `err` must be a literal integer label
-   --> tests/errors/continue_compilation_1.f90:574:18
+   --> tests/errors/continue_compilation_1.f90:597:18
     |
-574 |     read (*, err=x) x
+597 |     read (*, err=x) x
     |                  ^ 
 
 semantic error: `err` must be a literal integer label
-   --> tests/errors/continue_compilation_1.f90:575:18
+   --> tests/errors/continue_compilation_1.f90:598:18
     |
-575 |     read (*, err=9013.0) x
+598 |     read (*, err=9013.0) x
     |                  ^^^^^^ 
 
 semantic error: `end` is only supported for READ statements
-   --> tests/errors/continue_compilation_1.f90:576:5
+   --> tests/errors/continue_compilation_1.f90:599:5
     |
-576 |     write (*, end=9014) x
+599 |     write (*, end=9014) x
     |     ^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: end= label 999 is not defined
-   --> tests/errors/continue_compilation_1.f90:581:20
+   --> tests/errors/continue_compilation_1.f90:604:20
     |
-581 |     read(*, *, end=999) x   
+604 |     read(*, *, end=999) x   
     |                    ^^^ 
 
 semantic error: err= label 500 is not defined
-   --> tests/errors/continue_compilation_1.f90:582:20
+   --> tests/errors/continue_compilation_1.f90:605:20
     |
-582 |     read(*, *, err=500) x
+605 |     read(*, *, err=500) x
     |                    ^^^ 
 
 semantic error: Duplicate value of `recl` found, it has already been specified via arguments or keyword arguments
-   --> tests/errors/continue_compilation_1.f90:584:5
+   --> tests/errors/continue_compilation_1.f90:607:5
     |
-584 |     OPEN(unit=10, recl=10, recl=20)
+607 |     OPEN(unit=10, recl=10, recl=20)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `recl` must be of type, Integer
-   --> tests/errors/continue_compilation_1.f90:585:5
+   --> tests/errors/continue_compilation_1.f90:608:5
     |
-585 |     OPEN(unit=10, recl=10.5)
+608 |     OPEN(unit=10, recl=10.5)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Invalid substring syntax: use lower:upper instead of lower,upper
-   --> tests/errors/continue_compilation_1.f90:588:14
+   --> tests/errors/continue_compilation_1.f90:611:14
     |
-588 |     print *, string(i,i)
+611 |     print *, string(i,i)
     |              ^^^^^^^^^^^ 
 
 semantic error: Allocate should only be called with Allocatable or Pointer type inputs, found str
-   --> tests/errors/continue_compilation_1.f90:590:14
+   --> tests/errors/continue_compilation_1.f90:613:14
     |
-590 |     allocate(strx)
+613 |     allocate(strx)
     |              ^^^^ 'strx' is not allocatable or pointer
 
 semantic error: Type mismatch: allocatable character dummy argument 's' has length 5 but actual argument has length 10.
-   --> tests/errors/continue_compilation_1.f90:592:32
+   --> tests/errors/continue_compilation_1.f90:615:32
     |
-592 |     call modify_and_deallocate(strx)
+615 |     call modify_and_deallocate(strx)
     |                                ^^^^ dummy argument 's' declared here
 
 semantic error: Intrinsic `allocated` can be called only on allocatable argument
-   --> tests/errors/continue_compilation_1.f90:593:14
+   --> tests/errors/continue_compilation_1.f90:616:14
     |
-593 |     print *, allocated(strx)
+616 |     print *, allocated(strx)
     |              ^^^^^^^^^^^^^^^ 
 
 semantic error: Duplicate value of `encoding` found
-   --> tests/errors/continue_compilation_1.f90:597:5
+   --> tests/errors/continue_compilation_1.f90:620:5
     |
-597 |     OPEN(unit=10, encoding="UTF-8", encoding="UTF-8")
+620 |     OPEN(unit=10, encoding="UTF-8", encoding="UTF-8")
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `encoding` must be of type, String or StringPointer
-   --> tests/errors/continue_compilation_1.f90:598:5
+   --> tests/errors/continue_compilation_1.f90:621:5
     |
-598 |     OPEN(unit=10, encoding=10)
+621 |     OPEN(unit=10, encoding=10)
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `rec` specifier is not allowed for internal file I/O
-   --> tests/errors/continue_compilation_1.f90:601:5
+   --> tests/errors/continue_compilation_1.f90:624:5
     |
-601 |     read(str_var, rec=1) x
+624 |     read(str_var, rec=1) x
     |     ^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `rec` specifier is not allowed for internal file I/O
-   --> tests/errors/continue_compilation_1.f90:602:5
+   --> tests/errors/continue_compilation_1.f90:625:5
     |
-602 |     write(str_var, rec=1) x
+625 |     write(str_var, rec=1) x
     |     ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Duplicate value of `rec` found, it has already been specified via arguments or keyword arguments
-   --> tests/errors/continue_compilation_1.f90:603:5
+   --> tests/errors/continue_compilation_1.f90:626:5
     |
-603 |     read(unit=10, rec=1, rec=2) y
+626 |     read(unit=10, rec=1, rec=2) y
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Duplicate value of `rec` found, it has already been specified via arguments or keyword arguments
-   --> tests/errors/continue_compilation_1.f90:604:5
+   --> tests/errors/continue_compilation_1.f90:627:5
     |
-604 |     write(unit=10, rec=1, rec=2) y
+627 |     write(unit=10, rec=1, rec=2) y
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `rec` must be of type, Integer
-   --> tests/errors/continue_compilation_1.f90:605:5
+   --> tests/errors/continue_compilation_1.f90:628:5
     |
-605 |     read(10, rec=1.5) y
+628 |     read(10, rec=1.5) y
     |     ^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `rec` must be of type, Integer
-   --> tests/errors/continue_compilation_1.f90:606:5
+   --> tests/errors/continue_compilation_1.f90:629:5
     |
-606 |     write(10, rec=2.5) y
+629 |     write(10, rec=2.5) y
     |     ^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `bad` is not defined or imported
-   --> tests/errors/continue_compilation_1.f90:609:13
+   --> tests/errors/continue_compilation_1.f90:632:13
     |
-609 |     bad_x = .bad. 10
+632 |     bad_x = .bad. 10
     |             ^^^^^^^^ 
 
 semantic error: `op` is not defined or imported
-   --> tests/errors/continue_compilation_1.f90:610:13
+   --> tests/errors/continue_compilation_1.f90:633:13
     |
-610 |     bad_x = 5 .op. 3
+633 |     bad_x = 5 .op. 3
     |             ^^^^^^^^ 
 
 semantic error: Operands of comparison operator '==' are not comparable: ieee_class_type == ieee_class_type
-   --> tests/errors/continue_compilation_1.f90:612:10
+   --> tests/errors/continue_compilation_1.f90:635:10
     |
-612 |     b = (ieee_cls == ieee_quiet_nan)
+635 |     b = (ieee_cls == ieee_quiet_nan)
     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Type mismatch in assignment, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:612:5
+   --> tests/errors/continue_compilation_1.f90:635:5
     |
-612 |     b = (ieee_cls == ieee_quiet_nan)
+635 |     b = (ieee_cls == ieee_quiet_nan)
     |     ^                ^^^^^^^^^^^^^^ type mismatch (integer[:] and ieee_class_type)
 
 semantic error: Type mismatch in assignment, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:617:5
+   --> tests/errors/continue_compilation_1.f90:640:5
     |
-617 |     base_var = derived_var
+640 |     base_var = derived_var
     |     ^^^^^^^^   ^^^^^^^^^^^ type mismatch (base and derived)
 
 semantic error: Type mismatch in argument `this`: expected `derived_type` but got `integer(4)`
-   --> tests/errors/continue_compilation_1.f90:628:21
+   --> tests/errors/continue_compilation_1.f90:651:21
     |
-628 |     call set_caller(1)
+651 |     call set_caller(1)
     |                     ^ 
 
 semantic error: Implied DO loop must be enclosed within array constructor brackets [...]; expected '[( ... )]' in assignment
-   --> tests/errors/continue_compilation_1.f90:629:15
+   --> tests/errors/continue_compilation_1.f90:652:15
     |
-629 |     arr_idl = (i, i = 1, 4)
+652 |     arr_idl = (i, i = 1, 4)
     |               ^^^^^^^^^^^^^ 
 
 semantic error: ADVANCE= specifier must have value = YES or NO
-   --> tests/errors/continue_compilation_1.f90:632:30
+   --> tests/errors/continue_compilation_1.f90:655:30
     |
-632 |     write (*, "(a)", advance="hello") "Dothraki culture"
+655 |     write (*, "(a)", advance="hello") "Dothraki culture"
     |                              ^^^^^^^ 
 
 semantic error: 'dim' argument of 'sum' intrinsic must be INTEGER
-   --> tests/errors/continue_compilation_1.f90:633:30
+   --> tests/errors/continue_compilation_1.f90:656:30
     |
-633 |     print *, sum(arr1, dim = mask1)
+656 |     print *, sum(arr1, dim = mask1)
     |                              ^^^^^ 
 
 semantic error: 'ieee_is_nan' is not accessible in the current scope; add 'use, intrinsic :: ieee_arithmetic' to use it
-   --> tests/errors/continue_compilation_1.f90:634:13
+   --> tests/errors/continue_compilation_1.f90:657:13
     |
-634 |     print*, ieee_is_nan(1.0)
+657 |     print*, ieee_is_nan(1.0)
     |             ^^^^^^^^^^^^^^^^ not in scope
 
 semantic error: `decimal` must be of type, String or StringPointer
-   --> tests/errors/continue_compilation_1.f90:635:5
+   --> tests/errors/continue_compilation_1.f90:658:5
     |
-635 |     open(unit=7, decimal=1, decimal="comma")
+658 |     open(unit=7, decimal=1, decimal="comma")
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Duplicate value of `decimal` found
-   --> tests/errors/continue_compilation_1.f90:636:5
+   --> tests/errors/continue_compilation_1.f90:659:5
     |
-636 |     open(unit=7, decimal="POINT", decimal="comma")
+659 |     open(unit=7, decimal="POINT", decimal="comma")
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Missing 'boundary' argument to 'eoshift' intrinsic
-   --> tests/errors/continue_compilation_1.f90:642:38
+   --> tests/errors/continue_compilation_1.f90:665:38
     |
-642 |     eoshift_derived_result = eoshift(eoshift_derived_array, 1)
+665 |     eoshift_derived_result = eoshift(eoshift_derived_array, 1)
     |                                      ^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Implicit casting from LOGICAL to INTEGER is not allowed by default. Use `--logical-casting` flag to enable it.
-   --> tests/errors/continue_compilation_1.f90:648:5
+   --> tests/errors/continue_compilation_1.f90:671:5
     |
-648 |     a(1) = .true.
+671 |     a(1) = .true.
     |     ^^^^^^^^^^^^^ 
 
 semantic error: Type mismatch in assignment, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:649:5
+   --> tests/errors/continue_compilation_1.f90:672:5
     |
-649 |     derived_cls = base_var
+672 |     derived_cls = base_var
     |     ^^^^^^^^^^^   ^^^^^^^^ type mismatch (derived and base)
 
 warning: Real constant overflows its kind (4)
-   --> tests/errors/continue_compilation_1.f90:651:15
+   --> tests/errors/continue_compilation_1.f90:674:15
     |
-651 |     print  *, 9.99e+99
+674 |     print  *, 9.99e+99
     |               ^^^^^^^^ 
 
 semantic error: Missing actual argument for argument 'stat'
-   --> tests/errors/continue_compilation_1.f90:652:10
+   --> tests/errors/continue_compilation_1.f90:675:10
     |
-652 |     a5 = missing_required_arg_func()
+675 |     a5 = missing_required_arg_func()
     |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `asynchronous` must be of type String
-   --> tests/errors/continue_compilation_1.f90:655:69
+   --> tests/errors/continue_compilation_1.f90:678:69
     |
-655 |     open(newunit=u, file="test.dat", status="replace", asynchronous=1)
+678 |     open(newunit=u, file="test.dat", status="replace", asynchronous=1)
     |                                                                     ^ 
 
 semantic error: Duplicate value of `asynchronous` found
-   --> tests/errors/continue_compilation_1.f90:656:89
+   --> tests/errors/continue_compilation_1.f90:679:89
     |
-656 |     open(newunit=u, file="test.dat", status="replace", asynchronous="yes", asynchronous="no")
+679 |     open(newunit=u, file="test.dat", status="replace", asynchronous="yes", asynchronous="no")
     |                                                                                         ^^^^ 
 
 semantic error: The argument `shift` in `eoshift` must be scalar or have rank one less than `array`
-   --> tests/errors/continue_compilation_1.f90:659:22
+   --> tests/errors/continue_compilation_1.f90:682:22
     |
-659 |     b1 = eoshift(b1, eoshift_bad_shift)
+682 |     b1 = eoshift(b1, eoshift_bad_shift)
     |                      ^^^^^^^^^^^^^^^^^ 
 
 semantic error: No matching `operator(-)` found for this operand type
-   --> tests/errors/continue_compilation_1.f90:665:18
+   --> tests/errors/continue_compilation_1.f90:688:18
     |
-665 |         print *, -tt
+688 |         print *, -tt
     |                  ^^^ 
 
 semantic error: Variable 'k' is not declared
-   --> tests/errors/continue_compilation_1.f90:681:12
+   --> tests/errors/continue_compilation_1.f90:704:12
     |
-681 |         do k = 1, 3
+704 |         do k = 1, 3
     |            ^ 'k' is undeclared
 
 semantic error: Expected logical expression in if statement, but recieved logical[:] instead
-   --> tests/errors/continue_compilation_1.f90:692:13
+   --> tests/errors/continue_compilation_1.f90:715:13
     |
-692 |         if (abs(arr1)(1) /= 2471095) error stop
+715 |         if (abs(arr1)(1) /= 2471095) error stop
     |             ^^^^^^^^^^^^^^^^^^^^^^^ logical[:] expression, expected logical
 
 semantic error: Character intrinsic 'len' with class(*) argument must be inside 'type is (character(len=*))' guard
-   --> tests/errors/continue_compilation_1.f90:700:22
+   --> tests/errors/continue_compilation_1.f90:723:22
     |
-700 |         print *, len(generic)
+723 |         print *, len(generic)
     |                      ^^^^^^^ invalid use of character intrinsic with polymorphic argument
 
 semantic error: Argument of 'len' intrinsic must be CHARACTER, found integer instead.
-   --> tests/errors/continue_compilation_1.f90:701:22
+   --> tests/errors/continue_compilation_1.f90:724:22
     |
-701 |         print *, len(a)
+724 |         print *, len(a)
     |                      ^ 
 
 semantic error: `unit` must be of type Integer or Character
-   --> tests/errors/continue_compilation_1.f90:707:9
+   --> tests/errors/continue_compilation_1.f90:730:9
     |
-707 |         write(unit=r, fmt=*) "hello"  ! {Error} `unit` must be of type Integer or Character
+730 |         write(unit=r, fmt=*) "hello"  ! {Error} `unit` must be of type Integer or Character
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Type mismatch in assignment, the types must be compatible
-   --> tests/errors/continue_compilation_1.f90:713:9
+   --> tests/errors/continue_compilation_1.f90:736:9
     |
-713 |         x = [character(len=3) :: "aa", "bb", "aa"]
+736 |         x = [character(len=3) :: "aa", "bb", "aa"]
     |         ^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ type mismatch (integer[:] and string[:])
 
 semantic error: case value must be scalar
-   --> tests/errors/continue_compilation_1.f90:745:16
+   --> tests/errors/continue_compilation_1.f90:768:16
     |
-745 |         case (:[2])
+768 |         case (:[2])
     |                ^^^ 
 
 semantic error: Alternate return arguments are not permitted in calls to the 'cpu_time' intrinsic.
-   --> tests/errors/continue_compilation_1.f90:753:9
+   --> tests/errors/continue_compilation_1.f90:776:9
     |
-753 |         call cpu_time(*1)
+776 |         call cpu_time(*1)
     |         ^^^^^^^^^^^^^^^^^ 
 
 semantic error: `stat` argument of `sync all` must be of type integer, found string
-   --> tests/errors/continue_compilation_1.f90:759:9
+   --> tests/errors/continue_compilation_1.f90:782:9
     |
-759 |         sync all (stat=cstat)  ! {Error} `stat` argument of `sync all` must be of type integer
+782 |         sync all (stat=cstat)  ! {Error} `stat` argument of `sync all` must be of type integer
     |         ^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `errmsg` argument of `sync all` must be of type character, found integer
-   --> tests/errors/continue_compilation_1.f90:764:9
+   --> tests/errors/continue_compilation_1.f90:787:9
     |
-764 |         sync all (errmsg=imsg)  ! {Error} `errmsg` argument of `sync all` must be of type character
+787 |         sync all (errmsg=imsg)  ! {Error} `errmsg` argument of `sync all` must be of type character
     |         ^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `stat` argument of `sync all` must be scalar
-   --> tests/errors/continue_compilation_1.f90:769:9
+   --> tests/errors/continue_compilation_1.f90:792:9
     |
-769 |         sync all (stat=astat)  ! {Error} `stat` argument of `sync all` must be scalar
+792 |         sync all (stat=astat)  ! {Error} `stat` argument of `sync all` must be scalar
     |         ^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Variable 'nosuch' is not declared
-   --> tests/errors/continue_compilation_1.f90:773:9
+   --> tests/errors/continue_compilation_1.f90:796:9
     |
-773 |         sync all (stat=nosuch)  ! {Error} Variable 'nosuch' is not declared
+796 |         sync all (stat=nosuch)  ! {Error} Variable 'nosuch' is not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^ 'nosuch' is undeclared
 
 semantic error: actual argument for 'x' cannot be an assumed-size array
-   --> tests/errors/continue_compilation_1.f90:777:23
+   --> tests/errors/continue_compilation_1.f90:800:23
     |
-777 |         call ptr_sink(x)  ! {Error} actual argument for 'x' cannot be an assumed-size array
+800 |         call ptr_sink(x)  ! {Error} actual argument for 'x' cannot be an assumed-size array
     |                       ^ 
 
 semantic error: select case expression must be of type integer, character, or logical
-   --> tests/errors/continue_compilation_1.f90:785:22
+   --> tests/errors/continue_compilation_1.f90:808:22
     |
-785 |         select case (nn)
+808 |         select case (nn)
     |                      ^^ 
 
 semantic error: select case expression must be of type integer, character, or logical
-   --> tests/errors/continue_compilation_1.f90:792:22
+   --> tests/errors/continue_compilation_1.f90:815:22
     |
-792 |         select case (x)
+815 |         select case (x)
     |                      ^ 
 
 semantic error: second argument of `lge` must have kind equal to 1
-   --> tests/errors/continue_compilation_1.f90:800:18
+   --> tests/errors/continue_compilation_1.f90:823:18
     |
-800 |         print *, lge("a", glyph)  
+823 |         print *, lge("a", glyph)  
     |                  ^^^^^^^^^^^^^^^ 
 
 semantic error: second argument of `lgt` must have kind equal to 1
-   --> tests/errors/continue_compilation_1.f90:801:18
+   --> tests/errors/continue_compilation_1.f90:824:18
     |
-801 |         print *, lgt("a", glyph)  
+824 |         print *, lgt("a", glyph)  
     |                  ^^^^^^^^^^^^^^^ 
 
 semantic error: first argument of `lle` must have kind equal to 1
-   --> tests/errors/continue_compilation_1.f90:802:18
+   --> tests/errors/continue_compilation_1.f90:825:18
     |
-802 |         print *, lle(glyph, "z")  
+825 |         print *, lle(glyph, "z")  
     |                  ^^^^^^^^^^^^^^^ 
 
 semantic error: first argument of `llt` must have kind equal to 1
-   --> tests/errors/continue_compilation_1.f90:803:18
+   --> tests/errors/continue_compilation_1.f90:826:18
     |
-803 |         print *, llt(glyph, "z")  
+826 |         print *, llt(glyph, "z")  
     |                  ^^^^^^^^^^^^^^^ 
 
 semantic error: Dimension index 5 is out of range for `spread`; expected 1 <= dim <= 2
-   --> tests/errors/continue_compilation_1.f90:818:28
+   --> tests/errors/continue_compilation_1.f90:841:28
     |
-818 |         print *, spread(a, 5, 2)
+841 |         print *, spread(a, 5, 2)
     |                            ^ 
 
 semantic error: Type and kind of the relevant arguments of Merge must be the same
-   --> tests/errors/continue_compilation_1.f90:827:18
+   --> tests/errors/continue_compilation_1.f90:850:18
     |
-827 |         print *, merge(a, b, .true.)
+850 |         print *, merge(a, b, .true.)
     |                  ^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `a` argument of `co_max` must be of integer, real or character type, but got complex
-   --> tests/errors/continue_compilation_1.f90:833:21
+   --> tests/errors/continue_compilation_1.f90:856:21
     |
-833 |         call co_max(z)
+856 |         call co_max(z)
     |                     ^ must be integer, real or character type
 
 semantic error: `a` argument of `co_sum` must be of integer, real or complex type, but got logical
-   --> tests/errors/continue_compilation_1.f90:839:21
+   --> tests/errors/continue_compilation_1.f90:862:21
     |
-839 |         call co_sum(mask)
+862 |         call co_sum(mask)
     |                     ^^^^ must be integer, real or complex type
 
 semantic error: duplicate statement label 1000
-   --> tests/errors/continue_compilation_1.f90:844:9
+   --> tests/errors/continue_compilation_1.f90:867:9
     |
-844 | 1000    continue
+867 | 1000    continue
     |         ^^^^^^^^ 
 
 semantic error: Selector shall be polymorphic in SELECT TYPE statement
-   --> tests/errors/continue_compilation_1.f90:850:22
+   --> tests/errors/continue_compilation_1.f90:873:22
     |
-850 |         select type (a)
+873 |         select type (a)
     |                      ^ 
 
 semantic error: The `MIN` intrinsic requires all CHARACTER arguments to have the same kind; found kind 1 and 4
-   --> tests/errors/continue_compilation_1.f90:859:18
+   --> tests/errors/continue_compilation_1.f90:882:18
     |
-859 |         print *, min(c1, c4)
+882 |         print *, min(c1, c4)
     |                  ^^^^^^^^^^^ 
 
 semantic error: Label 20 is not defined
-   --> tests/errors/continue_compilation_1.f90:864:9
+   --> tests/errors/continue_compilation_1.f90:887:9
     |
-864 |         goto 20  ! {Error} Label 20 is not defined
+887 |         goto 20  ! {Error} Label 20 is not defined
     |         ^^^^^^^ 
 
 semantic error: actual argument for 'items' cannot be an assumed-size array
-   --> tests/errors/continue_compilation_1.f90:875:36
+   --> tests/errors/continue_compilation_1.f90:898:36
     |
-875 |         call consume_assumed_shape(items)  ! {Error} actual argument for 'items' cannot be an assumed-size array
+898 |         call consume_assumed_shape(items)  ! {Error} actual argument for 'items' cannot be an assumed-size array
     |                                    ^^^^^ 
 
 semantic error: actual argument for 'items' cannot be an assumed-size array
-   --> tests/errors/continue_compilation_1.f90:884:49
+   --> tests/errors/continue_compilation_1.f90:907:49
     |
-884 |         print *, consume_assumed_shape_function(items)  ! {Error} actual argument for 'items' cannot be an assumed-size array
+907 |         print *, consume_assumed_shape_function(items)  ! {Error} actual argument for 'items' cannot be an assumed-size array
     |                                                 ^^^^^ 
 
 semantic error: Association target cannot be a BOZ literal constant
-   --> tests/errors/continue_compilation_1.f90:892:25
+   --> tests/errors/continue_compilation_1.f90:915:25
     |
-892 |         associate (y => z'1') 
+915 |         associate (y => z'1') 
     |                         ^^^^ 
 
 semantic error: Cannot initialize integer(4) variable with character(len=3) value in DATA statement
-   --> tests/errors/continue_compilation_1.f90:899:9
+   --> tests/errors/continue_compilation_1.f90:922:9
     |
-899 |         data x / "abc" /
+922 |         data x / "abc" /
     |         ^^^^^^^^^^^^^^^^ 
 
 semantic error: `array` argument of `norm2` intrinsic must be an array
-   --> tests/errors/continue_compilation_1.f90:903:19
+   --> tests/errors/continue_compilation_1.f90:926:19
     |
-903 |         x = norm2(1.0)
+926 |         x = norm2(1.0)
     |                   ^^^ 
 
 semantic error: `array` argument of `norm2` intrinsic must be real
-   --> tests/errors/continue_compilation_1.f90:904:19
+   --> tests/errors/continue_compilation_1.f90:927:19
     |
-904 |         x = norm2([1, 2])
+927 |         x = norm2([1, 2])
     |                   ^^^^^^ 
 
 semantic error: `dim` argument of `norm2` intrinsic is not a valid dimension index
-   --> tests/errors/continue_compilation_1.f90:905:35
+   --> tests/errors/continue_compilation_1.f90:928:35
     |
-905 |         x = norm2([1.0, 2.0], dim=2)
+928 |         x = norm2([1.0, 2.0], dim=2)
     |                                   ^ 
 
 semantic error: Unsupported Real kind '666' in `real()`, must be one of: 4, 8, 16
-   --> tests/errors/continue_compilation_1.f90:918:27
+   --> tests/errors/continue_compilation_1.f90:941:27
     |
-918 |         print *, real(1., 666)
+941 |         print *, real(1., 666)
     |                           ^^^ 
 
 semantic error: `array` and `value` arguments of `findloc` must have the same type and kind, but got character(len=1, kind=4) and character(len=1, kind=1)
-   --> tests/errors/continue_compilation_1.f90:959:18
+   --> tests/errors/continue_compilation_1.f90:982:18
     |
-959 |         print *, findloc(names, key)
+982 |         print *, findloc(names, key)
     |                  ^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: The implied do loop variable 'r_idx' must be a scalar integer, not real(4)
-   --> tests/errors/continue_compilation_1.f90:966:19
+   --> tests/errors/continue_compilation_1.f90:989:19
     |
-966 |         values = [(real(r_idx), r_idx = 1, 3)]  ! {Error} The implied do loop variable 'r_idx' must be a scalar integer, not real(4)
+989 |         values = [(real(r_idx), r_idx = 1, 3)]  ! {Error} The implied do loop variable 'r_idx' must be a scalar integer, not real(4)
     |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: operands of // must be character with the same kind, found character(4) and character(1)
-   --> tests/errors/continue_compilation_1.f90:976:18
+   --> tests/errors/continue_compilation_1.f90:999:18
     |
-976 |         print *, wide // narrow  ! {Error} operands of // must be character with the same kind, found character(4) and character(1)
+999 |         print *, wide // narrow  ! {Error} operands of // must be character with the same kind, found character(4) and character(1)
     |                  ^^^^^^^^^^^^^^ 
 
 semantic error: operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
-   --> tests/errors/continue_compilation_1.f90:985:13
-    |
-985 |         if (wide == narrow) print *, "eq"  ! {Error} operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
-    |             ^^^^^^^^^^^^^^ 
+    --> tests/errors/continue_compilation_1.f90:1008:13
+     |
+1008 |         if (wide == narrow) print *, "eq"  ! {Error} operands of comparison operator '==' must be character with the same kind, found character(4) and character(1)
+     |             ^^^^^^^^^^^^^^ 
 
 semantic error: kind 3 is not supported for character, only 1 and 4 are
-   --> tests/errors/continue_compilation_1.f90:991:13
-    |
-991 |         s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
-    |             ^^^^^^^ 
+    --> tests/errors/continue_compilation_1.f90:1014:13
+     |
+1014 |         s = 3_"abc"  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+     |             ^^^^^^^ 
 
 semantic error: Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
-    --> tests/errors/continue_compilation_1.f90:1006:18
+    --> tests/errors/continue_compilation_1.f90:1029:18
      |
-1006 |         print *, d%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+1029 |         print *, d%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
      |                  ^^^^^^^^^ 
 
 semantic error: Character variable 's' only has %len and %kind members, not 'bogus'
-    --> tests/errors/continue_compilation_1.f90:1007:18
+    --> tests/errors/continue_compilation_1.f90:1030:18
      |
-1007 |         print *, d%s%bogus  ! {Error} Character variable 's' only has %len and %kind members, not 'bogus'
+1030 |         print *, d%s%bogus  ! {Error} Character variable 's' only has %len and %kind members, not 'bogus'
      |                  ^^^^^^^^^ 
 
 semantic error: Variable 'i' doesn't have any member named, 'bogus'.
-    --> tests/errors/continue_compilation_1.f90:1008:18
+    --> tests/errors/continue_compilation_1.f90:1031:18
      |
-1008 |         print *, d%i%bogus  ! {Error} Variable 'i' doesn't have any member named, 'bogus'.
+1031 |         print *, d%i%bogus  ! {Error} Variable 'i' doesn't have any member named, 'bogus'.
      |                  ^^^^^^^^^ 
 
 semantic error: Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
-    --> tests/errors/continue_compilation_1.f90:1009:18
+    --> tests/errors/continue_compilation_1.f90:1032:18
      |
-1009 |         print *, o%in%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
+1032 |         print *, o%in%c%bogus  ! {Error} Complex variable 'c' only has %re, %im, and %kind members, not 'bogus'
      |                  ^^^^^^^^^^^^ 
 
 semantic error: `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
-    --> tests/errors/continue_compilation_1.f90:1016:13
+    --> tests/errors/continue_compilation_1.f90:1039:13
      |
-1016 |         r = maxval(c, dim=1)  ! {Error} `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
+1039 |         r = maxval(c, dim=1)  ! {Error} `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
      |             ^^^^^^^^^^^^^^^^ 
 
 semantic error: `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
-    --> tests/errors/continue_compilation_1.f90:1017:13
+    --> tests/errors/continue_compilation_1.f90:1040:13
      |
-1017 |         r = minval(c, dim=1)  ! {Error} `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
+1040 |         r = minval(c, dim=1)  ! {Error} `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
      |             ^^^^^^^^^^^^^^^^ 
 
 semantic error: `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
-    --> tests/errors/continue_compilation_1.f90:1018:13
+    --> tests/errors/continue_compilation_1.f90:1041:13
      |
-1018 |         s = maxval(c, mask=.false.)  ! {Error} `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
+1041 |         s = maxval(c, mask=.false.)  ! {Error} `dim` and `mask` arguments to `MaxVal` are not implemented yet for arrays of character type
      |             ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
-    --> tests/errors/continue_compilation_1.f90:1019:13
+    --> tests/errors/continue_compilation_1.f90:1042:13
      |
-1019 |         s = minval(c, mask=.false.)  ! {Error} `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
+1042 |         s = minval(c, mask=.false.)  ! {Error} `dim` and `mask` arguments to `MinVal` are not implemented yet for arrays of character type
      |             ^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: the arms of a conditional expression must have the same type and kind
-    --> tests/errors/continue_compilation_1.f90:1028:24
+    --> tests/errors/continue_compilation_1.f90:1051:24
      |
-1028 |         x = ( .true. ? 1 : 1.0 )  ! {Error} the arms of a conditional expression must have the same type and kind
+1051 |         x = ( .true. ? 1 : 1.0 )  ! {Error} the arms of a conditional expression must have the same type and kind
      |                        ^   ^^^ type mismatch (integer(4) and real(4))
 
 semantic error: the arms of a conditional expression must have the same type and kind
-    --> tests/errors/continue_compilation_1.f90:1041:24
+    --> tests/errors/continue_compilation_1.f90:1064:24
      |
-1041 |         x = ( .true. ? a : b )  ! {Error} the arms of a conditional expression must have the same type and kind
+1064 |         x = ( .true. ? a : b )  ! {Error} the arms of a conditional expression must have the same type and kind
      |                        ^   ^ type mismatch (integer(4) and integer(8))
 
 semantic error: the arms of a conditional expression must have the same type and kind
-    --> tests/errors/continue_compilation_1.f90:1043:24
+    --> tests/errors/continue_compilation_1.f90:1066:24
      |
-1043 |         c = ( .true. ? c1 : c4 )  ! {Error} the arms of a conditional expression must have the same type and kind
+1066 |         c = ( .true. ? c1 : c4 )  ! {Error} the arms of a conditional expression must have the same type and kind
      |                        ^^   ^^ type mismatch (string(kind=1) and string(kind=4))
 
 semantic error: the arms of a conditional expression must have the same type and kind
-    --> tests/errors/continue_compilation_1.f90:1045:24
+    --> tests/errors/continue_compilation_1.f90:1068:24
      |
-1045 |         l = ( .true. ? l4 : l8 )  ! {Error} the arms of a conditional expression must have the same type and kind
+1068 |         l = ( .true. ? l4 : l8 )  ! {Error} the arms of a conditional expression must have the same type and kind
      |                        ^^   ^^ type mismatch (logical(kind=4) and logical(kind=8))
 
 semantic error: the arms of a conditional expression must have the same rank
-    --> tests/errors/continue_compilation_1.f90:1052:29
+    --> tests/errors/continue_compilation_1.f90:1075:29
      |
-1052 |         print *, ( .true. ? a : b )  ! {Error} the arms of a conditional expression must have the same rank
+1075 |         print *, ( .true. ? a : b )  ! {Error} the arms of a conditional expression must have the same rank
      |                             ^   ^ rank mismatch (0 and 1)
 
 semantic error: the arms of a conditional expression must have the same declared type
-    --> tests/errors/continue_compilation_1.f90:1066:29
+    --> tests/errors/continue_compilation_1.f90:1089:29
      |
-1066 |         print *, ( .true. ? e : b )  ! {Error} the arms of a conditional expression must have the same declared type
+1089 |         print *, ( .true. ? e : b )  ! {Error} the arms of a conditional expression must have the same declared type
      |                             ^   ^ type mismatch (cond_ext and cond_base)
 
 semantic error: the condition of a conditional expression must be logical
-    --> tests/errors/continue_compilation_1.f90:1072:15
+    --> tests/errors/continue_compilation_1.f90:1095:15
      |
-1072 |         x = ( 1 ? 2 : 3 )  ! {Error} the condition of a conditional expression must be logical
+1095 |         x = ( 1 ? 2 : 3 )  ! {Error} the condition of a conditional expression must be logical
      |               ^ this condition is integer(4)
 
 semantic error: the condition of a conditional expression must be scalar
-    --> tests/errors/continue_compilation_1.f90:1081:20
+    --> tests/errors/continue_compilation_1.f90:1104:20
      |
-1081 |         print *, ( m ? a : b )  ! {Error} the condition of a conditional expression must be scalar
+1104 |         print *, ( m ? a : b )  ! {Error} the condition of a conditional expression must be scalar
      |                    ^ this condition is logical[:]
      |
-1081 |         print *, ( m ? a : b )  ! {Error} the condition of a conditional expression must be scalar
+1104 |         print *, ( m ? a : b )  ! {Error} the condition of a conditional expression must be scalar
      |                    ~ help: use `merge` to select elementwise with an array mask
 
 semantic error: a conditional expression cannot be a pointer assignment target
-    --> tests/errors/continue_compilation_1.f90:1091:14
+    --> tests/errors/continue_compilation_1.f90:1114:14
      |
-1091 |         p => ( .true. ? a : b )  ! {Error} a conditional expression cannot be a pointer assignment target
+1114 |         p => ( .true. ? a : b )  ! {Error} a conditional expression cannot be a pointer assignment target
      |              ^^^^^^^^^^^^^^^^^^ this is a value, not a target or a pointer


### PR DESCRIPTION
## Summary

`tests/errors/continue_compilation_1.f90` had one dead test case: `module conditional_expr_purity_1` sat at the end of the file, and its `! {Error} Call to impure procedure 'conditional_expr_impure' is not allowed inside a PURE procedure` annotation had no corresponding diagnostic in the reference output.

The cause is `program continue_compilation_1` itself, not the trailing `module_error_recovery_1`: the program fails semantic analysis, and that stops the body visitor from descending into *any* program unit that follows it.

Evidence:

- Adding an unrelated body error (`conditional_expr_pure = zzz_undeclared_marker()`) to the trailing module produces no diagnostic at all — the body visitor never enters the unit.
- The symbol table visitor *does* reach it: `module_error_recovery_1`'s `Derived type 't_recovery' not declared` is emitted normally, as are the declaration-level errors in the last subroutines of the program.
- Deleting `module_error_recovery_1` entirely, or swapping the two trailing modules, does not restore the purity error. Moving the purity module anywhere ahead of the program does.
- In isolation (recovery module plus purity module alone, in either order) the purity error is reported normally.

Delta-debugging the program's specification part narrows the suppression to at least two independent triggers (around `call sub(not_real)` in the specification part and the `interface operator(.bad.)` block), so this is a test-ordering fix rather than a single source-level fix.

## Scope

- Move `module conditional_expr_purity_1` from the end of the file to just before `program continue_compilation_1`, with a comment recording the constraint so future body-visitor error cases are not appended into the dead region.
- `module_error_recovery_1` stays at the end: its expected error comes from the symbol table visitor, which does reach units after the program.
- Regenerate `tests/reference/asr-continue_compilation_1-04b6d40.{stderr,json}`.

No compiler source is touched.

## Verification

Reference regenerated with:

    ./run_tests.py -t "errors/continue_compilation_1.f90" -u -s

- The purity diagnostic now appears in the reference at `tests/errors/continue_compilation_1.f90:225`.
- All 45 `! {Error}` annotations in the file now have a diagnostic at their exact line; none are dead.
- Total diagnostic count is unchanged at 332.

Full reference suite passes:

    ./run_tests.py
    ...
    TESTS PASSED

## Rationale

One diagnostic changed besides the addition: the reference loses one of two identical `Symbol 'bad_op' not declared` entries. The compiler emits one copy of that error per module following the program, all at a bogus `:1:2` location; with one fewer trailing module, one fewer copy is emitted. One copy remains, so the case stays covered. That the copy count tracks the number of trailing modules (and that the error vanishes entirely when no module follows the program) looks like a separate bug, left for a follow-up.
