### PR TITLE
Allow c_loc on assumed-rank arrays

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -969,6 +969,7 @@ RUN(NAME assumed_rank_11 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 COMPILE(NAME assumed_rank_12 COMPILERS gfortran llvm llvm_wasm) # move to RUN with llvm once assumed-size -> assumed-rank codegen is supported (#11851)
 
 RUN(NAME assumed_rank_14 LABELS gfortran llvm)
+RUN(NAME assumed_rank_15 LABELS gfortran llvm)
 RUN(NAME assume_rank_shape_product_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_rank_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME select_rank_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/assumed_rank_15.f90
+++ b/integration_tests/assumed_rank_15.f90
@@ -1,0 +1,71 @@
+! C_LOC accepts an assumed-rank actual argument (F2023 C840) and yields the
+! address of the first element of the array.
+program assumed_rank_15
+  use, intrinsic :: iso_c_binding
+  implicit none
+
+  integer, target :: r1(5) = [1, 2, 3, 4, 5]
+  integer, target :: r2(2, 2) = reshape([10, 20, 30, 40], [2, 2])
+  real(c_double), target :: r3(2, 2, 2)
+  integer, allocatable, target :: alloc(:)
+  integer, target :: sec(6) = [1, 2, 3, 4, 5, 6]
+  integer, target :: m(2, 3) = reshape([1, 2, 3, 4, 5, 6], [2, 3])
+
+  r3 = 0.0_c_double
+  allocate(alloc(4))
+  alloc = [7, 8, 9, 10]
+
+  ! rank is only known at run time, so C_LOC must go through the descriptor
+  call set_first_int(r1)
+  if (r1(1) /= 99) error stop "rank 1"
+
+  call set_first_int(r2)
+  if (r2(1, 1) /= 99) error stop "rank 2"
+
+  call set_first_real(r3)
+  if (r3(1, 1, 1) /= 5.0_c_double) error stop "rank 3"
+
+  call set_first_int(alloc)
+  if (alloc(1) /= 99) error stop "allocatable"
+
+  ! a contiguous section must give the address of the section, not of sec(1)
+  call check_first_int(sec(3:5), 3)
+  ! for a rank-2 array the first element in array element order is m(1, 1)
+  call check_first_int(m, 1)
+
+  print *, "ok"
+
+contains
+
+  subroutine set_first_int(a)
+    integer, intent(inout), target, contiguous :: a(..)
+    type(c_ptr) :: cptr
+    integer, pointer :: fptr
+
+    cptr = c_loc(a)
+    call c_f_pointer(cptr, fptr)
+    fptr = 99
+  end subroutine set_first_int
+
+  subroutine set_first_real(a)
+    real(c_double), intent(inout), target, contiguous :: a(..)
+    type(c_ptr) :: cptr
+    real(c_double), pointer :: fptr
+
+    cptr = c_loc(a)
+    call c_f_pointer(cptr, fptr)
+    fptr = 5.0_c_double
+  end subroutine set_first_real
+
+  subroutine check_first_int(a, expected)
+    integer, intent(in), target, contiguous :: a(..)
+    integer, intent(in) :: expected
+    type(c_ptr) :: cptr
+    integer, pointer :: fptr
+
+    cptr = c_loc(a)
+    call c_f_pointer(cptr, fptr)
+    if (fptr /= expected) error stop "c_loc did not point at the first element"
+  end subroutine check_first_int
+
+end program assumed_rank_15

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -13888,7 +13888,8 @@ public:
                     } else if (!(intrinsic_name == "len" || intrinsic_name == "size" || intrinsic_name == "lbound" || intrinsic_name == "ubound" || 
                         intrinsic_name == "rank" || intrinsic_name == "shape" || intrinsic_name == "is_contiguous" || 
                         intrinsic_name == "associated" || intrinsic_name == "allocated" || intrinsic_name == "present" ||
-                        intrinsic_name == "storage_size" || intrinsic_name == "same_type_as" || intrinsic_name == "extends_type_of")) {
+                        intrinsic_name == "storage_size" || intrinsic_name == "same_type_as" || intrinsic_name == "extends_type_of" ||
+                        intrinsic_name == "c_loc")) {
                         diag.semantic_error_label("Assumed rank arrays cannot be used as arguments to intrinsics",
                             {arg_expr->base.loc}, "");
                         throw SemanticAbort();

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -9143,6 +9143,7 @@ public:
             llvm::Type *el_type = llvm_utils->get_el_type(
                 asr_expr, ASRUtils::extract_type(asr_type), module.get());
             switch( physical_type ) {
+                case ASR::array_physical_typeType::AssumedRankArray:
                 case ASR::array_physical_typeType::DescriptorArray: {
                     llvm_tmp = llvm_utils->CreateLoad2(el_type->getPointerTo(), arr_descr->get_pointer_to_data(llvm_utils->get_type_from_ttype_t_util(asr_expr, asr_type, module.get()), llvm_tmp));
                     break;


### PR DESCRIPTION
Fixes: #12691 

F2023 C840 explicitly permits an assumed-rank actual argument to C_LOC, but semantics rejected it with "Assumed rank arrays cannot be used as arguments to intrinsics". Add c_loc to the allowlist of intrinsics that accept an assumed-rank argument.

An assumed-rank array shares the descriptor representation used by DescriptorArray, so GetPointerCPtrUtil lowers it through the same path to obtain the address of the first element; previously that physical type fell through to an assertion.