### PR TITLE
fix: bound the digit scan in the C++ backend's trim_dims

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -956,6 +956,7 @@ RUN(NAME arrays_124 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME arrays_125 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME arrays_126 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME array_128 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME arrays_131 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 
 # DISABLED: #8115 - ICE: get_struct_sym_from_struct_expr returns nullptr for empty struct array constructors [tp ::]
 # RUN(NAME array_init LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/arrays_131.f90
+++ b/integration_tests/arrays_131.f90
@@ -1,0 +1,24 @@
+program arrays_131
+implicit none
+call automatic_array(4)
+
+contains
+
+    ! `a` is an automatic array: its extent is only known at runtime.  The C++
+    ! backend encodes the extents of an array into the name of the struct it
+    ! generates for it, and a symbolic extent contributes no digits at all.
+    subroutine automatic_array(n)
+    integer, intent(in) :: n
+    integer :: a(n)
+    integer :: i, s
+    do i = 1, n
+        a(i) = i
+    end do
+    s = 0
+    do i = 1, n
+        s = s + a(i)
+    end do
+    if (s /= 10) error stop
+    end subroutine
+
+end program

--- a/src/libasr/codegen/asr_to_cpp.cpp
+++ b/src/libasr/codegen/asr_to_cpp.cpp
@@ -53,7 +53,7 @@ std::string trim_dims(std::string &dims) {
     std::string trimmed;
     bool last_is_digit = true;
     size_t i = 0;
-    while (!isdigit(dims[i])) i++;
+    while (i < dims.size() && !isdigit(dims[i])) i++;
     for (; i < dims.size(); i++) {
         if (isdigit(dims[i])) {
             if (!last_is_digit) {

--- a/tests/reference/cpp-arrays_131-d5fd3aa.json
+++ b/tests/reference/cpp-arrays_131-d5fd3aa.json
@@ -1,0 +1,13 @@
+{
+    "basename": "cpp-arrays_131-d5fd3aa",
+    "cmd": "lfortran --no-color --show-cpp {infile}",
+    "infile": "tests/../integration_tests/arrays_131.f90",
+    "infile_hash": "56aba6fa3b60439d8286c57a19962ef5aec45ecd52368a2db46bf389",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "cpp-arrays_131-d5fd3aa.stdout",
+    "stdout_hash": "81f12d3918c40dbab2fcd9d8906bca3b4ae29a7b063513feb28d6221",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/cpp-arrays_131-d5fd3aa.stdout
+++ b/tests/reference/cpp-arrays_131-d5fd3aa.stdout
@@ -1,0 +1,76 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <cassert>
+#include <cmath>
+#include <complex>
+#include <Kokkos_Core.hpp>
+#include <lfortran_intrinsics.h>
+
+template <typename T>
+Kokkos::View<T*> from_std_vector(const std::vector<T> &v)
+{
+    Kokkos::View<T*> r("r", v.size());
+    for (size_t i=0; i < v.size(); i++) {
+        r(i) = v[i];
+    }
+    return r;
+}
+
+
+struct dimension_descriptor
+{
+    int32_t lower_bound, length, stride;
+};
+
+struct i32__1
+{
+    Kokkos::View<int32_t*>* data;
+    dimension_descriptor dims[1];
+    bool is_allocated;
+
+    i32__1(Kokkos::View<int32_t*>* data_): data{data_} {};
+};
+
+// Forward declarations
+namespace {
+void automatic_array(int32_t n);
+}
+
+// Implementations
+namespace {
+void automatic_array(int32_t n)
+{
+    Kokkos::View<int32_t*> a_data("a_data");
+    i32__1 a_value(&a_data);
+    i32__1* a = &a_value;
+    a->dims[0].lower_bound = 1;
+    a->dims[0].length = n;
+    int32_t i;
+    int32_t s;
+    for (i=1; i<=n; i++) {
+        a->data->operator[](i - a->dims[0].lower_bound) = i;
+    }
+    s = 0;
+    for (i=1; i<=n; i++) {
+        s = s + a->data->operator[](i - a->dims[0].lower_bound);
+    }
+    if (s != 10) {
+        std::cerr << "ERROR STOP" << std::endl;
+        exit(1);
+    }
+}
+
+
+void main2() {
+    automatic_array(4);
+}
+
+}
+int main(int argc, char* argv[])
+{
+    Kokkos::initialize(argc, argv);
+    main2();
+    Kokkos::finalize();
+    return 0;
+}

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1186,6 +1186,10 @@ asr = true
 julia = true
 
 [[test]]
+filename = "../integration_tests/arrays_131.f90"
+cpp = true
+
+[[test]]
 filename = "../integration_tests/arrays_01_size.f90"
 asr = true
 llvm = true


### PR DESCRIPTION
## Summary

`trim_dims()` in `src/libasr/codegen/asr_to_cpp.cpp` skipped leading non-digit characters with an unbounded loop:

```cpp
while (!isdigit(dims[i])) i++;
```

When the dimension string contains no digit at all, the loop walks past the end of the string.

That is exactly what happens for an array whose extent is only known at runtime. For an automatic array such as `real :: a(n)`, `convert_dims()` produces the placeholder `[ /* FIXME symbolic dimensions */ ]`. It has no digits, and at 35 characters it is heap allocated rather than held in `std::string`'s small-buffer storage, so reading past its terminator is a genuine heap-buffer-overflow.

The fix stops the scan at `dims.size()`.

**The generated C++ is unchanged.** The following `for (; i < dims.size(); i++)` loop already exits immediately once `i` has passed the end, so `trimmed` was — and remains — empty in this case, and the generated struct name stays `i32__1` / `f32__1`. This is purely the removal of an out-of-bounds read.

## Scope

- `src/libasr/codegen/asr_to_cpp.cpp` — one line, the bounds check.
- `integration_tests/arrays_131.f90` — new automatic-array test.
- `integration_tests/CMakeLists.txt` — registers it with labels `gfortran llvm llvm_wasm llvm_wasm_emcc`.
- `tests/tests.toml` + `tests/reference/cpp-arrays_131-*` — registers the same file with `cpp = true`, so `lfortran --show-cpp` is run over the fixed code path and its output is pinned.

The bug is in the backend's own bookkeeping (an unchecked index into a string it built itself), not in the ASR it is handed — the ASR for `real :: a(n)` is well formed — so the backend is the right place for the fix.

`arrays_131` is deliberately **not** given the `cpp` label: the C++ backend emits an unsized `Kokkos::View` for an automatic array, which is a separate pre-existing limitation and out of scope here. The `cpp = true` reference test covers the code path that overflowed without depending on that.

## Verification

**The ASan report is the primary proof.** The overflow is invisible in a normal build — as noted in the issue thread, `--show-cpp` prints correct C++ either way — so it must be built with `-fsanitize=address`.

Build used:

```
cmake -S . -B build-asan -G Ninja -DCMAKE_BUILD_TYPE=Debug -DWITH_LLVM=ON \
  -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer" \
  -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer" \
  -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address"
```

### Before the fix

On the issue's reproducer verbatim, and on the new test:

```
$ lfortran --show-cpp integration_tests/arrays_131.f90
=================================================================
==25735==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5040000184f4 ...
READ of size 1 at 0x5040000184f4 thread T0
    #0 ... LCompilers::trim_dims(...) ../src/libasr/codegen/asr_to_cpp.cpp:56
    #1 ... LCompilers::ASRToCPPVisitor::get_array_type(...) ../src/libasr/codegen/asr_to_cpp.cpp:131
    #2 ... LCompilers::ASRToCPPVisitor::generate_array_decl(...) ../src/libasr/codegen/asr_to_cpp.cpp:155
    #3 ... LCompilers::ASRToCPPVisitor::convert_variable_decl(...) ../src/libasr/codegen/asr_to_cpp.cpp:279
...
0x504000017574 is located 0 bytes after 36-byte region [0x504000017550,0x504000017574)
allocated by thread T0 here:
    ... LCompilers::ASRToCPPVisitor::convert_dims(...) ../src/libasr/codegen/asr_to_cpp.cpp:100
SUMMARY: AddressSanitizer: heap-buffer-overflow ../src/libasr/codegen/asr_to_cpp.cpp:56 in LCompilers::trim_dims(...)
exit=1
```

The 36-byte region is `[ /* FIXME symbolic dimensions */ ]` (35 characters plus the terminator), and the read is exactly one byte past it — matching the report in the issue, down to the stack frames.

### After the fix

Same ASan binary, rebuilt with the one-line change:

```
$ lfortran --show-cpp re_12699.f90              # the issue's reproducer verbatim
exit=0, no AddressSanitizer output
$ lfortran --show-cpp integration_tests/arrays_131.f90
exit=0, no AddressSanitizer output
```

The new reference test, run against the ASan binary — it crashes with the report above before the fix and passes after:

```
$ ./run_tests.py -t "arrays_131.f90"
 START TEST:  ../integration_tests/arrays_131.f90
../integration_tests/arrays_131.f90 * cpp ✓
TESTS PASSED
```

### Test suites

Integration tests, LLVM backend, full suite:

```
$ cd integration_tests && ./run_tests.py -j4 -b llvm
100% tests passed, 0 tests failed out of 4104
```

Reference tests: the full suite passes apart from the LLVM-IR-comparing tests, which fail in this environment for an unrelated reason — the checked-in `llvm-*` references were generated with LLVM 14 (typed pointers) while this machine has LLVM 18 (opaque pointers), so every such test diffs as `i8*` vs `ptr` regardless of this change. Excluding the 162 tests that emit LLVM IR:

```
$ ./run_tests.py --exclude-test <the 162 llvm-output tests>
TESTS PASSED
```

That covers every `ast`, `asr`, `cpp`, `c`, `julia`, `fortran`, `obj` and `run` reference output, including the new `cpp` one.

`./run_tests.py -b cpp` (which compiles the generated C++ with Kokkos) could not be run here: this machine has no Kokkos, so `LFORTRAN_KOKKOS_DIR is not defined` for every `cpp`-labelled test, including pre-existing ones. CI covers it.

## Rationale

`trim_dims` builds the suffix of the generated struct name from the digits in the dimension string. An extent that is not a compile-time constant contributes no digits, so the "skip to the first digit" loop has no digit to stop at. Guarding it with `i < dims.size()` is the minimal correct fix and preserves the existing (empty-suffix) naming behaviour.

Fixes #12699
