### PR TITLE
fix: don't apply intrinsic assignment shape rules to a defined assign…

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2577,6 +2577,7 @@ RUN(NAME derived_types_157 LABELS gfortran llvm)
 RUN(NAME derived_types_158 LABELS gfortran llvm)
 RUN(NAME derived_types_159 LABELS gfortran llvm)
 RUN(NAME defined_assignment_01 LABELS llvm flang)
+RUN(NAME defined_assignment_02 LABELS gfortran llvm)
 RUN(NAME defined_assignment_free_interface_01 LABELS gfortran llvm flang)
 
 RUN(NAME derived_type_with_default_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/defined_assignment_02.f90
+++ b/integration_tests/defined_assignment_02.f90
@@ -1,0 +1,134 @@
+! Shape conformance is a rule of intrinsic assignment only. A defined
+! assignment passes both sides as actual arguments, so the RHS may be an array
+! constructor assigned to a scalar, or an array whose rank or size differs from
+! the target. LFortran used to apply the intrinsic-assignment checks regardless
+! of whether the statement resolved to a defined assignment(=).
+! See https://github.com/lfortran/lfortran/issues/12665
+!
+! Every case below is rejected without the fix.
+!
+! The free interface and the type-bound generic live in separate modules, and
+! each test procedure uses only one of them: a module-level `interface
+! assignment(=)` in scope shadows type-bound assignment resolution (same
+! restriction noted in defined_assignment_01.f90).
+
+module defined_assignment_02_free_mod
+   implicit none
+
+   type :: bitset_t
+      integer :: bits = 0
+   end type bitset_t
+
+   type :: tag_t
+      integer :: n = 0
+   end type tag_t
+
+   interface assignment(=)
+      module procedure assign_logical_to_bitset
+      module procedure assign_int_to_bitset
+      module procedure assign_int_to_tag_1d
+      module procedure assign_real_to_tag_2d
+   end interface
+
+contains
+
+   subroutine assign_logical_to_bitset(self, v)
+      type(bitset_t), intent(out) :: self
+      logical, intent(in) :: v(:)
+      integer :: i
+      self%bits = 0
+      do i = 1, size(v)
+         if (v(i)) self%bits = ibset(self%bits, i - 1)
+      end do
+   end subroutine assign_logical_to_bitset
+
+   subroutine assign_int_to_bitset(self, v)
+      type(bitset_t), intent(out) :: self
+      integer, intent(in) :: v(:)
+      self%bits = sum(v)
+   end subroutine assign_int_to_bitset
+
+   subroutine assign_int_to_tag_1d(self, v)
+      type(tag_t), intent(out) :: self(:)
+      integer, intent(in) :: v(:)
+      self(:)%n = size(v)
+   end subroutine assign_int_to_tag_1d
+
+   subroutine assign_real_to_tag_2d(self, v)
+      type(tag_t), intent(out) :: self(:,:)
+      real, intent(in) :: v(:)
+      self(:,:)%n = size(v)
+   end subroutine assign_real_to_tag_2d
+
+end module defined_assignment_02_free_mod
+
+module defined_assignment_02_tb_mod
+   implicit none
+
+   type :: counter_t
+      integer :: n = 0
+   contains
+      procedure :: assign_counter
+      generic :: assignment(=) => assign_counter
+   end type counter_t
+
+contains
+
+   subroutine assign_counter(lhs, rhs)
+      class(counter_t), intent(out) :: lhs
+      integer, intent(in) :: rhs(:)
+      lhs%n = size(rhs)
+   end subroutine assign_counter
+
+end module defined_assignment_02_tb_mod
+
+program defined_assignment_02
+   implicit none
+
+   call test_scalar_target()
+   call test_array_target()
+   call test_type_bound()
+
+   print *, "ok"
+
+contains
+
+   ! Array constructor assigned to a scalar target
+   subroutine test_scalar_target()
+      use defined_assignment_02_free_mod
+      type(bitset_t) :: x
+
+      x = [.true., .false., .true., .false.]
+      if (x%bits /= 5) error stop 1
+
+      ! The generic still selects on the constructor's type
+      x = [1, 2, 3, 4]
+      if (x%bits /= 10) error stop 2
+   end subroutine test_scalar_target
+
+   ! Array target whose shape does not conform to the RHS
+   subroutine test_array_target()
+      use defined_assignment_02_free_mod
+      type(tag_t) :: a(5), b(2,3)
+      integer :: iv(2) = [1, 2]
+      real :: rv(4) = [1.0, 2.0, 3.0, 4.0]
+
+      ! Same rank, different size
+      a = iv
+      if (any(a%n /= 2)) error stop 3
+
+      ! Different rank
+      b = rv
+      if (any(b%n /= 4)) error stop 4
+   end subroutine test_array_target
+
+   ! Same, through a type-bound generic assignment(=)
+   subroutine test_type_bound()
+      use defined_assignment_02_tb_mod
+      type(counter_t) :: c
+
+      c = [10, 20, 30]
+      if (c%n /= 3) error stop 5
+   end subroutine test_type_bound
+
+end program defined_assignment_02

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -7000,16 +7000,23 @@ public:
 
         ASR::ttype_t *target_type = ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(target));
         ASR::ttype_t *value_type = ASRUtils::type_get_past_allocatable_pointer(ASRUtils::expr_type(value));
