### PR TITLE
fix: reject a zero statement label in the tokenizer

### DIFF
--- a/src/lfortran/parser/tokenizer.re
+++ b/src/lfortran/parser/tokenizer.re
@@ -644,7 +644,24 @@ int Tokenizer::lex(Allocator &al, YYSTYPE &yylval, Location &loc, diag::Diagnost
                     uint64_t u;
                     if (lex_int(tok, cur, u, yylval.int_suffix.int_kind)) {
                             yylval.n = u;
-                            if (enddo_label_stack[enddo_label_stack.size()-1] == u) {
+                            // A statement label is a positive integer, so a
+                            // zero here is not a label at all. It must be
+                            // rejected before it reaches `enddo_label_stack`,
+                            // whose bottom is a 0 sentinel that would then be
+                            // popped, leaving the stack empty and the loop
+                            // below reading past its front.
+                            if (u == 0) {
+                                token_loc(loc);
+                                diagnostics.add(diag::Diagnostic(
+                                    "Zero is not a valid statement label",
+                                    diag::Level::Error, diag::Stage::Tokenizer, {
+                                    diag::Label("", {loc})}
+                                ));
+                                if (!continue_compilation) {
+                                    throw parser_local::TokenizerAbort();
+                                }
+                                enddo_newline_process = false;
+                            } else if (enddo_label_stack[enddo_label_stack.size()-1] == u) {
                                 while (enddo_label_stack[enddo_label_stack.size()-1] == u) {
                                     enddo_label_stack.pop_back();
                                     enddo_insert_count++;

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -1183,3 +1183,10 @@ contains
         conditional_expr_pure = ( c ? 1 : conditional_expr_impure() )  ! {Error} Call to impure procedure 'conditional_expr_impure' is not allowed inside a PURE procedure
     end function
 end module
+
+! A statement label is a positive integer, so a leading zero is not a label at
+! all and must be rejected by the tokenizer.
+subroutine zero_statement_label_1()
+    implicit none
+    0 print *, "unreachable"  ! {Error} Zero is not a valid statement label
+end subroutine

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "f66bc67fe8d7dae96351b6672755e44ae6286ac4e132f31158e400a7",
+    "infile_hash": "2350a9a66caa7c47d4dd194ccba8e7ce21f2df08119b5cc6233d2471",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "a45410e7115988dee85dfd5d606456d769336a53be43e7ac0c9369af",
+    "stderr_hash": "1e849cf869ec1f947e9eb6fbdf19392539ba9518e5ebb984fe5d72fd",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -16,6 +16,12 @@ syntax error: Token 'foo' (of type 'identifier') is unexpected here
 1162 |       foo    end type t_recovery
      |       ^^^ 
 
+tokenizer error: Zero is not a valid statement label
+    --> tests/errors/continue_compilation_1.f90:1191:5
+     |
+1191 |     0 print *, "unreachable"  ! {Error} Zero is not a valid statement label
+     |     ^ 
+
 semantic error: `function` attribute of 'frexp' conflicts with `subroutine` attribute
   --> tests/errors/continue_compilation_1.f90:53:5 - 57:24
    |


### PR DESCRIPTION
## Summary

Fixes #12721.

`Tokenizer::enddo_label_stack` matches a label do statement with its terminating
labelled statement. It is created as `{0}`, so the 0 at the bottom is a sentinel
that keeps `back()` readable at all times.

A statement label is a positive integer, but the tokenizer accepted a `0` at the
start of a statement as a label and compared it against that sentinel. The
comparison matched, the sentinel was popped, and the `while` loop then evaluated
`enddo_label_stack[enddo_label_stack.size()-1]` on an empty vector — `size()-1`
wraps to `SIZE_MAX`, so the read lands 8 bytes before the allocation. The
tokenizer then inserted a spurious `end do`, which is why the user saw the
unrelated message `Newline is unexpected here`.

```fortran
program main
  0 print *, "error"
end
```

The read is silent on a normal build; AddressSanitizer is what makes it visible,
and **the ASan report is the primary proof for this PR**.

## Scope

One change, in `src/lfortran/parser/tokenizer.re`: reject a zero statement label
where it is first seen, reusing the wording the parser already uses for `do 0`
(`Zero is not a valid statement label`, which is also what GFortran prints).
The sentinel can no longer be popped, because every label still compared against
it is non-zero. Nothing else in the tokenizer or the enddo bookkeeping changes.

The fixed-form tokenizer declares the same member but never uses it, so it has no
equivalent bug and is left alone.

## Verification

**AddressSanitizer, before (unmodified `main`, `-fsanitize=address,undefined`):**

```
==24462==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5020000012e8 ...
READ of size 8 at 0x5020000012e8 thread T0
    #0 ... LCompilers::LFortran::Tokenizer::lex(...) parser/tokenizer.re:648
    #1 ... yylex(...)
    #3 ... yyparse(LCompilers::LFortran::Parser&)
    #4 ... LCompilers::LFortran::Parser::parse(...) src/lfortran/parser/parser.cpp:335

0x5020000012e8 is located 8 bytes before 8-byte region [0x5020000012f0,0x5020000012f8)
allocated by thread T0 here:
    #6 ... LCompilers::LFortran::Tokenizer::Tokenizer() src/lfortran/parser/tokenizer.h:9
```

**After, same binary flags, same input — no ASan report:**

```
tokenizer error: Zero is not a valid statement label
 --> mre.f90:2:3
  |
2 |   0 print *, "error"
  |   ^
```

GFortran on the same file: `Error: Zero is not a valid statement label`.

**Test:** appended to `tests/errors/continue_compilation_1.f90` (registered in
`tests/tests.toml` as `semantics_only_cc`), with the reference output updated.
This is a compile-time error, so it belongs there rather than in
`integration_tests/` per `AGENTS.md`'s test-placement rules. It is meaningful
without a sanitizer: it pins the new diagnostic.

Fails before the change, passes after — verified by reverting only
`tokenizer.re`, regenerating and rebuilding:

```
# without the fix
=== STDERR DIFF ===
< tokenizer error: Zero is not a valid statement label
<     --> tests/errors/continue_compilation_1.f90:1191:5
---
> syntax error: Newline is unexpected here
>     --> tests/errors/continue_compilation_1.f90:1192:15
TEST EXIT=1

# with the fix
errors/continue_compilation_1.f90 * asr OK
TESTS PASSED
```

The reference diff is exactly six added lines — no other diagnostic in that file
is gained or lost, so error recovery still continues past the new error.

**Suites** (Debug + LLVM 18, `-DWITH_RUNTIME_STACKTRACE=yes`):

- Integration tests: `./run_tests.py -j4 -b llvm` — `100% tests passed, 0 tests failed out of 4103`.
- Reference tests: `./run_tests.py --no-llvm --skip-run-with-dbg` — `TESTS PASSED`, 1422 checks.
- Two reference tests were excluded as pre-existing environment failures, not
  regressions: the `llvm = true` outputs (e.g. `asr_text_compile_01`) differ only
  as `i8**` vs `ptr`, an LLVM 18 opaque-pointer artifact of this machine, and
  `asr_text_compile_01` takes ASR text input so it never reaches the tokenizer;
  `runtime_stacktrace_01` under `run_dbg` is a build-configuration difference.
  Both fail identically without this patch.
- Manual checks under ASan: a labelled do loop (`do 10 i = ...` / `10 continue`),
  a `goto`/`continue` pair, and `do 0 i = 1, 3` (already rejected by the parser)
  all behave as before with no sanitizer report.

## Rationale

The fix goes where the ambiguity is created. By the time the parser sees the
label, `LABEL()` stores it as `m_label = 0`, which is indistinguishable from
"no label", so a zero label would otherwise be silently dropped. Rejecting it in
the tokenizer both removes the out-of-bounds read and reports the condition with
the message the compiler already uses elsewhere.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qswb5qZf7pAyUdHUspspDu)_