### PR TITLE
fix: propagation of dynamic type in associate block

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3265,6 +3265,7 @@ RUN(NAME class_148 LABELS gfortran llvm)
 RUN(NAME class_149 LABELS gfortran llvm)
 RUN(NAME class_150 LABELS gfortran llvm)
 RUN(NAME class_151 LABELS gfortran llvm)
+RUN(NAME class_152 LABELS gfortran llvm)
 
 RUN(NAME class_procedure_args_01 LABELS gfortran llvm)
 RUN(NAME generic_nopass_01 LABELS gfortran llvm)

--- a/integration_tests/class_152.f90
+++ b/integration_tests/class_152.f90
@@ -1,0 +1,34 @@
+! Test same_type_as between a polymorphic object and a non-polymorphic type
+program class_152
+  implicit none
+
+  type :: base
+    integer :: i = 0
+  end type
+  type, extends(base) :: child
+    real :: r = 0.
+  end type
+
+  class(base), allocatable :: obj
+  type(child) :: probe
+  type(base) :: base_probe
+
+  allocate(child :: obj)
+  base_probe = base(i=1)
+  associate (o => obj)
+    print *, same_type_as(o, probe)
+    print *, same_type_as(o, base_probe)
+    if (.not. same_type_as(o, probe)) error stop
+    if (same_type_as(o, base_probe)) error stop
+    select type (o)                        ! only legal if o is polymorphic
+    type is (child)
+      print *, 'select type sees CHILD'
+
+    class default
+      print *, 'select type sees base'
+      error stop
+    end select
+  end associate
+
+  print *, "Done"
+end program class_152

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -4025,32 +4025,12 @@ public:
                     ASRUtils::get_struct_sym_from_struct_expr(x.m_args[0]));
                 ASR::symbol_t* struct_sym1 = ASRUtils::symbol_get_past_external(
                     ASRUtils::get_struct_sym_from_struct_expr(x.m_args[1]));
-                llvm::Type* class_type0 = llvm_utils->getClassType(
-                    ASR::down_cast<ASR::Struct_t>(struct_sym0), false);
-                llvm::Type* class_type1 = llvm_utils->getClassType(
-                    ASR::down_cast<ASR::Struct_t>(struct_sym1), false);
 
