### PR TITLE
Add LLVM 23 support

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -219,7 +219,7 @@ jobs:
         # exactly the same manner, to ensure that users can just change the
         # `llvmdev` version in their conda environment and everything will just
         # work.
-        llvm-version: ["8", "10", "11", "15", "17", "18", "19", "21", "22"]
+        llvm-version: ["8", "10", "11", "15", "17", "18", "19", "21", "22", "23"]
         python-version: ["3.10"]
         include:
           - os: macos-latest
@@ -331,6 +331,22 @@ jobs:
             zstd-static=1.5.7
 
       - uses: mamba-org/setup-micromamba@v2.0.2
+        if: contains(matrix.llvm-version, '23') && contains(matrix.os, 'ubuntu')
+        with:
+          micromamba-version: '2.0.4-0'
+          environment-file: ci/environment_linux_llvm.yml
+          create-args: >-
+            python=${{ matrix.python-version }}
+            llvmdev=${{ matrix.llvm-version }}
+            bison=3.4
+            openblas=0.3.21
+            llvm-openmp=14.0.4
+            make=4.3
+            openmpi=5.0.10
+            binutils=2.45.1
+            zstd-static=1.5.7
+
+      - uses: mamba-org/setup-micromamba@v2.0.2
         if: contains(matrix.os, 'macos')
         with:
           micromamba-version: '2.0.4-0'
@@ -359,7 +375,7 @@ jobs:
             openmpi=5.0.3
 
       - uses: mamba-org/setup-micromamba@v2.0.2
-        if: ${{! ( contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '12') || contains(matrix.llvm-version, '18') || contains(matrix.llvm-version, '19') || contains(matrix.llvm-version, '20') || contains(matrix.llvm-version, '21') || contains(matrix.llvm-version, '22') )}}
+        if: ${{! ( contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '12') || contains(matrix.llvm-version, '18') || contains(matrix.llvm-version, '19') || contains(matrix.llvm-version, '20') || contains(matrix.llvm-version, '21') || contains(matrix.llvm-version, '22') || contains(matrix.llvm-version, '23') )}}
         with:
           micromamba-version: '2.0.4-0'
           environment-file: ci/environment_linux_llvm.yml

--- a/pixi.toml
+++ b/pixi.toml
@@ -52,6 +52,8 @@ llvmdev = "==20.1.8"
 llvmdev = "==21.1.2"
 [feature.llvm22.dependencies]
 llvmdev = "==22.1.0"
+[feature.llvm23.dependencies]
+llvmdev = "==23.1.0"
 [feature.llvm12.target.linux.dependencies]
 libunwind = "==1.7.2"
 [feature.llvm13.target.linux.dependencies]
@@ -73,6 +75,8 @@ libunwind = "==1.7.2"
 [feature.llvm21.target.linux.dependencies]
 libunwind = "==1.7.2"
 [feature.llvm22.target.linux.dependencies]
+libunwind = "==1.7.2"
+[feature.llvm23.target.linux.dependencies]
 libunwind = "==1.7.2"
 
 # Dependencies to build the project to be installed for the target architecture.
@@ -258,6 +262,7 @@ llvm19 = {features = ["llvm19", "build"]}
 llvm20 = {features = ["llvm20", "build"]}
 llvm21 = {features = ["llvm21", "build"]}
 llvm22 = {features = ["llvm22", "build"]}
