### PR TITLE
Follow-ups to conditional arguments: `.nil.` token placement and C1540 by keyword

### DIFF
--- a/src/lfortran/parser/parser.yy
+++ b/src/lfortran/parser/parser.yy
@@ -118,7 +118,6 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LFortran::Parser &p,
 %token TK_PERCENT "%"
 %token TK_VBAR "|"
 %token TK_QUESTION "?"
-%token TK_NIL ".nil."
 
 %token <str_prefix> TK_STRING
 %token <string> TK_COMMENT
@@ -147,6 +146,7 @@ void yyerror(YYLTYPE *yyloc, LCompilers::LFortran::Parser &p,
 %token TK_XOR ".xor."
 %token TK_EQV ".eqv."
 %token TK_NEQV ".neqv."
+%token TK_NIL ".nil."
 
 %token <string> TK_TRUE ".true."
 %token <string> TK_FALSE ".false."

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -21504,6 +21504,9 @@ public:
             args.push_back(al, call_arg);
         }
 
+        // The indices whose argument carries no value because the consequent
+        // chosen for them is `.nil.`, as opposed to not being supplied at all.
+        std::vector<int> nil_args_idx;
         for (int i = 0; i < (int)n; i++) {
             // `.nil.` leaves the argument with no value, which is how an
             // absent optional argument is carried (15.5.2.3)
@@ -21541,6 +21544,9 @@ public:
             args.p[idx].loc = is_nil ? kwargs[i].m_value->base.loc
                 : expr->base.loc;
             args.p[idx].m_value = expr;
+            if (is_nil) {
+                nil_args_idx.push_back(idx);
+            }
         }
 
         // Ensure required arguments are provided, but skip optional ones