-                // For allocatable/pointer class(*), the alloca holds a pointer
-                // to the polymorphic struct. Load the pointer first.
-                ASR::ttype_t* arg_type0 = ASRUtils::expr_type(x.m_args[0]);
-                ASR::ttype_t* arg_type1 = ASRUtils::expr_type(x.m_args[1]);
-                if (ASRUtils::is_allocatable(arg_type0) ||
-                    ASR::is_a<ASR::Pointer_t>(*arg_type0)) {
-                    arg0 = llvm_utils->CreateLoad2(class_type0->getPointerTo(), arg0);
-                }
-                if (ASRUtils::is_allocatable(arg_type1) ||
-                    ASR::is_a<ASR::Pointer_t>(*arg_type1)) {
-                    arg1 = llvm_utils->CreateLoad2(class_type1->getPointerTo(), arg1);
-                }
-
-                // Extract field 0 (type hash or vtable pointer) from both args
-                llvm::Value* id0_ptr = llvm_utils->create_gep2(class_type0, arg0, 0);
-                llvm::Value* id1_ptr = llvm_utils->create_gep2(class_type1, arg1, 0);
-                // Load and compare
-                llvm::Type* field0_type = llvm::cast<llvm::StructType>(class_type0)->getElementType(0);
-                llvm::Value* id0 = llvm_utils->CreateLoad2(field0_type, id0_ptr);
-                llvm::Value* id1 = llvm_utils->CreateLoad2(field0_type, id1_ptr);
-                if (field0_type->isPointerTy()) {
+                llvm::Value* id0 = llvm_utils->get_type_identifier_for_polymorphic_type(
+                    x.m_args[0], arg0, struct_sym0, module.get(), get_class_hash(struct_sym0));
+                llvm::Value* id1 = llvm_utils->get_type_identifier_for_polymorphic_type(
+                    x.m_args[1], arg1, struct_sym1, module.get(), get_class_hash(struct_sym1));
+                if (compiler_options.new_classes) {
                     // new_classes: compare vtable pointers
                     tmp = builder->CreateICmpEQ(
                         builder->CreatePtrToInt(id0, llvm::Type::getInt64Ty(context)),
@@ -4078,31 +4058,13 @@ public:
                     ASRUtils::get_struct_sym_from_struct_expr(x.m_args[0]));
                 ASR::symbol_t* struct_sym1 = ASRUtils::symbol_get_past_external(
                     ASRUtils::get_struct_sym_from_struct_expr(x.m_args[1]));
-                llvm::Type* class_type0 = llvm_utils->getClassType(
-                    ASR::down_cast<ASR::Struct_t>(struct_sym0), false);
-                llvm::Type* class_type1 = llvm_utils->getClassType(
-                    ASR::down_cast<ASR::Struct_t>(struct_sym1), false);
 
-                // For allocatable/pointer class(*), load the pointer first.
-                ASR::ttype_t* arg_type0 = ASRUtils::expr_type(x.m_args[0]);
-                ASR::ttype_t* arg_type1 = ASRUtils::expr_type(x.m_args[1]);
-                if (ASRUtils::is_allocatable(arg_type0) ||
-                    ASR::is_a<ASR::Pointer_t>(*arg_type0)) {
-                    arg0 = llvm_utils->CreateLoad2(class_type0->getPointerTo(), arg0);
-                }
-                if (ASRUtils::is_allocatable(arg_type1) ||
-                    ASR::is_a<ASR::Pointer_t>(*arg_type1)) {
-                    arg1 = llvm_utils->CreateLoad2(class_type1->getPointerTo(), arg1);
-                }
+                llvm::Value* id0 = llvm_utils->get_type_identifier_for_polymorphic_type(
+                    x.m_args[0], arg0, struct_sym0, module.get(), get_class_hash(struct_sym0));
+                llvm::Value* id1 = llvm_utils->get_type_identifier_for_polymorphic_type(
+                    x.m_args[1], arg1, struct_sym1, module.get(), get_class_hash(struct_sym1));
 
-                // Extract field 0 (type hash or vtable pointer)
-                llvm::Value* id0_ptr = llvm_utils->create_gep2(class_type0, arg0, 0);
-                llvm::Value* id1_ptr = llvm_utils->create_gep2(class_type1, arg1, 0);
-                llvm::Type* field0_type = llvm::cast<llvm::StructType>(class_type0)->getElementType(0);
-                llvm::Value* id0 = llvm_utils->CreateLoad2(field0_type, id0_ptr);
-                llvm::Value* id1 = llvm_utils->CreateLoad2(field0_type, id1_ptr);
-
-                if (field0_type->isPointerTy()) {
+                if (compiler_options.new_classes) {
                     // new_classes: walk parent chain via TypeInfo
                     // TypeInfo layout: { i8* name, i8* size, i8* parent_typeinfo }
                     // vptr[-1] = TypeInfo pointer

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -9493,6 +9493,31 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
         return gep;
     }
 
+    llvm::Value* LLVMUtils::get_type_identifier_for_polymorphic_type(
+            ASR::expr_t* arg, llvm::Value* arg_val, ASR::symbol_t* struct_sym,
+            llvm::Module* module, int class_type_id) {
+        struct_sym = ASRUtils::symbol_get_past_external(struct_sym);
+        ASR::ttype_t* arg_type = ASRUtils::expr_type(arg);
+        ASR::ttype_t* core_type = ASRUtils::type_get_past_allocatable_pointer(arg_type);
+        if (ASRUtils::is_class_type(core_type)) {
+            llvm::Type* class_type = getClassType(
+                ASR::down_cast<ASR::Struct_t>(struct_sym), false);
+            if (ASRUtils::is_allocatable(arg_type) ||
+                ASR::is_a<ASR::Pointer_t>(*arg_type)) {
+                arg_val = CreateLoad2(class_type->getPointerTo(), arg_val);
+            }
+            llvm::Value* id_ptr = create_gep2(class_type, arg_val, 0);
+            llvm::Type* field0_type = llvm::cast<llvm::StructType>(class_type)->getElementType(0);
+            return CreateLoad2(field0_type, id_ptr);
+        }
+        // Non-polymorphic derived type: use the static type's identifier.
+        if (compiler_options.new_classes) {
+            return struct_api->get_pointer_to_method(struct_sym, module);
+        }
+        return llvm::ConstantInt::get(getIntType(8),
+            llvm::APInt(64, class_type_id));
+    }
+
     void LLVMStruct::store_class_vptr(ASR::symbol_t* struct_sym, llvm::Value* ptr, llvm::Module* module)
     {
         struct_sym = ASRUtils::symbol_get_past_external(struct_sym);

--- a/src/libasr/codegen/llvm_utils.h
+++ b/src/libasr/codegen/llvm_utils.h
@@ -793,6 +793,9 @@ class ASRToLLVMVisitor;
 
             llvm::Type* getClassType(ASR::Struct_t* der_type, bool is_pointer=false);
 
+            llvm::Value* get_type_identifier_for_polymorphic_type(ASR::expr_t* arg, llvm::Value* arg_val, 
+                ASR::symbol_t* struct_sym, llvm::Module* module, int class_type_id);
+
             llvm::Type* getFPType(int a_kind, bool get_pointer=false);
 
             llvm::Type* getComplexType(int a_kind, bool get_pointer=false);


### PR DESCRIPTION
Fixes #12675 
Use the dynamic type identifier for polymorphic values and the static type
identifier for non-polymorphic derived types in SAME_TYPE_AS and
EXTENDS_TYPE_OF helpers.

Add the lowering helper in LLVMUtils, and update callsites to resolve
for types through this helper.