### PR TITLE
Blank pad the shorter character operand when comparing at run time

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1847,6 +1847,7 @@ RUN(NAME intrinsics_474 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc GFORTRAN_A
 RUN(NAME intrinsics_475 LABELS gfortran llvm) # ishftc with SIZE keeps high bits of I
 RUN(NAME intrinsics_476 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc) # scale with a negative exponent
 RUN(NAME intrinsics_477 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran) # right-padding of character args for LGT/LLT/LGE/LLE
+RUN(NAME intrinsics_478 LABELS gfortran llvm) # blank padding of character operands in LGE/LGT/LLE/LLT at run time
 RUN(NAME intrinsics_len_trim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME storage_size_01 LABELS gfortran llvm) # storage_size of allocatable character
 

--- a/integration_tests/intrinsics_478.f90
+++ b/integration_tests/intrinsics_478.f90
@@ -1,0 +1,110 @@
+program intrinsics_478
+! LGE/LGT/LLE/LLT compare character operands using the collating sequence
+! after the shorter operand is blank-padded on the right to the length of the
+! longer one. This must hold for compile time (folded) operands as well as for
+! operands that are only known at run time, and it differs from comparing the
+! two operands with their trailing blanks removed whenever the longer operand
+! carries characters that collate below a blank.
+implicit none
+
+character(len=3) :: short_abc
+character(len=5) :: abc_blanks
+character(len=2) :: ab
+character(len=0) :: empty
+character(len=3) :: blanks
+character(len=5) :: abc_low
+character(len=5) :: abc_high
+
+short_abc = 'abc'
+abc_blanks = 'abc  '
+ab = 'ab'
+blanks = '   '
+abc_low = 'abc'//char(0)//char(1)
+abc_high = 'abc'//char(126)//char(126)
+
+! ---------------------------------------------------------------------------
+! Compile time operands (constant folded)
+! ---------------------------------------------------------------------------
+
+! Trailing blanks do not change the value of a character operand.
+if (.not. lge('abc', 'abc  ')) error stop 'lge(abc, abc  )'
+if (.not. lle('abc', 'abc  ')) error stop 'lle(abc, abc  )'
+if (lgt('abc', 'abc  ')) error stop 'lgt(abc, abc  )'
+if (llt('abc', 'abc  ')) error stop 'llt(abc, abc  )'
+
+! The longer operand wins when its extra characters collate above a blank.
+if (.not. lgt('abc', 'ab')) error stop 'lgt(abc, ab)'
+if (.not. lge('abc', 'ab')) error stop 'lge(abc, ab)'
+if (lle('abc', 'ab')) error stop 'lle(abc, ab)'
+if (llt('abc', 'ab')) error stop 'llt(abc, ab)'
+
+! The same comparison with the operands swapped.
+if (.not. llt('ab', 'abc')) error stop 'llt(ab, abc)'
+if (.not. lle('ab', 'abc')) error stop 'lle(ab, abc)'
+if (lgt('ab', 'abc')) error stop 'lgt(ab, abc)'
+if (lge('ab', 'abc')) error stop 'lge(ab, abc)'
+
+! A zero length operand equals a string of blanks.
+if (.not. lge('', '   ')) error stop 'lge(, blanks)'
+if (.not. lle('', '   ')) error stop 'lle(, blanks)'
+if (lgt('', '   ')) error stop 'lgt(, blanks)'
+if (llt('', '   ')) error stop 'llt(, blanks)'
+if (.not. lgt('a', '')) error stop 'lgt(a, )'
+if (.not. llt('', 'a')) error stop 'llt(, a)'
+
+! Characters that collate below a blank make the longer operand the smaller
+! one, which blank padding gets right and trimming does not.
+if (.not. lgt('abc', 'abc'//char(1)//char(1))) error stop 'lgt(abc, abc low)'
+if (lle('abc', 'abc'//char(1)//char(1))) error stop 'lle(abc, abc low)'
+if (.not. llt('abc'//char(1), 'abc')) error stop 'llt(abc low, abc)'
+if (.not. lgt('abc'//char(126), 'abc')) error stop 'lgt(abc high, abc)'
+
+! ---------------------------------------------------------------------------
+! Run time operands (variables)
+! ---------------------------------------------------------------------------
+
+if (.not. lge(short_abc, abc_blanks)) error stop 'lge(short_abc, abc_blanks)'
+if (.not. lle(short_abc, abc_blanks)) error stop 'lle(short_abc, abc_blanks)'
+if (lgt(short_abc, abc_blanks)) error stop 'lgt(short_abc, abc_blanks)'
+if (llt(short_abc, abc_blanks)) error stop 'llt(short_abc, abc_blanks)'
+
+if (.not. lgt(short_abc, ab)) error stop 'lgt(short_abc, ab)'
+if (.not. lge(short_abc, ab)) error stop 'lge(short_abc, ab)'
+if (lle(short_abc, ab)) error stop 'lle(short_abc, ab)'
+if (llt(short_abc, ab)) error stop 'llt(short_abc, ab)'
+
+if (.not. llt(ab, short_abc)) error stop 'llt(ab, short_abc)'
+if (.not. lle(ab, short_abc)) error stop 'lle(ab, short_abc)'
+if (lgt(ab, short_abc)) error stop 'lgt(ab, short_abc)'
+if (lge(ab, short_abc)) error stop 'lge(ab, short_abc)'
+
+if (.not. lge(empty, blanks)) error stop 'lge(empty, blanks)'
+if (.not. lle(empty, blanks)) error stop 'lle(empty, blanks)'
+if (lgt(empty, blanks)) error stop 'lgt(empty, blanks)'
+if (llt(empty, blanks)) error stop 'llt(empty, blanks)'
+if (.not. lgt(short_abc, empty)) error stop 'lgt(short_abc, empty)'
+if (.not. llt(empty, short_abc)) error stop 'llt(empty, short_abc)'
+
+if (.not. lgt(short_abc, abc_low)) error stop 'lgt(short_abc, abc_low)'
+if (.not. lge(short_abc, abc_low)) error stop 'lge(short_abc, abc_low)'
+if (lle(short_abc, abc_low)) error stop 'lle(short_abc, abc_low)'
+if (llt(short_abc, abc_low)) error stop 'llt(short_abc, abc_low)'
+
+if (.not. llt(abc_low, short_abc)) error stop 'llt(abc_low, short_abc)'
+if (.not. lle(abc_low, short_abc)) error stop 'lle(abc_low, short_abc)'
+if (lgt(abc_low, short_abc)) error stop 'lgt(abc_low, short_abc)'
+if (lge(abc_low, short_abc)) error stop 'lge(abc_low, short_abc)'
+
+if (.not. lgt(abc_high, short_abc)) error stop 'lgt(abc_high, short_abc)'
+if (.not. llt(short_abc, abc_high)) error stop 'llt(short_abc, abc_high)'
+
+! The relational operators follow the same padding rule.
+if (.not. (short_abc == abc_blanks)) error stop 'short_abc == abc_blanks'
+if (short_abc == ab) error stop 'short_abc == ab'
+if (short_abc == abc_low) error stop 'short_abc == abc_low'
+if (.not. (short_abc > abc_low)) error stop 'short_abc > abc_low'
+if (.not. (short_abc < abc_high)) error stop 'short_abc < abc_high'
+
+print *, "Done"
+
+end program intrinsics_478

--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -5222,28 +5222,30 @@ LFORTRAN_API void _lfortran_strcpy_alloc(
 
 
 
-int strlen_without_trailing_space(char *str, int64_t len) {
-    int end = len - 1;
-    while(end >= 0 && str[end] == ' ') end--;
-    return end + 1;
-}
-
 int str_compare(char *s1, int64_t s1_len, char *s2, int64_t s2_len){
-    int s1_len_ = strlen_without_trailing_space(s1, s1_len);
-    int s2_len_ = strlen_without_trailing_space(s2, s2_len);
-    int lim = MIN(s1_len_, s2_len_);
-    int res = 0;
-    int i ;
+    /* If the operands are of different lengths, the shorter one is treated
+       as if it were blank padded on the right to the length of the longer
+       one before the comparison takes place. Characters are ordered by their
+       position in the collating sequence, so compare them as unsigned
+       values. */
+    int64_t lim = MIN(s1_len, s2_len);
+    int64_t i;
     for (i = 0; i < lim; i++) {
         if (s1[i] != s2[i]) {
-            /* Characters are ordered by their position in the collating
-               sequence, so compare them as unsigned values */
-            res = (unsigned char)s1[i] - (unsigned char)s2[i];
-            break;
+            return (unsigned char)s1[i] - (unsigned char)s2[i];
         }
     }
-    res = (i == lim)? s1_len_ - s2_len_ : res;
-    return res;
+    for (i = lim; i < s1_len; i++) {
+        if (s1[i] != ' ') {
+            return (unsigned char)s1[i] - (unsigned char)' ';
+        }
+    }
+    for (i = lim; i < s2_len; i++) {
+        if (s2[i] != ' ') {
+            return (unsigned char)' ' - (unsigned char)s2[i];
+        }
+    }
+    return 0;
 }
 
 LFORTRAN_API char* _lfortran_float_to_str4_alloc(lfortran_allocator_t* al, float num)


### PR DESCRIPTION
## Summary

`LGE`, `LGT`, `LLE` and `LLT` (and the character relational operators, which
share the same lowering) gave wrong answers for operands of different lengths
whenever the extra characters of the longer operand collate below a blank.

The runtime helper `str_compare` removed trailing blanks from both operands and,
when the trimmed prefixes matched, returned the difference of the *trimmed
lengths*. Trimming happens to agree with the blank padding the standard requires
only while every character of the longer operand collates above a blank; as soon
as one collates below a blank the sign of the result is inverted.

The constant-folded implementations of these intrinsics already blank pad
(`blank_pad_string_args` in `src/libasr/pass/intrinsic_functions.h`), so the two
paths disagreed: the same comparison returned different answers depending on
whether the operands were literals or variables.

The fix replaces trimming with padding: compare the common prefix, then compare
whatever is left of the longer operand against blanks.

Fixes #12378

## Scope

- `src/libasr/runtime/lfortran_intrinsics.c` — rewrite `str_compare`; drop
  `strlen_without_trailing_space`, which was only used by it and is now dead.
- `integration_tests/intrinsics_478.f90` — new test.
- `integration_tests/CMakeLists.txt` — register it with labels `gfortran llvm`.

No other change. The remaining failures in the issue's reproducer are a
*different* bug and are deliberately not addressed here (see Rationale).

## Verification

### Behaviour matrix against gfortran 13.3.0

Run-time operands (`a` is `character(len=3)` holding `'abc'`, `b` is
`character(len=5)` holding `'abc'//char(0)//char(0)`, `c` is `character(len=5)`
holding `'abc'//char(1)//char(1)`):

| expression | gfortran | lfortran (main) | lfortran (this PR) |
| --- | --- | --- | --- |
| `lgt(a, b)` | T | **F** | T |
| `lle(a, b)` | F | **T** | F |
| `a == b`    | F | F | F |
| `lgt(a, c)` | T | **F** | T |
| `a == c`    | F | F | F |
| `llt(b, a)` | T | **F** | T |

A 38-case matrix (equal length; shorter first; longer first; trailing-blank
equality; zero-length operands; `character(len=0)` vs blanks; both literal and
variable operands, all four intrinsics plus `==`) was diffed against gfortran:
identical on this branch.

The blank-padding cases where both operands only contain characters at or above
a blank already passed on `main` after 90d8239e6; this PR is what makes the
below-blank cases agree.

### Issue reproducer

```
                                                  gfortran  main  this PR
lge('abc','abc  ')                                    T       T      T
lgt('abc','abc'//repeat(char(0),2))                   T       F      F   <- see Rationale
'abc'=='abc  '                                        T       T      T
'abc'=='abc'//repeat(char(0),2)                       F       T      T   <- see Rationale
lle('abc','abc'//repeat(char(0),2))                   F       T      T   <- see Rationale
lge('abc',['abc','123'])                             T T     T T    T T
lge(['abc','abc'],['abc','123'])                     T T     T T    T T
```

### New integration test

`integration_tests/intrinsics_478.f90` on `main`:

```
ERROR STOP lgt(short_abc, abc_low)
EXIT=1
```

on this branch:

```
Done
EXIT=0
```

### Suites (run locally on this branch)

`cd integration_tests && ./run_tests.py -j4 -b llvm`:

```
1360/4111 Test #1360: intrinsics_478 ..................... Passed 0.01 sec
100% tests passed, 0 tests failed out of 4111
```

`cd integration_tests && ./run_tests.py -j4 -b gfortran -t intrinsics_478`:

```
1/1 Test #1349: intrinsics_478 ................... Passed 0.00 sec
100% tests passed, 0 tests failed out of 1
```

`./run_tests.py --no-llvm`:

```
TESTS PASSED
```

Note on that last one: the machine used here has LLVM 18 (opaque pointers) while
the checked-in `llvm-*` reference outputs were generated with an older LLVM, so
the LLVM-IR-text reference tests fail on it regardless of any change. `--no-llvm`
was used for that reason, so this is **not** a clean full reference run — CI is
the authority on the LLVM-IR references. This PR touches only the C runtime, so
no AST/ASR reference output changes, and none were regenerated.

## Rationale

The three reproducer lines that still differ from gfortran all involve
`char(0)` inside a **compile-time constant** expression. They are a separate,
deeper bug: ASR's `StringConstant` stores its value as a NUL-terminated `char*`
(`StringConstant(string s, ttype type)` in `ASR.asdl`), so everything from an
embedded NUL onwards is lost during folding:

```fortran
character(len=*), parameter :: s = 'ab'//char(0)//'cd'
print *, len(s), ichar(s(3:3)), ichar(s(4:4))
! gfortran:  5 0 99
! lfortran:  5 32 32
```

Fixing that means changing how ASR represents character constants, which is out
of scope here — one bug, one PR. The equivalent comparisons with run-time
operands (where the bytes survive) are correct on this branch, and the folded
path is verified with `char(1)`, which is below a blank but is not a NUL.

The fix is in the runtime rather than in codegen because codegen only lowers
`StringCompare` to a call to this helper; the padding rule is part of the
comparison itself.
