### PR TITLE
fix: keep `&!` inside character literals in free-form prescan

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2616,6 +2616,7 @@ RUN(NAME line_continuation_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm
 RUN(NAME line_continuation_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME line_continuation_04 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc wasm)
 RUN(NAME line_continuation_05 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME line_continuation_06 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 RUN(NAME program_01 LABELS gfortran)
 RUN(NAME program_02 LABELS gfortran llvm)

--- a/integration_tests/line_continuation_06.f90
+++ b/integration_tests/line_continuation_06.f90
@@ -1,0 +1,58 @@
+program line_continuation_06
+    ! `&!` inside a character literal must be kept verbatim: `!` never
+    ! starts a comment inside a string, and `&` is only a continuation
+    ! when it is the last non-blank character on the line.
+    implicit none
+    character(len=*), parameter :: expected = "x" // achar(38) // "!y"
+    character(len=*), parameter :: expected_amp = "x" // achar(38) // "y"
+    ! "&!" inside a plain single-line literal
+    character(len=*), parameter :: a = "x&!y"
+    ! "&!" inside a literal continued inside the quotes
+    character(len=*), parameter :: b = "x&!&
+&y"
+    ! "&!" at the start of the continuation line
+    character(len=*), parameter :: c = "x&
+&&!y"
+    ! "&" alone across a continuation (control: no "!")
+    character(len=*), parameter :: d = "x&&
+&y"
+    ! "&" followed by blanks and "!" inside a literal
+    character(len=*), parameter :: e = "x& !y"
+    ! single-quoted literal
+    character(len=*), parameter :: f = 'x&!y'
+    character(len=10) :: g
+
+    print *, len(a), "|", a, "|"
+    if (len(a) /= 4) error stop
+    if (a /= expected) error stop
+
+    print *, len(b), "|", b, "|"
+    if (len(b) /= 4) error stop
+    if (b /= expected) error stop
+
+    print *, len(c), "|", c, "|"
+    if (len(c) /= 4) error stop
+    if (c /= expected) error stop
+
+    print *, len(d), "|", d, "|"
+    if (len(d) /= 3) error stop
+    if (d /= expected_amp) error stop
+
+    print *, len(e), "|", e, "|"
+    if (len(e) /= 5) error stop
+    if (e /= "x" // achar(38) // " !y") error stop
+
+    print *, len(f), "|", f, "|"
+    if (len(f) /= 4) error stop
+    if (f /= expected) error stop
+
+    g = "&!"
+    print *, "|", trim(g), "|"
+    if (len_trim(g) /= 2) error stop
+    if (trim(g) /= achar(38) // "!") error stop
+
+    ! outside a string, `&!` is a continuation with a trailing comment
+    g = "ab" // &! comment
+        "cd"
+    if (trim(g) /= "abcd") error stop
+end program line_continuation_06

--- a/src/lfortran/parser/parser.cpp
+++ b/src/lfortran/parser/parser.cpp
@@ -916,7 +916,12 @@ Result<std::string> prescan(const std::string &s, LocationManager &lm,
             newline = false;
             if (s[pos] == '!' && !in_string) in_comment = true;
             if (in_comment && s[pos] == '\n') in_comment = false;
-            if (!in_comment && s[pos] == '&' &&(next_nonspace_character(s,pos) == '\n' || next_nonspace_character(s,pos) == '!')) {
+            // `&` starts a continuation if it is the last non-blank character
+            // on the line, or (outside a string) if it is followed by a
+            // trailing comment. Inside a string `!` never starts a comment,
+            // so `&!` must be kept verbatim there.
+            if (!in_comment && s[pos] == '&' && (next_nonspace_character(s,pos) == '\n'
+                    || (!in_string && next_nonspace_character(s,pos) == '!'))) {
                 size_t pos2=pos+1;
                 bool ws_or_comment = false;
                 cont1(s, pos2, in_string, quote, ws_or_comment);


### PR DESCRIPTION
## Summary

Fixes #12723.

The free-form prescanner in `src/lfortran/parser/parser.cpp` treated any `&` followed by `!` as a line continuation with a trailing comment, even inside a string literal. The follow-up scan (`cont1`) then found that no continuation actually occurred, but the `&` had already been skipped, so `"x&!y"` silently became `"x!y"`. The same happened for `"x& !y"`.

Inside a character context `!` never starts a comment and `&` is only a continuation when it is the last non-blank character on the line, so the `&!` case is now only treated as a continuation outside strings. The `&` followed by newline case (a real continuation inside a string) is unchanged.

## Scope

- `src/lfortran/parser/parser.cpp`: add `!in_string` to the `&!` branch of the continuation check in `prescan`.
- `integration_tests/line_continuation_06.f90` (registered with `gfortran llvm llvm_wasm llvm_wasm_emcc`): covers `&!` in a plain literal, in a continued literal, at the start of a continuation line, `&` alone across a continuation, `& !` inside a literal, a single-quoted literal, and `&!` outside a string (continuation plus comment). Expected values are built with `achar(38)` so the check is not vacuous.

## Verification

- The new test fails on `main` (`3 |x!y|` then `ERROR STOP`) and passes with this change; the issue's reproducer now prints `4 |x&!y|` for cases 1 to 3 and `3 |x&y|` for case 4, matching gfortran and flang.
- `gfortran integration_tests/line_continuation_06.f90` compiles and runs cleanly.
- `cd integration_tests && ./run_tests.py -b llvm`: 3980/3980 passed.
- `cd integration_tests && ./run_tests.py -b gfortran`: 4026/4026 passed.
- `./run_tests.py --no-llvm`: passed (the `llvm` reference outputs were skipped locally because the local LLVM 18 emits opaque-pointer IR that differs from the checked-in references; this change does not touch codegen).

## Rationale

`integration_tests/line_continuation_04.f90` already contains `'&!'` and `"& !"` checks, but both sides of each comparison went through the same prescanner, so the corruption went undetected. The earlier `previous_nonspace_character(s, pos) != '&'` special case in `cont1` was an attempt at this bug that did not restore the dropped `&`; it is left in place to keep this PR minimal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WC5yhnMEzpewYSHZDDP9XF)_