### PR TITLE
Answer size(matmul) and size(transpose) from the operand shapes

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4209,6 +4209,7 @@ RUN(NAME matmul_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --re
 RUN(NAME matmul_05 LABELS gfortran llvm)
 RUN(NAME matmul_06 LABELS gfortran llvm)
 RUN(NAME matmul_07 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
+RUN(NAME array_size_matmul_01 LABELS gfortran llvm)
 RUN(NAME simd_01 LABELS gfortran c llvm llvm_nopragma c_nopragma)
 RUN(NAME simd_02 LABELS gfortran c llvm llvm_nopragma c_nopragma NO_FAST_MATH)
 RUN(NAME legacy_array_sections_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvmStackArray EXTRA_ARGS --legacy-array-sections)

--- a/integration_tests/array_size_matmul_01.f90
+++ b/integration_tests/array_size_matmul_01.f90
@@ -1,0 +1,85 @@
+! Type-level size(matmul(...)) and size(transpose(...)) must follow the
+! result shape, not the size of the first array argument.
+program array_size_matmul_01
+implicit none
+integer, parameter :: nrow = 3, ncol = 2, ncb = 4
+real :: a(nrow, ncol), b(ncol, ncb), v(ncol)
+integer :: i, k
+
+do i = 1, nrow
+    do k = 1, ncol
+        a(i, k) = real(i) + 10.0 * real(k)
+    end do
+end do
+do i = 1, ncol
+    do k = 1, ncb
+        b(i, k) = real(i) * 2.0 - real(k)
+    end do
+end do
+do i = 1, ncol
+    v(i) = real(i) * 3.0 - 1.0
+end do
+
+! (n,k) x (k) -> (n): size is n, not n*k.
+if (auto_matvec(a, v) /= nrow) error stop "matvec extent"
+! (n,k) x (k,m) -> (n,m)
+if (.not. auto_matmat(a, b, nrow, ncb)) error stop "matmat extents"
+! transpose swaps the two extents.
+if (.not. auto_transpose(a, ncol, nrow)) error stop "transpose extents"
+! Runtime dim selects among those extents via merge.
+if (auto_matmat_dim(a, b, 1) /= nrow) error stop "matmat dim 1"
+if (auto_matmat_dim(a, b, 2) /= ncb) error stop "matmat dim 2"
+! The same queries in an executable statement rather than in a declaration:
+! these go down the general (non type-level) path, which must agree.
+if (.not. runtime_extents(a, b, v)) error stop "runtime extents"
+
+contains
+
+function auto_matvec(x, y) result(n)
+real, intent(in) :: x(:,:), y(:)
+integer :: n
+real :: t(size(matmul(x, y)))
+n = size(t)
+end function
+
+function auto_matmat(x, y, d1, d2) result(ok)
+real, intent(in) :: x(:,:), y(:,:)
+integer, intent(in) :: d1, d2
+logical :: ok
+real :: t(size(matmul(x, y), 1), size(matmul(x, y), 2))
+t = matmul(x, y)
+ok = size(t, 1) == d1 .and. size(t, 2) == d2 .and. size(t) == d1 * d2
+end function
+
+function auto_transpose(x, d1, d2) result(ok)
+real, intent(in) :: x(:,:)
+integer, intent(in) :: d1, d2
+logical :: ok
+real :: t(size(transpose(x), 1), size(transpose(x), 2))
+t = transpose(x)
+ok = size(t, 1) == d1 .and. size(t, 2) == d2
+end function
+
+! size(...) asked outside a declaration, where the extent is computed
+! rather than used to shape an object.
+function runtime_extents(x, y, z) result(ok)
+real, intent(in) :: x(:,:), y(:,:), z(:)
+logical :: ok
+ok = size(matmul(x, y)) == size(x, 1) * size(y, 2) &
+    .and. size(matmul(x, y), 1) == size(x, 1) &
+    .and. size(matmul(x, y), 2) == size(y, 2) &
+    .and. size(matmul(x, z)) == size(x, 1) &
+    .and. size(matmul(z, y)) == size(y, 2) &
+    .and. size(transpose(x), 1) == size(x, 2) &
+    .and. size(transpose(x), 2) == size(x, 1)
+end function
+
+function auto_matmat_dim(x, y, d) result(n)
+real, intent(in) :: x(:,:), y(:,:)
+integer, intent(in) :: d
+integer :: n
+real :: t(size(matmul(x, y), d))
+n = size(t)
+end function
+
+end program

--- a/src/libasr/asr_utils.cpp
+++ b/src/libasr/asr_utils.cpp
@@ -3862,6 +3862,92 @@ ASR::expr_t* get_ArrayConstructor_size(Allocator& al, ASR::ArrayConstructor_t* x
     return array_size;
 }
 
+// The shape of `matmul` and of `transpose` follows entirely from the
+// shapes of their operands, and neither carries dimensions of its own in
+// its result type, so a `size(...)` query on one has to be answered from
+// the operands: matmul is (n,k)x(k,m) -> (n,m), (n,k)x(k) -> (n) and
+// (k)x(k,m) -> (m), and transpose swaps the two extents of its argument.
+// The general rule in `make_ArraySize_t_util` -- the size of the first
+// array argument, which holds for the intrinsics whose result has the
+// shape of their argument -- would answer `size(matmul(a, b))` with the
+// size of `a`.  Returns nullptr for every other intrinsic, and for an
+// operand rank combination that is not one of matmul's three.
+static ASR::asr_t* array_intrinsic_shape_size(Allocator &al,
+    const Location &a_loc, ASR::IntrinsicArrayFunction_t* af,
+    ASR::expr_t* a_dim, ASR::ttype_t* a_type, bool for_type) {
+    // Each dimension of the result, as the operand and the 1-based
+    // dimension of that operand whose extent it is.
+    std::vector<std::pair<ASR::expr_t*, int64_t>> shape;
+    ASRUtils::IntrinsicArrayFunctions id =
+        static_cast<ASRUtils::IntrinsicArrayFunctions>(af->m_arr_intrinsic_id);
+    if( id == ASRUtils::IntrinsicArrayFunctions::MatMul ) {
+        if( af->n_args != 2 ) return nullptr;
+        ASR::expr_t* a = ASRUtils::get_past_array_physical_cast(af->m_args[0]);
+        ASR::expr_t* b = ASRUtils::get_past_array_physical_cast(af->m_args[1]);
+        size_t ra = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(a));
+        size_t rb = ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(b));
+        if( ra == 2 && rb == 2 ) {
+            shape.push_back({a, 1});
+            shape.push_back({b, 2});
+        } else if( ra == 2 && rb == 1 ) {
+            shape.push_back({a, 1});
+        } else if( ra == 1 && rb == 2 ) {
+            shape.push_back({b, 2});
+        } else {
+            return nullptr;
+        }
+    } else if( id == ASRUtils::IntrinsicArrayFunctions::Transpose ) {
+        if( af->n_args != 1 ) return nullptr;
+        ASR::expr_t* a = ASRUtils::get_past_array_physical_cast(af->m_args[0]);
+        if( ASRUtils::extract_n_dims_from_ttype(ASRUtils::expr_type(a)) != 2 ) {
+            return nullptr;
+        }
+        shape.push_back({a, 2});
+        shape.push_back({a, 1});
+    } else {
+        return nullptr;
+    }
+    ASRBuilder builder(al, a_loc);
+    ASR::ttype_t* int32_type = ASRUtils::TYPE(ASR::make_Integer_t(al, a_loc, 4));
+    auto extent = [&](size_t i) {
+        ASR::expr_t* d = ASRUtils::EXPR(ASR::make_IntegerConstant_t(
+            al, a_loc, shape[i].second, int32_type));
+        return ASRUtils::EXPR(make_ArraySize_t_util(al, a_loc, shape[i].first,
+            d, a_type, nullptr, for_type));
+    };
+    if( a_dim == nullptr ) {
+        ASR::expr_t* size = extent(0);
+        for( size_t i = 1; i < shape.size(); i++ ) {
+            size = builder.Mul(size, extent(i));
+        }
+        return &(size->base);
+    }
+    if( shape.size() == 1 ) {
+        // A rank-one result has one dimension whatever `dim` evaluates to.
+        return &(extent(0)->base);
+    }
+    int dim = -1;
+    if( ASRUtils::extract_value(ASRUtils::expr_value(a_dim), dim) ) {
+        if( dim < 1 || (size_t) dim > shape.size() ) return nullptr;
+        return &(extent((size_t) dim - 1)->base);
+    }
+    Vec<ASR::expr_t*> merge_args; merge_args.reserve(al, 3);
+    merge_args.push_back(al, extent(0));
+    merge_args.push_back(al, extent(1));
+    merge_args.push_back(al, builder.Eq(a_dim,
+        builder.i_t(1, ASRUtils::expr_type(a_dim))));
+    diag::Diagnostics diag;
+    ASR::asr_t *merged = ASRUtils::Merge::create_Merge(
+        al, a_loc, merge_args, diag);
+    // The three arguments are two integer extents and a logical test
+    // constructed here, so Merge cannot reject them. A failure is an
+    // invariant break, not a user diagnostic to drop.
+    LCOMPILERS_ASSERT(merged != nullptr);
+    LCOMPILERS_ASSERT(!diag.has_error());
+    if (merged == nullptr || diag.has_error()) return nullptr;
+    return merged;
+}
+
 ASR::asr_t* make_ArraySize_t_util(
     Allocator &al, const Location &a_loc, ASR::expr_t* a_v,
     ASR::expr_t* a_dim, ASR::ttype_t* a_type, ASR::expr_t* a_value,
@@ -3878,6 +3964,9 @@ ASR::asr_t* make_ArraySize_t_util(
     }
     if ( ASR::is_a<ASR::IntrinsicArrayFunction_t>(*a_v) && for_type ) {
         ASR::IntrinsicArrayFunction_t* af = ASR::down_cast<ASR::IntrinsicArrayFunction_t>(a_v);
+        ASR::asr_t* shape_size = array_intrinsic_shape_size(al, a_loc, af,
+            a_dim, a_type, for_type);
+        if( shape_size != nullptr ) return shape_size;
         int64_t dim_arg_index = ASRUtils::IntrinsicArrayFunctionRegistry::get_dim_arg_index(
             static_cast<ASRUtils::IntrinsicArrayFunctions>(af->m_arr_intrinsic_id));
         ASR::expr_t* af_dim = nullptr;


### PR DESCRIPTION
## Summary

`size(matmul(...))` and `size(transpose(...))` used at type level were answered
with the size of the first array argument, so a declaration shaped by one got
the wrong extents.

The shape of `matmul` and of `transpose` follows entirely from the shapes of
their operands, and neither carries dimensions of its own in its result type,
so the query has to be answered from the operands: matmul is
`(n,k)x(k,m) -> (n,m)`, `(n,k)x(k) -> (n)` and `(k)x(k,m) -> (m)`; transpose
swaps the two extents of its argument. A `dim` the compiler cannot evaluate
picks between the two extents with `merge`.

## Scope

Split out of the GPU offload work in
[#12705](https://github.com/lfortran/lfortran/pull/12705), which needs it. This
is the part of that branch that changes behaviour for every front end and
backend independently of GPU offload, so it is reviewable and bisectable on its
own. The GPU work follows in a stacked PR based on this one.

- `src/libasr/asr_utils.cpp` — `array_intrinsic_shape_size`, consulted from
  `make_ArraySize_t_util`.
- `integration_tests/array_size_matmul_01.f90` — new test, registered
  `gfortran llvm`.

## Verification

The test fails on `main` and passes here:

```
$ ./a.out            # main
ERROR STOP matvec extent
$ ./a.out            # this branch
(exit 0)
```

It covers both paths the query can take:

- the type-level path, where the result shapes a declared object
  (`real :: t(size(matmul(x, y), 1), size(matmul(x, y), 2))`) — this is what
  was wrong;
- the executable path, where the size is computed rather than used to shape
  something. That path was already correct; the test locks it in, since the fix
  only touches the `for_type` branch and nothing else guarded it.

Both are checked against GFortran, which agrees.

Suites, LLVM 18 / Ninja / Debug:

- `./run_tests.py` — clean apart from `llvm-asr_text_compile_01`, which differs
  only as `i8**` vs `ptr`: an opaque-pointer artifact of the local LLVM version,
  present on `main` in the same environment and untouched by this change.
- `cd integration_tests && ./run_tests.py -b llvm` — **3962/3962 passed**.

## Rationale

`make_ArraySize_t_util` already special-cases `FunctionCall` and
`ArrayReshape`, whose results carry their own dimensions. `matmul` and
`transpose` do not, so the general "size of the first array argument" rule --
which is right for the intrinsics whose result has the shape of their argument
-- is wrong for them, and the answer has to be rebuilt from the operands. This
belongs in AST-to-ASR, where the shape of an expression is decided, rather than
in any backend.