+llvm23 = {features = ["llvm23", "build"]}
 test = {features = ["test"]}
 wasm-build = {features = ["wasm-build"], no-default-feature = true}
 wasm-host = {features = ["wasm-host"], no-default-feature = true}

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -608,7 +608,7 @@ public:
     void start_new_block(llvm::BasicBlock *bb) {
         llvm::BasicBlock *last_bb = builder->GetInsertBlock();
         llvm::Function *fn = last_bb->getParent();
-        llvm::Instruction *block_terminator = last_bb->getTerminator();
+        llvm::Instruction *block_terminator = LLVM::get_terminator(last_bb);
         if (block_terminator == nullptr) {
             // The previous block is not terminated --- terminate it by jumping
             // to our new block

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -5737,7 +5737,7 @@ public:
                                     if (offset != 0 && alias_target) {
                                         llvm::Constant* indices[] = {
                                             llvm::ConstantInt::get(context, llvm::APInt(32, 0)),
-                                            llvm::ConstantInt::get(context, llvm::APInt(32, offset))
+                                            llvm::ConstantInt::get(context, llvm::APInt(32, offset, true))
                                         };
                                         llvm::Type* target_ty = llvm_utils->get_type_from_ttype_t_util(x.m_symbolic_value, target_var->m_type, module.get());
                                         alias_target = llvm::ConstantExpr::getGetElementPtr(target_ty, alias_target, indices);
@@ -13381,7 +13381,7 @@ public:
         // type code (field 4, i8)
         builder->CreateStore(
             llvm::ConstantInt::get(llvm::Type::getInt8Ty(context),
-                get_cfi_type_code(elem_asr_type)),
+                get_cfi_type_code(elem_asr_type), true),
             llvm_utils->create_gep2(desc_type, desc, 4));
         // attribute (field 5, i8): allocatable=2, pointer=1, other=0
         int cfi_attr = 0;
@@ -16016,7 +16016,8 @@ public:
         if (ASRUtils::is_integer(*x_m_type)) {
             for (size_t i=0; i < (size_t) arr_size; i++) {
                 ASR::expr_t *el = ASRUtils::fetch_ArrayConstant_value(al, x, i);
-                values.push_back(llvm::ConstantInt::get(el_type, down_cast<ASR::IntegerConstant_t>(el)->m_n));
+                values.push_back(llvm::ConstantInt::get(el_type,
+                    down_cast<ASR::IntegerConstant_t>(el)->m_n, true));
             }
         } else if (ASRUtils::is_real(*x_m_type)) {
             for (size_t i=0; i < (size_t) arr_size; i++) {
@@ -17811,7 +17812,7 @@ public:
             llvm::Value* item_name_ptr = LCompilers::create_global_string_ptr(
                 context, *module, *builder, LCompilers::to_lower(item_name));
             builder->CreateStore(item_name_ptr, builder->CreateStructGEP(item_type, item, 0));
-            builder->CreateStore(llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), type_code),
+            builder->CreateStore(llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), type_code, true),
                                  builder->CreateStructGEP(item_type, item, 1));
             builder->CreateStore(llvm::ConstantInt::get(llvm::Type::getInt32Ty(context), rank),
                                  builder->CreateStructGEP(item_type, item, 2));
@@ -23738,7 +23739,7 @@ public:
                         LLVMArrUtils::SimpleCMODescriptor::CFI_FIELD_ELEM_LEN));
                 builder->CreateStore(
                     llvm::ConstantInt::get(llvm::Type::getInt8Ty(context),
-                        get_cfi_type_code(elem_asr_type)),
+                        get_cfi_type_code(elem_asr_type), true),
                     llvm_utils->create_gep2(cfi_type, descriptor,
                         LLVMArrUtils::SimpleCMODescriptor::CFI_FIELD_TYPE));
                 {
@@ -24158,7 +24159,7 @@ public:
                         }
                         int8_t cfi_type_code = get_cfi_type_code(elem_type);
                         builder->CreateStore(
-                            llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), cfi_type_code),
+                            llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), cfi_type_code, true),
                             llvm_utils->create_gep2(array_type, unlimited_polymorphic_type_array, 4));
                         llvm::Value* src_attr = llvm_utils->CreateLoad2(
                             llvm::Type::getInt8Ty(context),
@@ -24874,7 +24875,7 @@ public:
                         for (int j = 0; j < n_dims_fixed; j++) {
                             if (m_dims_pointer[j].m_length) {
                                 llvm::Value* dim = llvm::ConstantInt::get(llvm_utils->getIntType(4), llvm::APInt(32, j + 1));
-                                llvm::Value* fixed_length = llvm::ConstantInt::get(llvm_utils->getIntType(4), llvm::APInt(32, ASRUtils::extract_dim_value_int(m_dims_fixed[j].m_length)));
+                                llvm::Value* fixed_length = llvm::ConstantInt::get(llvm_utils->getIntType(4), llvm::APInt(32, ASRUtils::extract_dim_value_int(m_dims_fixed[j].m_length), true));
                                 load_array_size_deep_copy(m_dims_pointer[j].m_length);
                                 // Convert user dimension expression to i32 to match fixed-size format
                                 llvm::Value* pointer_length = builder->CreateSExtOrTrunc(
@@ -26061,7 +26062,7 @@ public:
             } else {
                 LCOMPILERS_ASSERT(false);
             }
-            tmp = llvm::ConstantInt::get(context, llvm::APInt(kind * 8, bound_value));
+            tmp = llvm::ConstantInt::get(context, llvm::APInt(kind * 8, bound_value, true));
             return ;
         }
 

--- a/src/libasr/codegen/llvm_array_utils.cpp
+++ b/src/libasr/codegen/llvm_array_utils.cpp
@@ -1949,7 +1949,7 @@ namespace LCompilers {
 
             // type code and attribute from parameters
             builder->CreateStore(
-                llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), type_code),
+                llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), type_code, true),
                 llvm_utils->create_gep2(cfi_type, cfi, CFI_FIELD_TYPE));
             builder->CreateStore(
                 llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), cfi_attr),

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -2151,7 +2151,7 @@ namespace LCompilers {
     void LLVMUtils::start_new_block(llvm::BasicBlock *bb) {
         llvm::BasicBlock *last_bb = builder->GetInsertBlock();
         llvm::Function *fn = last_bb->getParent();
-        llvm::Instruction *block_terminator = last_bb->getTerminator();
+        llvm::Instruction *block_terminator = LLVM::get_terminator(last_bb);
         if (block_terminator == nullptr) {
             // The previous block is not terminated --- terminate it by jumping
             // to our new block

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -226,6 +226,19 @@ class ASRToLLVMVisitor;
         // e.g. -> `i64*`
         bool is_llvm_pointer(const ASR::ttype_t& asr_type);
 
+        // Returns the terminator of `bb`, or nullptr when `bb` is not
+        // terminated yet. `llvm::BasicBlock::getTerminator()` asserts on a
+        // block without a terminator from LLVM 23 on, so inspect the last
+        // instruction directly: this behaves identically on every LLVM
+        // version we support.
+        static inline llvm::Instruction* get_terminator(llvm::BasicBlock* bb) {
+            if (bb->empty()) {
+                return nullptr;
+            }
+            llvm::Instruction& last_instruction = bb->back();
+            return last_instruction.isTerminator() ? &last_instruction : nullptr;
+        }
+
     }
 
     class LLVMList;
@@ -2101,7 +2114,7 @@ class ASRToLLVMVisitor;
          */
         void END_CACHE(llvm::BasicBlock* revert_bb) {
             LCOMPILERS_ASSERT(revert_bb)
-            LCOMPILERS_ASSERT_MSG(!builder_->GetInsertBlock()->getTerminator(),
+            LCOMPILERS_ASSERT_MSG(!LLVM::get_terminator(builder_->GetInsertBlock()),
                 "`END CACHE` adds the terminator, not expected to be added by other utility")
             builder_->CreateRetVoid();
             builder_->SetInsertPoint(revert_bb);
@@ -2515,7 +2528,7 @@ class ASRToLLVMVisitor;
 
         void check_all_caches_done_properly(){
             for(auto const& cache_pair : type_finalizer_cache_){
-                if(cache_pair.second->back().getTerminator() == nullptr){
+                if(LLVM::get_terminator(&cache_pair.second->back()) == nullptr){
                     throw LCompilersException("Cache function" + 
                             cache_pair.second->getName().str() +
                             "Not properly created");


### PR DESCRIPTION
## Summary

Adds LLVM 23 support: a `llvm23` pixi environment, the two codegen fixes
LLVM 23 exposed, and an LLVM 23 job in the exhaustive checks.

Fixes #12659.

## Scope

- `pixi.toml`: new `llvm23` feature/environment (`llvmdev==23.1.0`, plus
  `libunwind` on Linux like the other recent versions).
- `getTerminator()`: LLVM 23 made `llvm::BasicBlock::getTerminator()` assert that
  the block is well-formed, so a debug build aborted with
  `cannot get terminator of non-well-formed block` on the very first program
  compiled. `start_new_block()` calls it precisely to find out whether the block
  still needs a terminator. Replaced by `LLVM::get_terminator()`, which looks at
  the block's last instruction and returns `nullptr` when there is none — the
  pre-LLVM-23 behaviour, using APIs present in every supported LLVM version.
- Negative integer constants: `llvm::ConstantInt::get(Ty, V, IsSigned)` and
  `llvm::APInt(bits, V, isSigned)` take `V` as `uint64_t`. Passing a negative
  `int` sign-extends it to 64 bits, so it no longer fits the requested bit
  width. Up to LLVM 22 the surplus bits were dropped; LLVM 23 keeps them, so the
  `ConstantInt` says `i8` while its `APInt` still holds
  `0xffffffffffffffff`. The IR printer masks the value — the module prints
  correctly — but SelectionDAG store merging reads the raw words, folding
  adjacent `i8` stores of `-1` and `2` into one `i16` store of `0xffff` instead
  of `0x02ff`.

  In practice this corrupted the CFI descriptor written back by an
  `intent(out)` `allocatable` `bind(C)` dummy, because the CFI type code sits
  one byte before the attribute: the C caller saw `attribute == 255` and
  `CFI_deallocate()` rejected the descriptor. `IsSigned` is now passed
  explicitly everywhere the value can be negative (CFI type codes, array
  constant elements, namelist type codes, array bounds, alias offsets). On older
  LLVM versions the emitted constants are bit-for-bit unchanged.
- CI: `test_llvm` matrix gains `"23"`, with a micromamba setup block matching
  the LLVM 22 one.

## Verification

All local runs use the new pixi environments (`pixi run -e llvm23 build`).

LLVM 23.1.0:

- `integration_tests/run_tests.py -j16 -b llvm` → `100% tests passed, 0 tests
  failed out of 3951` (before the constant fix: `bindc_iso_fb_02` failed with
  `C test failed with code: 33` / `ERROR STOP FAIL: C allocatable tests failed`)
- `integration_tests/run_tests.py -j16 -b llvm -f -nf16` → 0 failures out of 3951
- `-b llvm2 llvm_rtlib llvm_nopragma c c_nopragma` → 0 failures
- Before the `getTerminator()` fix, LLVM 23 could not compile anything at all:
  `Assertion failed: (hasTerminator() && "cannot get terminator of
  non-well-formed block")` on `examples/expr2.f90`.

LLVM 11.1.0 (no-regression check):

- `./run_tests.py` (reference tests) → `TESTS PASSED`
- `integration_tests/run_tests.py -j16 -b llvm` → 0 failures out of 3951

Two pre-existing, unrelated failures on this machine are not touched by this PR:
`string_37` on the `fortran` backend (fails identically without these changes)
and the `cpp` backend, which needs `LFORTRAN_KOKKOS_DIR`.

## Rationale

Both fixes are corrections to LFortran, not version-conditional workarounds:
`get_terminator()` and the explicit `IsSigned` arguments produce identical IR on
every LLVM version, so no `LLVM_VERSION_MAJOR` guard is needed.