@@ -21548,6 +21554,14 @@ public:
             if (args[i].m_value == nullptr) {
                 // Skip checking if the argument is optional
                 if (std::find(optional_args_idx.begin(), optional_args_idx.end(), i) != optional_args_idx.end()) {
+                    continue;
+                }
+                // A `.nil.` consequent supplies the argument, it just gives
+                // it no value. C1540 is what it violates when the dummy
+                // argument is not optional, and the argument checks report
+                // that, the same as for a positional conditional argument.
+                if (std::find(nil_args_idx.begin(), nil_args_idx.end(), i)
+                        != nil_args_idx.end()) {
                     continue;
                 }
                 diag.semantic_error_label(

--- a/tests/errors/conditional_arg_1.f90
+++ b/tests/errors/conditional_arg_1.f90
@@ -44,6 +44,11 @@ contains
         returns_one = x
     end function
 
+    subroutine two_required(x, y)
+        integer, intent(in) :: x, y
+        print *, x, y
+    end subroutine
+
     ! C1540: a consequent may be `.NIL.` only when the dummy argument it
     ! corresponds to is optional, since `.NIL.` leaves it not present.
     subroutine nil_for_a_required_dummy()
@@ -62,6 +67,16 @@ contains
         a = 1
         r = returns_one( ( .true. ? a : .nil. ) )  ! {Error} `.nil.` is not allowed for the dummy argument `x`, which is not optional
         print *, r
+    end subroutine
+
+    ! C1540 through a keyword actual argument (R1523). The consequent is
+    ! supplied, it just leaves the argument with no value, so this is the same
+    ! violation as the positional form and not a missing argument.
+    subroutine nil_for_a_required_dummy_by_keyword()
+        implicit none
+        integer :: a
+        a = 1
+        call two_required(x = a, y = ( .true. ? a : .nil. ))  ! {Error} `.nil.` is not allowed for the dummy argument `y`, which is not optional
     end subroutine
 
     ! C1540: at least one consequent shall be a consequent-arg, so they

--- a/tests/reference/asr-conditional_arg_1-84d560e.json
+++ b/tests/reference/asr-conditional_arg_1-84d560e.json
@@ -2,12 +2,12 @@
     "basename": "asr-conditional_arg_1-84d560e",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/conditional_arg_1.f90",
-    "infile_hash": "dc7d2fecf75b17e4e52c4b62560648d36850c5a2c9e87bcaf2be8a1f",
+    "infile_hash": "47ddbe1dfcb27562d205cae594915134260fe5bfe93ffa76b4bb0145",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-conditional_arg_1-84d560e.stderr",
-    "stderr_hash": "55216bbbaea76587478c65a3648221efbd22b35b907f7bdf9a93baa9",
+    "stderr_hash": "aeb27b1e944fc3fc8792645513631d1ca09329d7d1162a8e00481a9c",
     "returncode": 1
 }

--- a/tests/reference/asr-conditional_arg_1-84d560e.stderr
+++ b/tests/reference/asr-conditional_arg_1-84d560e.stderr
@@ -1,41 +1,47 @@
 semantic error: `.nil.` is not allowed for the dummy argument `x`, which is not optional
-  --> tests/errors/conditional_arg_1.f90:53:39
+  --> tests/errors/conditional_arg_1.f90:58:39
    |
-53 |         call required( ( .true. ? a : .nil. ) )  ! {Error} `.nil.` is not allowed for the dummy argument `x`, which is not optional
+58 |         call required( ( .true. ? a : .nil. ) )  ! {Error} `.nil.` is not allowed for the dummy argument `x`, which is not optional
    |                                       ^^^^^ a consequent may be `.nil.` only when the dummy argument is optional (Fortran 2023 C1540)
 
 semantic error: `.nil.` is not allowed for the dummy argument `x`, which is not optional
-  --> tests/errors/conditional_arg_1.f90:63:41
+  --> tests/errors/conditional_arg_1.f90:68:41
    |
-63 |         r = returns_one( ( .true. ? a : .nil. ) )  ! {Error} `.nil.` is not allowed for the dummy argument `x`, which is not optional
+68 |         r = returns_one( ( .true. ? a : .nil. ) )  ! {Error} `.nil.` is not allowed for the dummy argument `x`, which is not optional
    |                                         ^^^^^ a consequent may be `.nil.` only when the dummy argument is optional (Fortran 2023 C1540)
 
-semantic error: every consequent of this conditional argument is `.nil.`
-  --> tests/errors/conditional_arg_1.f90:71:28
+semantic error: `.nil.` is not allowed for the dummy argument `y`, which is not optional
+  --> tests/errors/conditional_arg_1.f90:79:53
    |
-71 |         call optional_arg( ( .true. ? .nil. : .nil. ) )  ! {Error} every consequent of this conditional argument is `.nil.`
+79 |         call two_required(x = a, y = ( .true. ? a : .nil. ))  ! {Error} `.nil.` is not allowed for the dummy argument `y`, which is not optional
+   |                                                     ^^^^^ a consequent may be `.nil.` only when the dummy argument is optional (Fortran 2023 C1540)
+
+semantic error: every consequent of this conditional argument is `.nil.`
+  --> tests/errors/conditional_arg_1.f90:86:28
+   |
+86 |         call optional_arg( ( .true. ? .nil. : .nil. ) )  ! {Error} every consequent of this conditional argument is `.nil.`
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^ at least one consequent shall be an argument (Fortran 2023 C1540)
 
 semantic error: Non-variable expression in variable definition context (actual argument to INTENT = OUT/INOUT)
-  --> tests/errors/conditional_arg_1.f90:79:38
+  --> tests/errors/conditional_arg_1.f90:94:38
    |
-79 |         call defined( ( .true. ? a : 1 ) )  ! {Error} Non-variable expression in variable definition context (actual argument to INTENT = OUT/INOUT)
+94 |         call defined( ( .true. ? a : 1 ) )  ! {Error} Non-variable expression in variable definition context (actual argument to INTENT = OUT/INOUT)
    |                                      ^ 
 
 semantic error: the consequents of a conditional argument must have the same rank
-  --> tests/errors/conditional_arg_1.f90:87:35
-   |
-87 |         call required( ( .true. ? a : b ) )  ! {Error} the consequents of a conditional argument must have the same rank
-   |                                   ^   ^ rank mismatch (0 and 1) (Fortran 2023 C1539)
+   --> tests/errors/conditional_arg_1.f90:102:35
+    |
+102 |         call required( ( .true. ? a : b ) )  ! {Error} the consequents of a conditional argument must have the same rank
+    |                                   ^   ^ rank mismatch (0 and 1) (Fortran 2023 C1539)
 
 semantic error: the consequents of a conditional argument must have the same type and kind
-  --> tests/errors/conditional_arg_1.f90:98:35
-   |
-98 |         call required( ( .true. ? a : b ) )  ! {Error} the consequents of a conditional argument must have the same type and kind
-   |                                   ^   ^ type mismatch (integer and real) (Fortran 2023 C1538)
+   --> tests/errors/conditional_arg_1.f90:113:35
+    |
+113 |         call required( ( .true. ? a : b ) )  ! {Error} the consequents of a conditional argument must have the same type and kind
+    |                                   ^   ^ type mismatch (integer and real) (Fortran 2023 C1538)
 
 semantic error: the consequents of a conditional argument to a generic procedure must have the same `allocatable` and `pointer` attributes
-   --> tests/errors/conditional_arg_1.f90:109:30
+   --> tests/errors/conditional_arg_1.f90:124:30
     |
-109 |         call gen( ( .true. ? a : p ) )  ! {Error} the consequents of a conditional argument to a generic procedure must have the same `allocatable` and `pointer` attributes
+124 |         call gen( ( .true. ? a : p ) )  ! {Error} the consequents of a conditional argument to a generic procedure must have the same `allocatable` and `pointer` attributes
     |                              ^   ^ this consequent is allocatable, this one is a pointer (Fortran 2023 C1545)


### PR DESCRIPTION
## Summary

The two follow-ups left over from the review of #12670, one commit each.

## Scope

**`parser: declare `.nil.` with the other dotted operators`.** `TK_NIL` was
declared at the end of the single-character punctuation block, while every other
dotted operator token is grouped together after the relational operators:

```
%token TK_NOT  ".not."
%token TK_AND  ".and."
%token TK_OR   ".or."
%token TK_XOR  ".xor."
%token TK_EQV  ".eqv."
%token TK_NEQV ".neqv."
%token TK_NIL  ".nil."
```

`.nil.` is one of those, so it now sits with them. Only the position of the
declaration changes; the alias stays, as it does for every token in that group
and for `::`, `**`, `//`, `=>`, `..` and `/)`, and the grammar rules go on
spelling it `".nil."` the way the rule two lines above spells `".not."`.

**`fix: report C1540 for a `.nil.` keyword actual argument`.** A conditional
argument whose chosen consequent is `.NIL.` leaves the actual argument with no
value. Passed positionally, an argument with no value for a dummy argument that
is not optional was reported as the C1540 violation it is. Passed by keyword it
was not:

```fortran
call two_required(x = a, y = ( .true. ? a : .nil. ))
```

`visit_kwargs` cannot tell a null it wrote for an explicit `.nil.` from one left
by an argument that was never supplied, so the "required argument missing" check
fired first and claimed the argument had not been specified at all — pointing at
the whole statement rather than the consequent, and naming the argument by a
zero-based index in a message that reads as one-based:

```
semantic error: Argument was not specified
  |
  |         call kw_required(a=i, b=( .true. ? i : .nil. ))
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 1-th argument not specified for kw_required
```

The fix records which indices were given `.nil.` and lets those fall through to
the argument checks, which already report C1540 for the positional form. Both
forms now give the same diagnostic, against the dummy argument's name and at the
consequent:

```
semantic error: `.nil.` is not allowed for the dummy argument `b`, which is not optional
  |
  |         call kw_required(a=i, b=( .true. ? i : .nil. ))
  |                                                ^^^^^ a consequent may be `.nil.` only when the dummy argument is optional (Fortran 2023 C1540)
```

The message stays in one place rather than being duplicated into the keyword
path. A `.NIL.` keyword argument for a dummy that *is* optional is unaffected and
still leaves it not present, which `integration_tests/conditional_arg_02.f90`
already covers (`call five(x = ( a>0 ? a : .NIL. ))`).

## Verification

`tests/errors/conditional_arg_1.f90` gains the keyword form of C1540, next to
the positional subroutine and function cases. On `main` it reports
`Argument was not specified` and so fails against the expected message; here it
reports C1540 and passes.

| Suite | Result |
| --- | --- |
| `./run_tests.py` | PASSED |
| `cd integration_tests && ./run_tests.py -b llvm` | 3956/3956 |
| `ctest` | 16/16 |
| `ci/grammar_conflicts.sh` | no essential conflicts |

## Rationale

Letting the keyword path fall through to the existing check, rather than raising
C1540 in `visit_kwargs` itself, keeps one wording and one place that decides what
an argument with no value means for a dummy argument that is not optional. The
"required argument missing" check stays correct for what it is actually for: an
argument the caller never wrote.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDQ64UXwx1Vhb1BvQU4eDZ)_