### PR TITLE
fix: preserve GPU fallback for allocatable function results

### DIFF
--- a/doc/src/asr/asr_nodes/statement_nodes/GpuKernelLaunch.md
+++ b/doc/src/asr/asr_nodes/statement_nodes/GpuKernelLaunch.md
@@ -37,6 +37,14 @@ The kernel is an ordinary [Function](../symbol_nodes/Function.md); what makes
 it launchable is that its signature has `exec_space = Kernel`, and a kernel
 has no result. See [exec_space](../enum_nodes/exec_space.md).
 
+Before creating a launch, GPU offload checks the allocation of allocatable
+array results in callees that remain out of line. Nested or multiple allocation
+sites must agree with a buffer shape established by an unconditional fixed
+allocation. Otherwise the loop is rejected while the original loop is still
+available; `--gpu-allow-cpu-fallback` instead runs that loop on the CPU.
+Reallocation and conditional assignments remain eligible when they preserve
+every extent, not just the total element count.
+
 ## Examples
 
 ```clojure

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -5238,6 +5238,8 @@ RUN(NAME gpu_metal_323 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_324 LABELS gfortran llvm metal)
 RUN(NAME gpu_metal_325 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_326 LABELS gfortran llvm metal cuda_cpu)
+RUN(NAME gpu_metal_327 LABELS gfortran llvm metal cuda_cpu EXTRA_ARGS --gpu-allow-cpu-fallback --realloc-lhs-arrays)
+RUN(NAME gpu_metal_328 LABELS gfortran llvm metal cuda_cpu EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME gpu_kernel_source_01 LABELS gfortran llvm)
 RUN(NAME gpu_kernel_source_02 LABELS gfortran llvm)

--- a/integration_tests/gpu_metal_327.f90
+++ b/integration_tests/gpu_metal_327.f90
@@ -1,0 +1,95 @@
+! Result allocations must be checked before offload commits, while CPU
+! fallback can still preserve the function's run-time result shape.
+program gpu_metal_327
+implicit none
+real :: conditional(4), resized(4), assigned(4), reshaped(1)
+real :: implicit_results(4)
+real, parameter :: expected(4) = [2.0, 2.0, 6.0, 4.0]
+integer :: i
+
+do concurrent (i = 1:4)
+    conditional(i) = sum(conditional_result(i))
+end do
+do concurrent (i = 1:4)
+    resized(i) = sum(resized_result(i))
+end do
+do concurrent (i = 1:4)
+    assigned(i) = sum_assigned(i)
+end do
+do concurrent (i = 1:1)
+    reshaped(i) = sum(reshaped_result(i))
+end do
+do concurrent (i = 1:4)
+    implicit_results(i) = sum(fixed_implicit_result(i))
+end do
+
+if (any(abs(conditional - expected) > 1.0e-5)) error stop
+if (any(abs(resized - expected) > 1.0e-5)) error stop
+if (any(abs(assigned - expected) > 1.0e-5)) error stop
+if (abs(reshaped(1) - 3.0) > 1.0e-5) error stop
+if (any(abs(implicit_results - [-2.0, 4.0, -6.0, 8.0]) > 1.0e-5)) error stop
+print *, "PASS"
+
+contains
+
+pure function conditional_result(n) result(r)
+    integer, intent(in) :: n
+    real, allocatable :: r(:)
+    if (mod(n, 2) == 0) then
+        allocate(r(1))
+    else
+        allocate(r(2))
+    end if
+    r = real(n)
+end function
+
+pure function resized_result(n) result(r)
+    integer, intent(in) :: n
+    real, allocatable :: r(:)
+    allocate(r(2))
+    r = real(n)
+    if (mod(n, 2) /= 0) return
+    deallocate(r)
+    allocate(r(1))
+    r = real(n)
+end function
+
+pure function assigned_result(n) result(r)
+    integer, intent(in) :: n
+    real, allocatable :: r(:)
+    if (mod(n, 2) == 0) then
+        r = [real(n)]
+    else
+        r = [real(n), real(n)]
+    end if
+end function
+
+pure function sum_assigned(n) result(r)
+    integer, intent(in) :: n
+    real :: r
+    r = sum(assigned_result(n))
+end function
+
+pure function reshaped_result(n) result(r)
+    integer, intent(in) :: n
+    real, allocatable :: r(:, :)
+    allocate(r(1, 2))
+    r = real(n)
+    if (mod(n, 2) /= 0) then
+        r = reshape([real(n), real(n)], [2, 1])
+    end if
+    r(1, 1) = real(size(r, 1))
+end function
+
+pure function fixed_implicit_result(n) result(r)
+    integer, intent(in) :: n
+    real, allocatable :: r(:)
+    r = [real(n), real(n)]
+    if (mod(n, 2) == 0) then
+        r = [real(n), real(n)]
+    else
+        r = -real(n)
+    end if
+end function
+
+end program

--- a/integration_tests/gpu_metal_328.f90
+++ b/integration_tests/gpu_metal_328.f90
@@ -1,0 +1,44 @@
+! A single fixed result allocation remains offloadable even when its data
+! are assigned conditionally and the actual argument is device-local.
+program gpu_metal_328
+implicit none
+real :: results(4), reallocated(4)
+integer :: i
+
+do concurrent (i = 1:4)
+    results(i) = sum(fixed_result(i))
+end do
+do concurrent (i = 1:4)
+    reallocated(i) = sum(reallocated_result(i))
+end do
+
+if (any(abs(results - [-2.0, 4.0, -6.0, 8.0]) > 1.0e-5)) error stop
+if (any(abs(reallocated - [2.0, 4.0, 6.0, 8.0]) > 1.0e-5)) error stop
+print *, "PASS"
+
+contains
+
+pure function fixed_result(n) result(r)
+    integer, intent(in) :: n
+    integer, parameter :: width = 2
+    real, allocatable :: r(:)
+    allocate(r(width))
+    r = real(n)
+    if (mod(n, 2) == 0) then
+        r = [real(n), real(n)]
+    else
+        r = -real(n)
+    end if
+end function
+
+pure function reallocated_result(n) result(r)
+    integer, intent(in) :: n
+    real, allocatable :: r(:)
+    allocate(r(2))
+    r = -real(n)
+    deallocate(r)
+    allocate(r(2))
+    r = real(n)
+end function
+
+end program

--- a/src/libasr/pass/gpu_decline.cpp
+++ b/src/libasr/pass/gpu_decline.cpp
@@ -117,6 +117,7 @@ GpuDeclineClass gpu_decline_class(const GpuDecline &decline,
         case GpuDeclineReason::AliasTemporaryRuntimeSized:
         case GpuDeclineReason::UngatherableStridedSection:
         case GpuDeclineReason::DeviceFunctionInlining:
+        case GpuDeclineReason::FunctionResultAllocation:
         case GpuDeclineReason::NestedArraySection:
         case GpuDeclineReason::WorkspaceNotSizeableOnHost:
         case GpuDeclineReason::StructDeclarationUnknown:
@@ -182,6 +183,9 @@ std::string gpu_decline_message(const GpuDecline &decline) {
             return "a strided section cannot be gathered for the gpu";
         case GpuDeclineReason::DeviceFunctionInlining:
             return "a device function cannot be inlined";
+        case GpuDeclineReason::FunctionResultAllocation:
+            return "the allocatable array result of '" + decline.name +
+                "' has no single allocation the gpu can use";
         case GpuDeclineReason::NestedArraySection:
             return "a nested array section cannot be addressed on the gpu";
         case GpuDeclineReason::WorkspaceNotSizeableOnHost:

--- a/src/libasr/pass/gpu_decline.h
+++ b/src/libasr/pass/gpu_decline.h
@@ -113,6 +113,7 @@ enum class GpuDeclineReason {
     AliasTemporaryRuntimeSized,
     UngatherableStridedSection,
     DeviceFunctionInlining,
+    FunctionResultAllocation,
     NestedArraySection,
     WorkspaceNotSizeableOnHost,
 

--- a/src/libasr/pass/gpu_offload.cpp
+++ b/src/libasr/pass/gpu_offload.cpp
@@ -562,15 +562,16 @@ void GpuOffloadVisitor::visit_OMPRegion(const ASR::OMPRegion_t &region) {
     if (device_caps.splices_device_functions()) {
         std::map<ASR::Function_t*, bool> needs_inline_memo;
         std::set<ASR::Function_t*> on_stack;
+        GpuDecline decline;
         if (!plan_device_function_inlining(work.body, work.n_body,
-                needs_inline_memo, on_stack)) {
-            // Some callee that must be inlined cannot be (recursive,
-            // early `return`, nested scopes, or called from a position
-            // with nowhere to put the result). Emitting a kernel that
-            // cannot compile would be worse than not offloading at all.
+                needs_inline_memo, on_stack, decline)) {
+            // Decline before destructive rewrites if a callee cannot be
+            // spliced or its result allocation cannot reach the device.
             functions_to_inline.clear();
-            report_not_offloaded(loc,
-                GpuDecline(GpuDeclineReason::DeviceFunctionInlining));
+            if (!decline.declined()) {
+                decline = GpuDecline(GpuDeclineReason::DeviceFunctionInlining);
+            }
+            report_not_offloaded(loc, decline);
             return;
         }
     }

--- a/src/libasr/pass/gpu_offload_device_fn.cpp
+++ b/src/libasr/pass/gpu_offload_device_fn.cpp
@@ -364,10 +364,13 @@ bool GpuOffloadVisitor::can_inline_device_function(ASR::Function_t *fn,
 }
 
 // True when `fn` itself needs a run-time sized temporary, or reaches
-// a function that does. Memoized; `visiting` breaks call cycles.
+// a function that does. Also check the results of callees that will remain
+// out of line, before later passes create their caller-owned temporaries.
+// Memoized; `visiting` breaks call cycles.
 bool GpuOffloadVisitor::device_function_needs_inlining(ASR::Function_t *fn,
         std::map<ASR::Function_t*, bool> &memo,
-        std::set<ASR::Function_t*> &visiting) {
+        std::set<ASR::Function_t*> &visiting,
+        GpuDecline &decline) {
     auto it = memo.find(fn);
     if (it != memo.end()) return it->second;
     if (visiting.count(fn)) return false;
@@ -375,22 +378,28 @@ bool GpuOffloadVisitor::device_function_needs_inlining(ASR::Function_t *fn,
     GpuDeviceFunctionArrayTempChecker checker;
     checker.check_function(fn);
     bool result = checker.has_runtime_sized_temp;
-    if (!result) {
-        GpuFunctionCollector fc;
-        for (size_t i = 0; i < fn->n_body; i++) {
-            fc.visit_stmt(*fn->m_body[i]);
-        }
-        for (auto &[name, sym] : fc.functions) {
-            ASR::Function_t *callee = resolve_device_function(sym);
-            if (callee && callee != fn &&
-                    device_function_needs_inlining(callee, memo,
-                        visiting)) {
-                result = true;
-                break;
+    GpuFunctionCollector fc;
+    for (size_t i = 0; i < fn->n_body; i++) {
+        fc.visit_stmt(*fn->m_body[i]);
+    }
+    for (auto &[name, sym] : fc.functions) {
+        ASR::Function_t *callee = resolve_device_function(sym);
+        if (callee && callee != fn) {
+            bool callee_needs_inlining = device_function_needs_inlining(
+                callee, memo, visiting, decline);
+            if (decline.declined()) {
+                visiting.erase(fn);
+                return false;
             }
+            result = result || callee_needs_inlining;
         }
     }
     visiting.erase(fn);
+    if (!result && !gpu_function_result_allocation_is_supported(*fn)) {
+        decline = GpuDecline(GpuDeclineReason::FunctionResultAllocation,
+            fn->m_name);
+        return false;
+    }
     memo[fn] = result;
     return result;
 }
@@ -398,12 +407,13 @@ bool GpuOffloadVisitor::device_function_needs_inlining(ASR::Function_t *fn,
 // Walk the statements that will become the kernel body and work out
 // which callees have to be spliced in. Purely analytical: nothing is
 // rewritten here, so the offload decision stays ahead of any
-// destructive change. Returns false when some callee that must be
-// inlined cannot be, in which case the loop is not offloaded.
+// destructive change. A callee that cannot be spliced or whose out-of-line
+// result allocation is unsupported keeps the loop on the host.
 bool GpuOffloadVisitor::plan_device_function_inlining(
         ASR::stmt_t **stmts, size_t n_stmts,
         std::map<ASR::Function_t*, bool> &memo,
         std::set<ASR::Function_t*> &on_stack,
+        GpuDecline &decline,
         bool spliceable) {
     for (size_t si = 0; si < n_stmts; si++) {
         ASR::stmt_t *stmt = stmts[si];
@@ -413,7 +423,7 @@ bool GpuOffloadVisitor::plan_device_function_inlining(
             if (b && ASR::is_a<ASR::Block_t>(*b)) {
                 ASR::Block_t *blk = ASR::down_cast<ASR::Block_t>(b);
                 if (!plan_device_function_inlining(blk->m_body,
-                        blk->n_body, memo, on_stack, spliceable)) {
+                        blk->n_body, memo, on_stack, decline, spliceable)) {
                     return false;
                 }
             }
@@ -429,7 +439,7 @@ bool GpuOffloadVisitor::plan_device_function_inlining(
                 // scope. An ASSOCIATE-local actual would leave a
                 // BlockCall whose Vars point outside that table.
                 if (!plan_device_function_inlining(blk->m_body,
-                        blk->n_body, memo, on_stack, false)) {
+                        blk->n_body, memo, on_stack, decline, false)) {
                     return false;
                 }
             }
@@ -442,8 +452,10 @@ bool GpuOffloadVisitor::plan_device_function_inlining(
             ASR::Function_t *callee = resolve_device_function(
                 call->m_name);
             if (!callee) continue;
-            if (!device_function_needs_inlining(callee, memo,
-                    on_stack)) continue;
+            bool needs_inlining = device_function_needs_inlining(callee,
+                memo, on_stack, decline);
+            if (decline.declined()) return false;
+            if (!needs_inlining) continue;
             // Only a call that *is* the assignment's value can be
             // spliced; one nested inside a larger expression would
             // need a temporary the caller does not have. ASSOCIATE
@@ -458,7 +470,7 @@ bool GpuOffloadVisitor::plan_device_function_inlining(
             functions_to_inline.insert(callee);
             on_stack.insert(callee);
             bool ok = plan_device_function_inlining(callee->m_body,
-                callee->n_body, memo, on_stack, spliceable);
+                callee->n_body, memo, on_stack, decline, spliceable);
             on_stack.erase(callee);
             if (!ok) return false;
         }

--- a/src/libasr/pass/gpu_offload_preflight.cpp
+++ b/src/libasr/pass/gpu_offload_preflight.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include <libasr/asr_utils.h>
 #include <libasr/codegen/gpu_utils.h>
 #include <libasr/pass/gpu_offload_preflight.h>
@@ -289,6 +291,121 @@ bool gpu_block_workspace_extents_resolvable(
             }
         });
     return ok;
+}
+
+// An out-of-line result becomes a caller-owned buffer. An unconditional
+// allocation may establish its shape, but every other allocation must
+// agree: selecting one branch or the last allocation is not sound.
+class GpuResultAllocationChecker :
+        public ASRUtils::BlockBodyWalkVisitor<GpuResultAllocationChecker> {
+    ASR::symbol_t *result;
+    size_t depth = 0;
+    size_t allocations = 0;
+    std::vector<int64_t> buffer_shape;
+
+    bool is_result(ASR::expr_t *target) const {
+        target = ASRUtils::get_past_array_physical_cast(target);
+        return target && ASR::is_a<ASR::Var_t>(*target) &&
+            ASRUtils::symbol_get_past_external(
+                ASR::down_cast<ASR::Var_t>(target)->m_v) == result;
+    }
+
+    static std::vector<ASR::expr_t*> lengths_of(const ASR::alloc_arg_t &arg) {
+        std::vector<ASR::expr_t*> lengths;
+        for (size_t d = 0; d < arg.n_dims; d++) {
+            lengths.push_back(arg.m_dims[d].m_length);
+        }
+        return lengths;
+    }
+
+    static std::vector<int64_t> constant_shape(
+            const std::vector<ASR::expr_t*> &lengths) {
+        std::vector<int64_t> shape;
+        for (ASR::expr_t *length : lengths) {
+            int64_t extent = 0;
+            if (!try_eval_int_constant(length, extent)) return {};
+            shape.push_back(std::max<int64_t>(extent, 0));
+        }
+        return shape;
+    }
+
+    void record(const std::vector<ASR::expr_t*> &lengths) {
+        allocations++;
+        if (!buffer_shape.empty()) {
+            // Equal element counts alone are insufficient when individual
+            // dimensions have different lengths.
+            if (constant_shape(lengths) != buffer_shape) supported = false;
+        } else if (depth != 1 || allocations > 1) {
+            supported = false;
+        }
+    }
+
+    void record(const ASR::alloc_arg_t &arg) {
+        if (is_result(arg.m_a)) record(lengths_of(arg));
+    }
+
+public:
+    bool supported = true;
+
+    GpuResultAllocationChecker(ASR::symbol_t *result,
+            ASR::stmt_t **body, size_t n_body) : result(result) {
+        // The out-of-line call path propagates an explicit top-level
+        // allocation to the caller's result buffer.
+        for (size_t i = 0; i < n_body; i++) {
+            if (!ASR::is_a<ASR::Allocate_t>(*body[i])) continue;
+            ASR::Allocate_t *alloc = ASR::down_cast<ASR::Allocate_t>(body[i]);
+            for (size_t j = 0; j < alloc->n_args; j++) {
+                if (!is_result(alloc->m_args[j].m_a)) continue;
+                buffer_shape = constant_shape(lengths_of(alloc->m_args[j]));
+                if (!buffer_shape.empty()) return;
+            }
+        }
+    }
+
+    void visit_stmt(const ASR::stmt_t &stmt) {
+        depth++;
+        ASR::BaseWalkVisitor<GpuResultAllocationChecker>::visit_stmt(stmt);
+        depth--;
+    }
+
+    void visit_Allocate(const ASR::Allocate_t &x) {
+        for (size_t i = 0; i < x.n_args; i++) record(x.m_args[i]);
+    }
+
+    void visit_ReAlloc(const ASR::ReAlloc_t &x) {
+        for (size_t i = 0; i < x.n_args; i++) record(x.m_args[i]);
+    }
+
+    void visit_Assignment(const ASR::Assignment_t &x) {
+        if (!is_result(x.m_target)) return;
+        ASR::expr_t *value = ASRUtils::get_past_array_physical_cast(x.m_value);
+        // Scalar broadcast changes the elements, not the allocation.
+        if ((x.m_realloc_lhs || x.m_move_allocation) &&
+                ASRUtils::is_array(ASRUtils::expr_type(value)) &&
+                !ASR::is_a<ASR::ArrayBroadcast_t>(*value)) {
+            std::vector<ASR::expr_t*> lengths;
+            if (!gpu_expr_shape_extents(value, nullptr, lengths)) {
+                lengths.clear();
+            }
+            record(lengths);
+        }
+    }
+};
+
+bool gpu_function_result_allocation_is_supported(const ASR::Function_t &fn) {
+    if (!fn.m_return_var ||
+            !ASRUtils::is_allocatable(ASRUtils::expr_type(fn.m_return_var)) ||
+            !ASRUtils::is_array(ASRUtils::expr_type(fn.m_return_var))) {
+        return true;
+    }
+    LCOMPILERS_ASSERT(ASR::is_a<ASR::Var_t>(*fn.m_return_var));
+    GpuResultAllocationChecker checker(ASRUtils::symbol_get_past_external(
+        ASR::down_cast<ASR::Var_t>(fn.m_return_var)->m_v),
+        fn.m_body, fn.n_body);
+    for (size_t i = 0; i < fn.n_body; i++) {
+        checker.visit_stmt(*fn.m_body[i]);
+    }
+    return checker.supported;
 }
 
 bool gpu_struct_members_ok(ASR::symbol_t *struct_sym,

--- a/src/libasr/pass/gpu_offload_preflight.h
+++ b/src/libasr/pass/gpu_offload_preflight.h
@@ -68,6 +68,8 @@ bool gpu_block_workspace_extents_resolvable(
         const std::vector<std::string> &arg_names,
         std::string &unresolved_name);
 
+bool gpu_function_result_allocation_is_supported(const ASR::Function_t &fn);
+
 // A derived type is representable only when every one of its data members
 // is, because the device struct is laid out member by member: a single
 // unsupported member anywhere in the type changes the element size the

--- a/src/libasr/pass/gpu_offload_visitor.h
+++ b/src/libasr/pass/gpu_offload_visitor.h
@@ -153,11 +153,13 @@ public:
 
     bool device_function_needs_inlining(ASR::Function_t *fn,
             std::map<ASR::Function_t*, bool> &memo,
-            std::set<ASR::Function_t*> &visiting);
+            std::set<ASR::Function_t*> &visiting,
+            GpuDecline &decline);
 
     bool plan_device_function_inlining(ASR::stmt_t **stmts, size_t n_stmts,
             std::map<ASR::Function_t*, bool> &memo,
             std::set<ASR::Function_t*> &on_stack,
+            GpuDecline &decline,
             bool spliceable = true);
 
     void substitute_in_type(ASR::ttype_t *t,

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_327-7d92e2d.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_327-7d92e2d.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_metal_327-7d92e2d",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_metal_327.f90",
+    "infile_hash": "e031ffc5b9fbd7c6f9f942b6ceb2e29002ba52959ce8fd913e6053a6",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_metal_327-7d92e2d.stdout",
+    "stdout_hash": "db48093542b30a523ade64cf9f50871a495bcd7fa8a6d14e099928e9",
+    "stderr": "gpu_cuda_kernel-gpu_metal_327-7d92e2d.stderr",
+    "stderr_hash": "c4616d1ae9ba6778bccf891203ecd8a0ca0c0850cbbafef02d6b58ce",
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_327-7d92e2d.stderr
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_327-7d92e2d.stderr
@@ -1,0 +1,54 @@
+gpu-decline: not-implemented: the allocatable array result of 'conditional_result' has no single allocation the gpu can use
+gpu-decline: not-implemented: the allocatable array result of 'resized_result' has no single allocation the gpu can use
+gpu-decline: not-implemented: the allocatable array result of 'assigned_result' has no single allocation the gpu can use
+gpu-decline: not-implemented: the allocatable array result of 'reshaped_result' has no single allocation the gpu can use
+gpu-decline: not-implemented: the allocatable array result of 'fixed_implicit_result' has no single allocation the gpu can use
+warning: parallel loop not offloaded to the GPU, it runs on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:10:1 - 12:6
+   |
+10 |    do concurrent (i = 1:4)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+12 |    end do
+   | ...^^^^^^ the allocatable array result of 'conditional_result' has no single allocation the gpu can use
+
+warning: parallel loop not offloaded to the GPU, it runs on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:13:1 - 15:6
+   |
+13 |    do concurrent (i = 1:4)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+15 |    end do
+   | ...^^^^^^ the allocatable array result of 'resized_result' has no single allocation the gpu can use
+
+warning: parallel loop not offloaded to the GPU, it runs on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:16:1 - 18:6
+   |
+16 |    do concurrent (i = 1:4)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+18 |    end do
+   | ...^^^^^^ the allocatable array result of 'assigned_result' has no single allocation the gpu can use
+
+warning: parallel loop not offloaded to the GPU, it runs on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:19:1 - 21:6
+   |
+19 |    do concurrent (i = 1:1)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+21 |    end do
+   | ...^^^^^^ the allocatable array result of 'reshaped_result' has no single allocation the gpu can use
+
+warning: parallel loop not offloaded to the GPU, it runs on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:22:1 - 24:6
+   |
+22 |    do concurrent (i = 1:4)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+24 |    end do
+   | ...^^^^^^ the allocatable array result of 'fixed_implicit_result' has no single allocation the gpu can use

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_327-7d92e2d.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_327-7d92e2d.stdout
@@ -1,0 +1,2 @@
+#include <stdint.h>
+

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_328-cc3334c.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_328-cc3334c.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_metal_328-cc3334c",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_metal_328.f90",
+    "infile_hash": "cc3945ca2b2a90a01858d34cd69014d14012a474c544adfe1973f283",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_metal_328-cc3334c.stdout",
+    "stdout_hash": "7508bcecc67a4790909526eb389403fe4deda01b9308cc3f084d2667",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_328-cc3334c.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_328-cc3334c.stdout
@@ -1,0 +1,113 @@
+#include <stdint.h>
+
+__device__ inline void fixed_result_t(int n, float* r) {
+    const int width = 2;
+    int __1__libasr_index_;
+    int __do_loop_end;
+    int __do_loop_end1;
+    int __do_loop_end2;
+    float __libasr__created__var__0__array_constructor_[2];
+    int __libasr_index_0_;
+    int __libasr_index_0_1;
+    int __libasr_index_0_2;
+    int __libasr_index_0_3;
+    __do_loop_end = ((2 + 1) - 1);
+    __libasr_index_0_ = (((int)1) - 1);
+    while (((__libasr_index_0_ + 1) <= __do_loop_end)) {
+        __libasr_index_0_ = (__libasr_index_0_ + 1);
+        r[((int)(__libasr_index_0_) - (1))] = ((float)n);
+    }
+    if ((((n) % (2)) == 0)) {
+        __1__libasr_index_ = 1;
+        __libasr__created__var__0__array_constructor_[((int)(__1__libasr_index_) - (1))] = ((float)n);
+        __1__libasr_index_ = (__1__libasr_index_ + 1);
+        __libasr__created__var__0__array_constructor_[((int)(__1__libasr_index_) - (1))] = ((float)n);
+        __1__libasr_index_ = (__1__libasr_index_ + 1);
+        __libasr_index_0_2 = 1;
+        __do_loop_end1 = ((2 + 1) - 1);
+        __libasr_index_0_1 = (((int)1) - 1);
+        while (((__libasr_index_0_1 + 1) <= __do_loop_end1)) {
+            __libasr_index_0_1 = (__libasr_index_0_1 + 1);
+            r[((int)(__libasr_index_0_1) - (1))] = __libasr__created__var__0__array_constructor_[((int)(__libasr_index_0_2) - (1))];
+            __libasr_index_0_2 = (__libasr_index_0_2 + 1);
+        }
+    } else {
+        __do_loop_end2 = ((2 + 1) - 1);
+        __libasr_index_0_3 = (((int)1) - 1);
+        while (((__libasr_index_0_3 + 1) <= __do_loop_end2)) {
+            __libasr_index_0_3 = (__libasr_index_0_3 + 1);
+            r[((int)(__libasr_index_0_3) - (1))] = (-(((float)n)));
+        }
+    }
+}
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(
+    float* results)
+{
+    int __flat_idx;
+    int __gpu_sum_k;
+    float __gpu_sum_res;
+    float __libasr_created__function_call_fixed_result[2];
+    int i;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((4 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    __gpu_sum_res =   0.00000000000000000e+00f;
+    __gpu_sum_k = (1 - 1);
+    while (((__gpu_sum_k + 1) <= 2)) {
+        __gpu_sum_k = (__gpu_sum_k + 1);
+        fixed_result_t(i, __libasr_created__function_call_fixed_result);
+        __gpu_sum_res = (__gpu_sum_res + __libasr_created__function_call_fixed_result[((int)(__gpu_sum_k) - (1))]);
+    }
+    results[((int)(i) - (1))] = __gpu_sum_res;
+}
+
+__device__ inline void reallocated_result_t(int n, float* r, int __size_r_dim1) {
+    int __do_loop_end;
+    int __do_loop_end1;
+    int __libasr_index_0_;
+    int __libasr_index_0_1;
+    if (1) {
+    }
+    __do_loop_end = __size_r_dim1;
+    __libasr_index_0_ = (1 - 1);
+    while (((__libasr_index_0_ + 1) <= __do_loop_end)) {
+        __libasr_index_0_ = (__libasr_index_0_ + 1);
+        r[((int)(__libasr_index_0_) - (1))] = (-(((float)n)));
+    }
+    __do_loop_end1 = __size_r_dim1;
+    __libasr_index_0_1 = (1 - 1);
+    while (((__libasr_index_0_1 + 1) <= __do_loop_end1)) {
+        __libasr_index_0_1 = (__libasr_index_0_1 + 1);
+        r[((int)(__libasr_index_0_1) - (1))] = ((float)n);
+    }
+}
+
+extern "C" __global__ void __lfortran_gpu_kernel_1(
+    float* reallocated)
+{
+    int __flat_idx;
+    int __gpu_sum_k1;
+    float __gpu_sum_res1;
+    float __libasr_created__function_call_reallocated_result[2];
+    float __libasr_created__subroutine_from_function_[2];
+    int i;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((4 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    __gpu_sum_res1 =   0.00000000000000000e+00f;
+    __gpu_sum_k1 = (1 - 1);
+    while (((__gpu_sum_k1 + 1) <= 2)) {
+        __gpu_sum_k1 = (__gpu_sum_k1 + 1);
+        reallocated_result_t(i, __libasr_created__subroutine_from_function_, 2);
+        __libasr_created__function_call_reallocated_result[0] = __libasr_created__subroutine_from_function_[0];
+        __libasr_created__function_call_reallocated_result[1] = __libasr_created__subroutine_from_function_[1];
+        __gpu_sum_res1 = (__gpu_sum_res1 + __libasr_created__function_call_reallocated_result[((int)(__gpu_sum_k1) - (1))]);
+    }
+    reallocated[((int)(i) - (1))] = __gpu_sum_res1;
+}
+

--- a/tests/reference/gpu_offload_strict-gpu_metal_327-933fc85.json
+++ b/tests/reference/gpu_offload_strict-gpu_metal_327-933fc85.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_offload_strict-gpu_metal_327-933fc85",
+    "cmd": "lfortran --no-color --gpu=cuda -c {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/gpu_metal_327.f90",
+    "infile_hash": "e031ffc5b9fbd7c6f9f942b6ceb2e29002ba52959ce8fd913e6053a6",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "gpu_offload_strict-gpu_metal_327-933fc85.stderr",
+    "stderr_hash": "0299a43e8b596da59bd80f75649616a943703a259466b6c88484aba2",
+    "returncode": 5
+}

--- a/tests/reference/gpu_offload_strict-gpu_metal_327-933fc85.stderr
+++ b/tests/reference/gpu_offload_strict-gpu_metal_327-933fc85.stderr
@@ -1,0 +1,54 @@
+gpu-decline: not-implemented: the allocatable array result of 'conditional_result' has no single allocation the gpu can use
+gpu-decline: not-implemented: the allocatable array result of 'resized_result' has no single allocation the gpu can use
+gpu-decline: not-implemented: the allocatable array result of 'assigned_result' has no single allocation the gpu can use
+gpu-decline: not-implemented: the allocatable array result of 'reshaped_result' has no single allocation the gpu can use
+gpu-decline: not-implemented: the allocatable array result of 'fixed_implicit_result' has no single allocation the gpu can use
+ASR pass error: parallel loop cannot be offloaded to the GPU: the allocatable array result of 'conditional_result' has no single allocation the gpu can use; pass `--gpu-allow-cpu-fallback` to run it on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:10:1 - 12:6
+   |
+10 |    do concurrent (i = 1:4)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+12 |    end do
+   | ...^^^^^^ the allocatable array result of 'conditional_result' has no single allocation the gpu can use
+
+ASR pass error: parallel loop cannot be offloaded to the GPU: the allocatable array result of 'resized_result' has no single allocation the gpu can use; pass `--gpu-allow-cpu-fallback` to run it on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:13:1 - 15:6
+   |
+13 |    do concurrent (i = 1:4)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+15 |    end do
+   | ...^^^^^^ the allocatable array result of 'resized_result' has no single allocation the gpu can use
+
+ASR pass error: parallel loop cannot be offloaded to the GPU: the allocatable array result of 'assigned_result' has no single allocation the gpu can use; pass `--gpu-allow-cpu-fallback` to run it on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:16:1 - 18:6
+   |
+16 |    do concurrent (i = 1:4)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+18 |    end do
+   | ...^^^^^^ the allocatable array result of 'assigned_result' has no single allocation the gpu can use
+
+ASR pass error: parallel loop cannot be offloaded to the GPU: the allocatable array result of 'reshaped_result' has no single allocation the gpu can use; pass `--gpu-allow-cpu-fallback` to run it on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:19:1 - 21:6
+   |
+19 |    do concurrent (i = 1:1)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+21 |    end do
+   | ...^^^^^^ the allocatable array result of 'reshaped_result' has no single allocation the gpu can use
+
+ASR pass error: parallel loop cannot be offloaded to the GPU: the allocatable array result of 'fixed_implicit_result' has no single allocation the gpu can use; pass `--gpu-allow-cpu-fallback` to run it on the CPU instead
+  --> tests/../integration_tests/gpu_metal_327.f90:22:1 - 24:6
+   |
+22 |    do concurrent (i = 1:4)
+   |    ^^^^^^^^^^^^^^^^^^^^^^^...
+...
+   |
+24 |    end do
+   | ...^^^^^^ the allocatable array result of 'fixed_implicit_result' has no single allocation the gpu can use

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4326,6 +4326,17 @@ filename = "../integration_tests/gpu_metal_320.f90"
 gpu_cuda_kernel = true
 
 [[test]]
+filename = "../integration_tests/gpu_metal_327.f90"
+gpu_cuda_kernel = true
+gpu_offload_strict = true
+options = "--realloc-lhs-arrays --gpu-decline-stats"
+
+[[test]]
+filename = "../integration_tests/gpu_metal_328.f90"
+gpu_cuda_kernel = true
+options = "--realloc-lhs-arrays"
+
+[[test]]
 filename = "errors/array_bounds_check_01.f90"
 run = true
 


### PR DESCRIPTION
Check result allocation shapes during callee analysis, before GPU offload commits to a launch. Preserve fixed-shape allocations and assignments, and report unsupported shapes through the existing CPU fallback policy.

Add integration and diagnostic coverage for conditional allocation, implicit resizing, transitive callees, and per-dimension shape agreement.

Validated LLVM integrations (4104), Metal (334), CUDA CPU emulation (319), unit and ASR documentation tests (16), and the full reference suite. Existing reference snapshots are unchanged.