### PR TITLE
Migrate away from toml

### DIFF
--- a/src/libasr/compiler_tester/tester.py
+++ b/src/libasr/compiler_tester/tester.py
@@ -12,7 +12,7 @@ import pprint
 import shutil
 import subprocess
 import sys
-import toml
+import tomli
 from typing import Any, Mapping, List, Union
 
 level = logging.DEBUG
@@ -582,7 +582,8 @@ def tester_main(compiler, single_test, is_lcompilers_executable_installed=False)
     if not is_lcompilers_executable_installed:
         os.environ["PATH"] = os.path.join(SRC_DIR, "bin") \
             + os.pathsep + os.environ["PATH"]
-    test_data = toml.load(open(os.path.join(ROOT_DIR, "tests", "tests.toml")))
+    with open(os.path.join(ROOT_DIR, "tests", "tests.toml"), "rb") as f:
+         test_data = tomli.load(f)
     test_for_duplicates(test_data)
     filtered_tests = test_data["test"]
     if specific_tests:

--- a/tests/asr/check_llvm_coverage.py
+++ b/tests/asr/check_llvm_coverage.py
@@ -5,7 +5,7 @@ import pathlib
 import re
 import sys
 
-import toml
+import tomli
 
 
 def load_asdl(asdl_path):
@@ -35,7 +35,8 @@ def main():
     llvm_source = args.llvm.read_text(encoding="utf-8")
     direct = set(re.findall(
         r"\bvisit_([A-Za-z0-9_]+)\s*\(", llvm_source))
-    exceptions = toml.load(args.manifest.resolve())["constructors"]
+    with open(args.manifest.resolve(), "rb") as f:
+        exceptions = tomli.load(f)["constructors"]
 
     missing = []
     for base, constructor in constructors:

--- a/tests/asr/fuzz.py
+++ b/tests/asr/fuzz.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 
-import toml
+import tomli
 import edn
 import asr_generator
 
@@ -408,7 +408,7 @@ def load_sources(manifest, explicit_sources):
     manifest = manifest.resolve()
     root = manifest.parent
     sources = []
-    for item in toml.load(manifest)["seed"]:
+    for item in tomli.load(manifest)["seed"]:
         path = (root / item["filename"]).resolve()
         # The seed manifest names integration tests, which a source tarball
         # does not ship. Skip what is not there rather than failing the run.


### PR DESCRIPTION
Fedora has no toml package anymore (see https://fedoraproject.org/wiki/Changes/DeprecatePythonToml for details), hence I am trying to migrate to `tomli`, which we are already using in some places.