### PR TITLE
Fix implicit-interface CHARACTER array dummy length, and pin the layout with a regression test

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2230,6 +2230,8 @@ RUN(NAME implicit_interface_61 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
 RUN(NAME implicit_interface_62 LABELS gfortran llvm
     EXTRA_ARGS --separate-compilation --implicit-interface
     EXTRAFILES implicit_interface_62b.f90)
+RUN(NAME implicit_interface_63 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
+    EXTRAFILES implicit_interface_63b.f90)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2232,6 +2232,8 @@ RUN(NAME implicit_interface_62 LABELS gfortran llvm
     EXTRAFILES implicit_interface_62b.f90)
 RUN(NAME implicit_interface_63 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
     EXTRAFILES implicit_interface_63b.f90)
+RUN(NAME implicit_interface_64 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
+    EXTRAFILES implicit_interface_64b.f90)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/implicit_interface_63.f90
+++ b/integration_tests/implicit_interface_63.f90
@@ -1,0 +1,48 @@
+! Regression test for issue #12713: CHARACTER arrays passed through an implicit
+! interface to a separately compiled procedure must reach the callee with the
+! right data, element length and bounds, for every form the dummy can take.
+! The callees live in implicit_interface_63b.f90, so every call here goes
+! through a synthesized implicit interface rather than a real signature.
+program implicit_interface_63
+    implicit none
+    character(len=8) :: w(3)
+    character(len=1) :: c(3)
+    character(len=16) :: text(4)
+    character(len=4) :: grid(2,3)
+
+    w(1) = 'ab'
+    w(2) = 'cd'
+    w(3) = 'ef'
+
+    ! The five dummy declarations from the issue's table.
+    call check_fixed_shape(w)
+    call check_star_shape(w)
+    call check_fixed_size(w)
+    call check_star_size(w)
+
+    c(1) = 'a'
+    c(2) = 'c'
+    c(3) = 'e'
+    call check_char1_size(c)
+
+    ! The MODFLOW-2005 pattern: CHARACTER*16 TEXT(n) with a runtime bound.
+    text(1) = 'TEXT1'
+    text(2) = 'TEXT2'
+    text(3) = 'TEXT3'
+    text(4) = 'TEXT4'
+    call check_text16(text, 4)
+
+    ! A rank-2 CHARACTER array flattened onto an assumed-size dummy.
+    grid(1,1) = 'a11'
+    grid(2,1) = 'b21'
+    grid(1,2) = 'c12'
+    grid(2,2) = 'd22'
+    grid(1,3) = 'e13'
+    grid(2,3) = 'f23'
+    call check_rank2(grid)
+
+    ! An array section of a CHARACTER array.
+    call check_section(w(2:3))
+
+    print *, 'OK'
+end program implicit_interface_63

--- a/integration_tests/implicit_interface_63b.f90
+++ b/integration_tests/implicit_interface_63b.f90
@@ -1,0 +1,76 @@
+! Companion to implicit_interface_63, compiled as a separate unit so that the
+! caller has to synthesize an implicit interface for each of these.
+subroutine check_fixed_shape(arr)
+    implicit none
+    character(len=8) :: arr(3)
+    if (len(arr(1)) /= 8) error stop 11
+    if (arr(1) /= 'ab') error stop 12
+    if (arr(2) /= 'cd') error stop 13
+    if (arr(3) /= 'ef') error stop 14
+end subroutine check_fixed_shape
+
+subroutine check_star_shape(arr)
+    implicit none
+    character(len=*) :: arr(3)
+    if (len(arr(1)) /= 8) error stop 21
+    if (arr(1) /= 'ab') error stop 22
+    if (arr(2) /= 'cd') error stop 23
+    if (arr(3) /= 'ef') error stop 24
+end subroutine check_star_shape
+
+subroutine check_fixed_size(arr)
+    implicit none
+    character(len=8) :: arr(*)
+    if (len(arr(1)) /= 8) error stop 31
+    if (arr(1) /= 'ab') error stop 32
+    if (arr(2) /= 'cd') error stop 33
+    if (arr(3) /= 'ef') error stop 34
+end subroutine check_fixed_size
+
+subroutine check_star_size(arr)
+    implicit none
+    character(len=*) :: arr(*)
+    if (len(arr(1)) /= 8) error stop 41
+    if (arr(1) /= 'ab') error stop 42
+    if (arr(2) /= 'cd') error stop 43
+    if (arr(3) /= 'ef') error stop 44
+end subroutine check_star_size
+
+! The LAPACK pattern from issue #9381.
+subroutine check_char1_size(arr)
+    implicit none
+    character(1) :: arr(*)
+    if (len(arr(1)) /= 1) error stop 51
+    if (arr(1) /= 'a') error stop 52
+    if (arr(2) /= 'c') error stop 53
+    if (arr(3) /= 'e') error stop 54
+end subroutine check_char1_size
+
+subroutine check_text16(text, n)
+    implicit none
+    integer :: n
+    character(16) :: text(n)
+    if (len(text(1)) /= 16) error stop 61
+    if (n /= 4) error stop 62
+    if (text(1) /= 'TEXT1') error stop 63
+    if (text(3) /= 'TEXT3') error stop 64
+    if (text(4) /= 'TEXT4') error stop 65
+end subroutine check_text16
+
+subroutine check_rank2(g)
+    implicit none
+    character(len=4) :: g(*)
+    if (len(g(1)) /= 4) error stop 71
+    if (g(1) /= 'a11') error stop 72
+    if (g(2) /= 'b21') error stop 73
+    if (g(4) /= 'd22') error stop 74
+    if (g(6) /= 'f23') error stop 75
+end subroutine check_rank2
+
+subroutine check_section(arr)
+    implicit none
+    character(len=*) :: arr(*)
+    if (len(arr(1)) /= 8) error stop 81
+    if (arr(1) /= 'cd') error stop 82
+    if (arr(2) /= 'ef') error stop 83
+end subroutine check_section

--- a/integration_tests/implicit_interface_64.f90
+++ b/integration_tests/implicit_interface_64.f90
@@ -1,0 +1,23 @@
+! A deferred-length allocatable CHARACTER array passed through an implicit
+! interface to a separately compiled procedure. The synthesized dummy drops the
+! actual's ALLOCATABLE wrapper, so its element length must become an assumed
+! length rather than staying deferred. The callee is implicit_interface_64b.f90.
+program implicit_interface_64
+    implicit none
+    character(len=:), allocatable :: w(:)
+    character(len=:), allocatable :: s
+
+    allocate(character(len=5) :: w(3))
+    w(1) = 'aa'
+    w(2) = 'bb'
+    w(3) = 'cc'
+
+    call take_assumed_size(w)
+    call take_assumed_shape_len(w, 3)
+
+    ! A deferred-length scalar goes through the same synthesis path.
+    s = 'hello'
+    call take_scalar(s)
+
+    print *, 'OK'
+end program implicit_interface_64

--- a/integration_tests/implicit_interface_64b.f90
+++ b/integration_tests/implicit_interface_64b.f90
@@ -1,0 +1,27 @@
+! Companion to implicit_interface_64, compiled as a separate unit so the caller
+! has to synthesize an implicit interface from the actual argument alone.
+subroutine take_assumed_size(arr)
+    implicit none
+    character(len=*) :: arr(*)
+    if (len(arr(1)) /= 5) error stop 11
+    if (arr(1) /= 'aa') error stop 12
+    if (arr(2) /= 'bb') error stop 13
+    if (arr(3) /= 'cc') error stop 14
+end subroutine take_assumed_size
+
+subroutine take_assumed_shape_len(arr, n)
+    implicit none
+    integer :: n
+    character(len=*) :: arr(n)
+    if (len(arr(1)) /= 5) error stop 21
+    if (size(arr) /= 3) error stop 22
+    if (arr(1) /= 'aa') error stop 23
+    if (arr(3) /= 'cc') error stop 24
+end subroutine take_assumed_shape_len
+
+subroutine take_scalar(t)
+    implicit none
+    character(len=*) :: t
+    if (len(t) /= 5) error stop 31
+    if (t /= 'hello') error stop 32
+end subroutine take_scalar

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -17128,6 +17128,24 @@ public:
                     ASR::ttype_t* array_var_type = ASRUtils::type_get_past_allocatable(
                         ASRUtils::type_get_past_pointer(var_type));
                     ASR::Array_t* array_type = ASR::down_cast<ASR::Array_t>(array_var_type);
+                    // Dropping the actual's allocatable or pointer wrapper leaves a
+                    // deferred length on the element type, which only an allocatable
+                    // or pointer entity may carry. The dummy of an external procedure
+                    // takes the length from the string descriptor at run time, so it
+                    // is an assumed length, exactly like `character(len=*)`.
+                    if (ASR::is_a<ASR::String_t>(*array_type->m_type)) {
+                        ASR::String_t* elem_str = ASR::down_cast<ASR::String_t>(array_type->m_type);
+                        if (elem_str->m_len_kind == ASR::string_length_kindType::DeferredLength) {
+                            ASR::ttype_t* assumed_len_type = ASRUtils::TYPE(ASR::make_String_t(
+                                al, array_type->m_type->base.loc, elem_str->m_kind, nullptr,
+                                ASR::string_length_kindType::AssumedLength,
+                                elem_str->m_physical_type));
+                            array_var_type = ASRUtils::make_Array_t_util(al, array_var_type->base.loc,
+                                assumed_len_type, array_type->m_dims, array_type->n_dims,
+                                ASR::abiType::Source, true, array_type->m_physical_type, true);
+                            array_type = ASR::down_cast<ASR::Array_t>(array_var_type);
+                        }
+                    }
                     ASR::array_physical_typeType phys_type;
                     if (array_type->m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
                         phys_type = array_type->m_physical_type;


### PR DESCRIPTION
## Summary

Refs #12713.

The layout problem reported in #12713 **no longer reproduces on `main`**. All
five `DECL` rows of the issue's table now compile and print exactly what
gfortran 13 prints, verified at `456bdf263` with a Debug LLVM build using the
issue's own two-file reproducer. That table is now pinned by a regression test
so it cannot silently regress.

While probing around the reported shape I did find one case in the same code
path that still fails, and this PR fixes it: a **deferred-length allocatable**
CHARACTER array passed through an implicit interface is rejected by ASR
verification.

## Scope

Two commits, both about CHARACTER array dummies synthesized for an implicit
interface:

1. `test:` adds `implicit_interface_63` — the regression guard. It passes on
   `main` today; it is here so the reported layout cannot regress again.
2. `fix:` fixes the deferred-length case and adds `implicit_interface_64`,
   which **fails on `main`** and passes here.

### The fix

`create_implicit_interface_function` builds the dummy from the actual argument
and drops the actual's `Allocatable`/`Pointer` wrapper, but the element type
kept its deferred length. Only an allocatable or pointer entity may carry a
deferred length, so ASR verification rejected the result:

```
ASR verify pass error: Variable of string type with length kind "DeferredLength"
must be allocatable OR pointer
```

The dummy of an external procedure takes the element length from the string
descriptor at run time, which is an assumed length — exactly `character(len=*)`.
The synthesized element type is now built that way. The change is in AST→ASR
semantics, where the type decision belongs; no backend was touched.

### What fixed the original report

The reported behaviour was fixed by `0203a6798` ("fix: preserve CHARACTER
descriptors across Fortran calls", PR #12710, merged 2026-09-06), which removed
the `is_character` → `DescriptorArray` branch in
`create_implicit_interface_function` and gave `(*)` CHARACTER dummies the
`UnboundedPointerArray` physical type — essentially option 2 of the two the
issue proposed. The issue was filed against `d8082c0f`, which predates that
merge. I identified this by reading the history of the function rather than by
bisecting.

## Verification

Debug build, `-DWITH_LLVM=ON -DWITH_RUNTIME_STACKTRACE=yes`, gfortran 13.3.0 as
the reference compiler.

The issue's table, re-run at `456bdf263` with `lfortran --implicit-interface p.f90 pb.f90 -o p && ./p`:

| `DECL` | gfortran 13 | LFortran on `main` today |
| --- | --- | --- |
| `character(len=8) :: arr(3)` | `'ab      ' 'ef      ' len = 8` | same |
| `character(len=*) :: arr(3)` | `'ab      ' 'ef      ' len = 8` | same |
| `character(len=8) :: arr(*)` | `'ab      ' 'ef      ' len = 8` | same |
| `character(len=*) :: arr(*)` | `'ab      ' 'ef      ' len = 8` | same |
| `character(1) :: arr(*)` with a `character(1) :: w(3)` actual | `'a' 'e' len = 1` | same |

(The issue's gfortran column shows `'a' 'c'` for the last row; gfortran 13.3.0
prints `'a' 'e'`, which is `w(3)`, and LFortran agrees.)

Additional probes, all matching gfortran: `character(16) :: text(n)` with a
runtime bound (the MODFLOW-2005 shape), a rank-2 CHARACTER array flattened onto
an assumed-size dummy, an array section actual, an assumed-length dummy whose
actual has a different length, storage association of a `character(8)` actual
onto a `character(1) :: arr(*)` dummy, writing back through the dummy, and both
single-invocation and `--separate-compilation` builds.

The new test fails on `main` and passes on this branch:

```
$ lfortran --implicit-interface implicit_interface_64.f90 implicit_interface_64b.f90 -o t   # on main
ASR verify pass error: Variable of string type with length kind "DeferredLength" must be allocatable OR pointer
  --> implicit_interface_64.f90:16:5
$ lfortran --implicit-interface implicit_interface_64.f90 implicit_interface_64b.f90 -o t   # on this branch
$ ./t
 OK
```

Suites on this branch:

- `integration_tests/run_tests.py -j4 -b llvm` — `100% tests passed, 0 tests failed out of 4105`, including `implicit_interface_63` and `implicit_interface_64`.
- `integration_tests/run_tests.py -j4 -b gfortran` — `100% tests passed, 0 tests failed out of 4150`, including both new tests.
- `./run_tests.py --no-llvm` — `TESTS PASSED`.

One caveat, reported honestly: I had to pass `--no-llvm` to the reference
suite. This container has LLVM 18, which emits opaque pointers, so every
checked-in `llvm` reference output differs from the produced text by pure
`i8*` → `ptr` substitutions (for example `declare void
@_lpython_call_initial_functions(i32, i8**)` vs `(i32, ptr)`). That is a
pre-existing environment mismatch, present with or without this change. The
`asr` reference outputs, which are the ones this change could actually move,
all ran and all passed unchanged.

## Rationale

The reported symptom is gone, so this PR does not implement either ABI
direction the issue offered; #12710 already settled that question. What is left
is one narrow hole in the same synthesis path, fixed where the type is decided
rather than where it is lowered, plus a test that pins the reported table so
the next regression is caught by CI instead of by a user building MODFLOW.

I am not closing #12713 — a maintainer should decide whether the remaining
scope warrants keeping it open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qswb5qZf7pAyUdHUspspDu)_