### PR TITLE
fix: resolve a specific procedure stored under a mangled name

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2255,6 +2255,7 @@ RUN(NAME generic_name_08 LABELS gfortran llvm)
 RUN(NAME generic_name_09 LABELS gfortran llvm)
 RUN(NAME generic_name_10 LABELS gfortran llvm)
 RUN(NAME generic_name_11 LABELS gfortran llvm)
+RUN(NAME generic_name_12 LABELS gfortran llvm)
 
 RUN(NAME operator_overloading_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME operator_overloading_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/generic_name_12.f90
+++ b/integration_tests/generic_name_12.f90
@@ -1,0 +1,47 @@
+module generic_name_12_mod
+    implicit none
+
+    ! `push` is a generic interface and at the same time one of its own
+    ! specific procedures, so the specific one is stored under a mangled name.
+    ! The other generic interfaces of this module must still resolve it to the
+    ! function, no matter whether their own name sorts before or after `push`.
+    interface push
+        module procedure push, push_scaled
+    end interface push
+
+    interface add
+        module procedure push, push_scaled
+    end interface add
+
+    interface store
+        module procedure push, push_scaled
+    end interface store
+
+contains
+
+    function push() result(r)
+        integer :: r
+        r = 1
+    end function push
+
+    function push_scaled(i) result(r)
+        integer, intent(in) :: i
+        integer :: r
+        r = 10 * i
+    end function push_scaled
+
+end module generic_name_12_mod
+
+program generic_name_12
+    use generic_name_12_mod
+    implicit none
+    print *, push(), push(3)
+    print *, add(), add(3)
+    print *, store(), store(3)
+    if (push() /= 1) error stop
+    if (push(3) /= 30) error stop
+    if (add() /= 1) error stop
+    if (add(3) /= 30) error stop
+    if (store() /= 1) error stop
+    if (store(3) /= 30) error stop
+end program generic_name_12

--- a/src/lfortran/semantics/ast_symboltable_visitor.cpp
+++ b/src/lfortran/semantics/ast_symboltable_visitor.cpp
@@ -3876,26 +3876,23 @@ public:
             bool any_error = false;
             for (auto &pname : proc.second) {
                 std::string name = to_lower(pname.first);
-                ASR::symbol_t *x = nullptr;
-                if( name == proc.first ) {
-                    // A specific procedure declared in this scope under its
-                    // generic interface's name is stored with the
-                    // genericprocedure suffix, see the comment where the
-                    // suffix is added.
-                    x = current_scope->resolve_symbol(
-                        name + ASRUtils::genericprocedure_suffix);
-                    if (!x) {
-                        // Otherwise it comes from another scope (e.g. it is
-                        // use associated), where it keeps its plain name. The
-                        // generic interface itself is not a candidate.
-                        x = current_scope->resolve_symbol(name);
-                        if (x && ASR::is_a<ASR::GenericProcedure_t>(
-                                *ASRUtils::symbol_get_past_external(x))) {
-                            x = nullptr;
-                        }
-                    }
-                } else {
+                // A specific procedure declared in this scope under the name
+                // of a generic interface is stored with the genericprocedure
+                // suffix, see the comment where the suffix is added. That
+                // generic interface is not necessarily the one being built
+                // here, so always look for the suffixed name first.
+                ASR::symbol_t *x = current_scope->resolve_symbol(
+                    name + ASRUtils::genericprocedure_suffix);
+                if (!x) {
+                    // Otherwise it keeps its plain name, e.g. it comes from
+                    // another scope (it is use associated). The generic
+                    // interface being built is not a candidate for itself.
                     x = current_scope->resolve_symbol(name);
+                    if (name == proc.first && x &&
+                            ASR::is_a<ASR::GenericProcedure_t>(
+                                *ASRUtils::symbol_get_past_external(x))) {
+                        x = nullptr;
+                    }
                 }
                 if (!x) {
                     diag.add(Diagnostic(


### PR DESCRIPTION
A specific procedure declared under the name of a generic interface is stored in the symbol table as "<name>~genericprocedure", so that it does not clash with the GenericProcedure symbol. When building the list of specific procedures of a generic interface, only the interface of that very name looked for the mangled symbol; every other interface looked up the plain name. Any other generic interface in the same scope that listed the procedure therefore either failed with "Symbol '<name>' not declared" or, if its own name sorted after the procedure name, silently picked up the GenericProcedure instead of the function.

Always look for the mangled name first, and only reject a resolved GenericProcedure for the interface that is being built itself.

Adds integration test generic_name_12, which lists such a procedure in two further generic interfaces, one sorting before and one after it.

Fixes #12729.