### PR TITLE
fix: complex associates are pointer assigned instead of creating temporaries

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2776,11 +2776,11 @@ RUN(NAME associate_48 LABELS gfortran llvm)
 RUN(NAME associate_49 LABELS gfortran llvm)
 RUN(NAME associate_50 LABELS gfortran llvm)
 RUN(NAME associate_51 LABELS gfortran llvm)
-
 RUN(NAME associate_52 LABELS gfortran llvm)
 RUN(NAME associate_53 LABELS gfortran llvm)
 RUN(NAME associate_54 LABELS gfortran llvm)
 RUN(NAME associate_55 LABELS gfortran llvm)
+RUN(NAME associate_56 LABELS llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_56.f90
+++ b/integration_tests/associate_56.f90
@@ -1,0 +1,50 @@
+program associate_56
+    implicit none
+    complex :: z = (1., 2.)
+    complex :: zc(0:2) = [(1.,-1.), (2.,-2.), (3.,-3.)]
+    character(:), allocatable :: str
+  
+    ! scalar complex parts: designators => variables
+    associate (re => z%re, im => z%im)
+      re = 10.
+      im = 20.
+    end associate
+    print *, 'z after writes      =', z
+    if (z%re /= 10.) error stop 'z%re /= 10.'
+    if (z%im /= 20.) error stop 'z%im /= 20.'
+  
+    ! array complex part: like a strided section
+    associate (r => zc%re)
+      print *, 'is_contiguous(zc%re)=', is_contiguous(r)
+      print *, 'lbound(zc%re), ubound(zc%re), size(zc%re) =', lbound(r), ubound(r), size(r)
+      if (is_contiguous(r) .neqv. .false.) error stop 'is_contiguous(r) .neqv. .false.'
+      if (lbound(r, 1) /= 1) error stop 'lbound(r, 1) /= 1'
+      if (ubound(r, 1) /= 3) error stop 'ubound(r, 1) /= 3'
+      if (size(r, 1) /= 3) error stop 'size(r, 1) /= 3'
+      r = [7., 8., 9.]
+    end associate
+  
+    associate (im => zc%im)
+      print *, 'is_contiguous(zc%im)=', is_contiguous(im)
+      print *, 'lbound(zc%im), ubound(zc%im), size(zc%im) =', lbound(im), ubound(im), size(im)
+      if (is_contiguous(im) .neqv. .false.) error stop 'is_contiguous(im) .neqv. .false.'
+      if (lbound(im, 1) /= 1) error stop 'lbound(im, 1) /= 1'
+      if (ubound(im, 1) /= 3) error stop 'ubound(im, 1) /= 3'
+      if (size(im, 1) /= 3) error stop 'size(im, 1) /= 3'
+      im = [-7., -8., -9.]
+    end associate
+  
+    print *, 'zc after write      =', zc
+    if (any(zc%re /= [7., 8., 9.])) error stop 'zc%re /= [7., 8., 9.]'
+    if (any(zc%im /= [-7., -8., -9.])) error stop 'zc%im /= [-7., -8., -9.]'
+  
+    print *, "Done"
+  
+    ! type parameter inquiries: expressions => values
+    str = 'hello'
+    associate (k => z%kind, l => str%len)
+      print *, 'z%kind, str%len     =', k, l
+      if (k /= 4) error stop 'z%kind /= kind(z)'
+      if (l /= 5) error stop 'str%len /= len(str)'
+    end associate
+end program associate_56

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3210,6 +3210,11 @@ public:
                 tmp_type = sim->m_type;
             } else if (ASR::is_a<ASR::StringSection_t>(*tmp_expr)) {
                 create_associate_stmt = true;
+            } else if (ASR::is_a<ASR::ComplexRe_t>(*tmp_expr) ||
+                       ASR::is_a<ASR::ComplexIm_t>(*tmp_expr)) {
+                // Complex parts are designators. Associate them with the
+                // original storage instead of copying their current value.
+                create_associate_stmt = true;
             } else if( ASR::is_a<ASR::ArraySection_t>(*tmp_expr) ) {
                 create_associate_stmt = true;
                 ASR::ArraySection_t* tmp_array_section = ASR::down_cast<ASR::ArraySection_t>(tmp_expr);

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -13640,8 +13640,7 @@ public:
                     int kind = ASRUtils::extract_kind_from_ttype_t(v_variable_arr_type);
                     ASR::dimension_t* m_dims = nullptr;
                     int n_dims = ASRUtils::extract_dimensions_from_ttype(v_variable_arr_type, m_dims);
-                    Vec<ASR::dimension_t> dim_vec;
-                    dim_vec.from_pointer_n_copy(al, m_dims, n_dims);
+                    Vec<ASR::dimension_t> dim_vec = ASRUtils::make_complex_dimensions_bounds(al, loc, m_dims, n_dims);
                     ASR::ttype_t *real_type = ASR::down_cast<ASR::ttype_t>(
                         ASR::make_Real_t(al, loc, kind));
                     ASR::ttype_t* complex_arr_ret_type = ASRUtils::duplicate_type(al, real_type, &dim_vec,
@@ -13741,8 +13740,7 @@ public:
                 int n_dims = ASRUtils::extract_dimensions_from_ttype(
                     ASRUtils::type_get_past_allocatable_pointer(
                         ASRUtils::expr_type(base)), m_dims);
-                Vec<ASR::dimension_t> dim_vec;
-                dim_vec.from_pointer_n_copy(al, m_dims, n_dims);
+                Vec<ASR::dimension_t> dim_vec = ASRUtils::make_complex_dimensions_bounds(al, loc, m_dims, n_dims);
                 ASR::ttype_t* real_arr_type = ASRUtils::duplicate_type(al, real_type,
                     &dim_vec, ASR::array_physical_typeType::DescriptorArray, true);
                 if (member_name == "re") {

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4232,6 +4232,22 @@ static inline bool is_aggregate_type(ASR::ttype_t* asr_type) {
 
 static inline ASR::dimension_t* duplicate_dimensions(Allocator& al, ASR::dimension_t* m_dims, size_t n_dims);
 
+// Fortran array-valued complex part designators (%re, %im) have default
+// lower bound 1; preserve each dimension's length from the base array.
+static inline Vec<ASR::dimension_t> make_complex_dimensions_bounds(Allocator& al,
+        const Location &loc, ASR::dimension_t* m_dims, int n_dims) {
+    Vec<ASR::dimension_t> dim_vec;
+    dim_vec.reserve(al, n_dims);
+    ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, loc, 4));
+    for (int i = 0; i < n_dims; i++) {
+        ASR::dimension_t dim;
+        dim.loc = loc;
+        dim.m_start = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, 1, int_type));
+        dim.m_length = m_dims[i].m_length;
+        dim_vec.push_back(al, dim);
+    }
+    return dim_vec;
+}
 
 static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
     Vec<ASR::dimension_t>* dims=nullptr,

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -10304,6 +10304,38 @@ public:
             handle_array_section_association_to_pointer(x);
         } else if (is_component_array_expr(x.m_value)) {
             handle_component_array_association(x);
+        } else if ((ASR::is_a<ASR::ComplexRe_t>(*x.m_value) ||
+                    ASR::is_a<ASR::ComplexIm_t>(*x.m_value)) &&
+                   !ASRUtils::is_array(ASRUtils::expr_type(x.m_value))) {
+            // Complex scalar parts are designators in an ASSOCIATE target.
+            // Visit the complex argument without loading it, then associate
+            // the target pointer with the selected component address.
+            bool is_re = ASR::is_a<ASR::ComplexRe_t>(*x.m_value);
+            ASR::expr_t* complex_arg = is_re
+                ? ASR::down_cast<ASR::ComplexRe_t>(x.m_value)->m_arg
+                : ASR::down_cast<ASR::ComplexIm_t>(x.m_value)->m_arg;
+            int64_t ptr_loads_copy = ptr_loads;
+            ptr_loads = 0;
+            visit_expr(*complex_arg);
+            ptr_loads = ptr_loads_copy;
+            llvm::Value* complex_ptr = tmp;
+            if (!complex_ptr->getType()->isPointerTy()) {
+                llvm::Value* complex_storage = llvm_utils->CreateAlloca(
+                    complex_ptr->getType(), nullptr, "associate_complex_storage");
+                builder->CreateStore(complex_ptr, complex_storage);
+                complex_ptr = complex_storage;
+            }
+            int kind = ASRUtils::extract_kind_from_ttype_t(
+                ASRUtils::expr_type(complex_arg));
+            llvm::Type* complex_type = (kind == 4) ? complex_type_4 : complex_type_8;
+            llvm::Value* component_ptr = llvm_utils->create_gep2(
+                complex_type, complex_ptr, is_re ? 0 : 1);
+
+            ptr_loads = 0;
+            visit_expr(*x.m_target);
+            llvm::Value* target_ptr = tmp;
+            ptr_loads = ptr_loads_copy;
+            builder->CreateStore(component_ptr, target_ptr);
         } else {
             int64_t ptr_loads_copy = ptr_loads;
             ptr_loads = 0;


### PR DESCRIPTION
Fixes #12673 

Fixes addressed:

Fix-1:
fix: handle bounds of arrays extracting from complex arrays
Array-valued component reference from complex arrays shoudl have default lower
bound 1. Handle result dimensions for ComplexRe/ComplexIm,
handling the leghth by setting the lower bound to 1, in AST-ASR lowering.


Fix-2:
complex associates are pointer assigned instead of creating temporaries
- zc%re is represented as a real view over interleaved complex data.
- Its physical stride is correctly 2, because real elements are separated by the imaginary component.
- So, is_contigouous(r) gives result as false