-        if (target->type == ASR::exprType::Var && !ASRUtils::is_array(target_type) &&
-            value->type == ASR::exprType::ArrayConstant ) {
-            diag.add(Diagnostic(
-                "ArrayInitalizer expressions can only be assigned array references",
-                Level::Error, Stage::Semantic, {
-                    Label("",{x.base.base.loc})
-                }));
-            throw SemanticAbort();
+        // Shape conformance is a rule of intrinsic assignment only. A defined
+        // assignment passes both sides as actual arguments, so the value may be
+        // an array constructor assigned to a scalar, or an array of a different
+        // rank or size than the target; the overload resolution above has
+        // already matched it against the dummy arguments.
+        if (overloaded_stmt == nullptr) {
+            if (target->type == ASR::exprType::Var && !ASRUtils::is_array(target_type) &&
+                value->type == ASR::exprType::ArrayConstant ) {
+                diag.add(Diagnostic(
+                    "ArrayInitalizer expressions can only be assigned array references",
+                    Level::Error, Stage::Semantic, {
+                        Label("",{x.base.base.loc})
+                    }));
+                throw SemanticAbort();
+            }
+            check_ArrayAssignmentCompatibility(target, value, x);
         }
-        check_ArrayAssignmentCompatibility(target, value, x);
 
         if( overloaded_stmt == nullptr ) {
             bool lhs_supports_implicit_cast = (

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1829,6 +1829,16 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
 
 
     void visit_Assignment(const ASR::Assignment_t& x) {
+        // A non-elemental defined assignment is entirely carried out by the
+        // overloaded subroutine call, which takes both sides as actual
+        // arguments. There is no element-wise assignment to expand and no
+        // shape conformance to check. (An elemental one is expanded below.)
+        if (x.m_overloaded != nullptr &&
+                ASR::is_a<ASR::SubroutineCall_t>(*x.m_overloaded) &&
+                !ASRUtils::is_elemental(ASR::down_cast<ASR::SubroutineCall_t>(
+                    x.m_overloaded)->m_name)) {
+            return ;
+        }
         if (ASRUtils::is_simd_array(x.m_target)) {
             if( !(ASRUtils::is_allocatable(x.m_value) ||
                   ASRUtils::is_pointer(ASRUtils::expr_type(x.m_value))) ) {

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -1132,6 +1132,15 @@ program continue_compilation_1
         print *, parameterized_t(4, 1, 2)  ! {Error} too many arguments in derived type constructor
     end subroutine
 
+    ! Intrinsic assignment of an array constructor to a scalar. With a
+    ! defined assignment(=) in scope this is legal (see integration test
+    ! defined_assignment_02.f90); without one it stays an error.
+    subroutine array_constructor_to_scalar()
+        implicit none
+        integer :: i
+        i = [1, 2, 3]  ! {Error} ArrayInitalizer expressions can only be assigned array references
+    end subroutine
+
     ! Keep the unsupported character kind declarations last: a rejected
     ! declaration makes the symbol table visitor skip the program units that
     ! follow it, which would hide the errors expected above.

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "cf8a726eb5f5a9bbb60ac97201942d9d769767b29dbb8f517f597352",
+    "infile_hash": "f66bc67fe8d7dae96351b6672755e44ae6286ac4e132f31158e400a7",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "12a9b41df8a235e60f76874bfb471b377de5e551ee9b9c354416352e",
+    "stderr_hash": "fa9d9236cf318223068ac3399eaca21e45f6086780a5129af96ab75d",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -11,9 +11,9 @@ syntax error: implicit statement must appear before declaration and executable s
     |         ^^^^^^^^^^^^^^ 
 
 syntax error: Token 'foo' (of type 'identifier') is unexpected here
-    --> tests/errors/continue_compilation_1.f90:1153:7
+    --> tests/errors/continue_compilation_1.f90:1162:7
      |
-1153 |       foo    end type t_recovery
+1162 |       foo    end type t_recovery
      |       ^^^ 
 
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
@@ -599,21 +599,21 @@ semantic error: a conditional expression is not allowed in a specification expre
      |                        ~~~~~~~~~~~~~~~ help: Fortran 2023 10.1.11 does not list a conditional expression among the permitted primaries; use `merge`, which is permitted here
 
 semantic error: kind 2 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1140:19
+    --> tests/errors/continue_compilation_1.f90:1149:19
      |
-1140 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
+1149 |         character(kind=2, len=4) :: a  ! {Error} kind 2 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: kind 3 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1141:19
+    --> tests/errors/continue_compilation_1.f90:1150:19
      |
-1141 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
+1150 |         character(kind=3, len=4) :: b  ! {Error} kind 3 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: kind 8 is not supported for character, only 1 and 4 are
-    --> tests/errors/continue_compilation_1.f90:1142:19
+    --> tests/errors/continue_compilation_1.f90:1151:19
      |
-1142 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
+1151 |         character(kind=8, len=4) :: c  ! {Error} kind 8 is not supported for character, only 1 and 4 are
      |                   ^^^^^^ 
 
 semantic error: Symbol 'undeclared_proc' not declared
@@ -623,9 +623,9 @@ semantic error: Symbol 'undeclared_proc' not declared
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Derived type 't_recovery' not declared
-    --> tests/errors/continue_compilation_1.f90:1156:7
+    --> tests/errors/continue_compilation_1.f90:1165:7
      |
-1156 |       class(t_recovery), intent(in) :: self
+1165 |       class(t_recovery), intent(in) :: self
      |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 semantic error: Symbol 'bad_op' not declared
@@ -2108,3 +2108,9 @@ semantic error: too many arguments in derived type constructor
      |
 1132 |         print *, parameterized_t(4, 1, 2)  ! {Error} too many arguments in derived type constructor
      |                  ^^^^^^^^^^^^^^^^^^^^^^^^ more positional arguments than components and type parameters
+
+semantic error: ArrayInitalizer expressions can only be assigned array references
+    --> tests/errors/continue_compilation_1.f90:1141:9
+     |
+1141 |         i = [1, 2, 3]  ! {Error} ArrayInitalizer expressions can only be assigned array references
+     |         ^^^^^^^^^^^^^ 


### PR DESCRIPTION
…ment

Shape conformance is a rule of intrinsic assignment. A defined assignment passes both sides as actual arguments, so the RHS may be an array constructor assigned to a scalar, or an array whose rank or size differs from the target; the overload resolution has already matched it against the dummy arguments.

Two places applied the intrinsic rules without consulting the resolved overload:

  - The Assignment visitor rejected `scalar_var = [ ... ]` with "ArrayInitalizer expressions can only be assigned array references", and ran check_ArrayAssignmentCompatibility() on an array target, reporting "Different shape for array assignment" or "Incompatible ranks" for a legal defined assignment. Both checks now run only when no overloaded assignment was resolved.

  - The array_op pass expanded such an assignment element-wise and emitted a DebugCheckArrayBounds, so a non-conforming array target failed at run time instead. A non-elemental defined assignment is carried out entirely by the overloaded subroutine call, so there is nothing to expand and no shape to check; return early. An elemental defined assignment is still expanded as before.

The diagnostics are unchanged for genuine intrinsic assignments.

Fixes #12665