### PR TITLE
Do not scan Hollerith text as format edit descriptors

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -400,6 +400,7 @@ RUN(NAME procedure_pointer_array_01 LABELS gfortran llvm)
 
 RUN(NAME label_01 LABELS gfortran llvm)
 RUN(NAME format_hollerith_01 LABELS gfortran llvm)
+RUN(NAME format_hollerith_02 LABELS gfortran llvm)
 
 RUN(NAME print_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc cpp llvm2 wasm fortran mlir)
 RUN(NAME print_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc llvm2 wasm fortran)

--- a/integration_tests/format_hollerith_02.f90
+++ b/integration_tests/format_hollerith_02.f90
@@ -1,0 +1,22 @@
+program format_hollerith_02
+implicit none
+
+! A Hollerith edit descriptor `nH...` carries n literal characters. Those
+! characters must not be scanned as edit descriptors, even when they look
+! like ones (issue #12254).
+
+character(len=64) :: str
+
+write (str, 100)
+if (str /= "Hello World!") error stop
+
+write (str, 200) 42
+if (str /= "value = 42") error stop
+
+write (str, 300)
+if (str /= "a,b(x)") error stop
+
+100 format (12hHello World!)
+200 format (8hvalue = ,i0)
+300 format (6ha,b(x))
+end program format_hollerith_02

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -1658,8 +1658,11 @@ inline void validate_format_string(const std::string& fmt_str, const Location& l
         }
         
         bool had_repeat_count = false;
+        size_t repeat_count = 0;
         while (i < content.length() && std::isdigit(content[i])) {
             had_repeat_count = true;
+            repeat_count = std::min(content.length(),
+                repeat_count * 10 + static_cast<size_t>(content[i] - '0'));
             i++;
         }
         while (i < content.length() && std::isspace(content[i])) {
@@ -1669,6 +1672,16 @@ inline void validate_format_string(const std::string& fmt_str, const Location& l
         
         c = content[i];
         
+        if (had_repeat_count && (c == 'h' || c == 'H')) {
+            // Hollerith edit descriptor `nH<n characters>`: the n characters
+            // following the `H` are literal text and must not be scanned as
+            // edit descriptors.
+            i++;
+            i += std::min(repeat_count, content.length() - i);
+            prev_desc = DescType::DATA;
+            continue;
+        }
+
         DescType current_desc = DescType::NONE;
         
         char c_upper = std::toupper(c);

--- a/tests/reference/asr-format_hollerith_02-962b33a.json
+++ b/tests/reference/asr-format_hollerith_02-962b33a.json
@@ -1,0 +1,13 @@
+{
+    "basename": "asr-format_hollerith_02-962b33a",
+    "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
+    "infile": "tests/../integration_tests/format_hollerith_02.f90",
+    "infile_hash": "868be5d11cd5eecd9190720193c8b12874760a798474a56690884660",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -1963,6 +1963,13 @@ filename = "../integration_tests/format_02.f90"
 ast = true
 ast_f90 = true
 
+# Pins that a Hollerith edit descriptor emits no diagnostics: the n characters
+# it carries are literal text, so letters in them must not be scanned as edit
+# descriptors and reported as a missing comma (C1302).
+[[test]]
+filename = "../integration_tests/format_hollerith_02.f90"
+semantics_only_cc = true
+
 [[test]]
 filename = "format1.f90"
 run = true


### PR DESCRIPTION
Fixes #12254

## Summary

`validate_format_string` (the check behind `warning: Format string missing comma between descriptors (F2023 constraint C1302)`) did not know about the Hollerith edit descriptor `nH`. It consumed the repeat count, failed to match `H` against any descriptor letter, and then went on scanning the *n* literal characters that the descriptor carries as if they were edit descriptors. Every character in that text that happens to name a descriptor was reported as a descriptor without a separating comma.

For the reporter's program, `Hello World!` contributes `e`, `l`, `l`, `o`, `o`, `l`, `d` and produced six bogus warnings:

```fortran
      program hollhello
        implicit none
        write (6,100)
  100   format (12hHello World!)
      end program
```

Before:

```
warning: Format string missing comma between descriptors (F2023 constraint C1302)
 --> re_hollhello.f90:6:9
  |
6 |   100   format (12hHello World!)
  |         ^^^^^^^^^^^^^^^^^^^^^^^^

... (the same warning, at the same location, six times in total)

Note: Please report unclear, confusing or incorrect messages as bugs at
https://github.com/lfortran/lfortran/issues.
Hello World!
```

After:

```
Hello World!
```

## Scope

One change in the format-string checker in `src/lfortran/semantics/ast_common_visitor.h`: capture the repeat count's value, and when the character that follows it is `h`/`H`, skip that many characters and treat the whole thing as a single descriptor for the comma check. No backend, ASR or codegen change.

The diagnostic is not silenced in general — the warning is still emitted where C1302 is genuinely violated, including after a Hollerith descriptor:

```
warning: Format string missing comma between descriptors (F2023 constraint C1302)
 --> sanity.f90:7:5
  |
7 | 200 format (5hval= i3)
  |     ^^^^^^^^^^^^^^^^^^
```

## Rationale

The Hollerith edit descriptor is a Fortran 66/77 feature deleted in Fortran 95, which LFortran deliberately supports as a legacy extension (#12026, #12029, `integration_tests/format_hollerith_01.f90`). Its *n* characters are literal text, not descriptors, so nothing inside them can violate C1302; a warning pointing at them is simply wrong and there is no correct rewording of it. The right behaviour for `(12hHello World!)` is no diagnostic at all.

That matches GFortran 13.3.0, which is silent both at its default `-std=gnu` and at `-std=legacy`, and only warns under a strict standard mode about the feature itself:

```
$ gfortran hollhello.f90            # no diagnostics
$ gfortran -std=legacy hollhello.f90  # no diagnostics
$ gfortran -std=f2018 hollhello.f90
    6 |   100   format (12hHello World!)
      |                       1
Warning: The H format specifier at (1) is a Fortran 95 deleted feature
```

LFortran has no equivalent strict-standard mode here and already accepts Hollerith by design, so no "deleted feature" warning is added — that would be a separate feature, not this bug fix.

## Verification

New test `integration_tests/format_hollerith_02.f90`, registered twice:

- `integration_tests/CMakeLists.txt`: `RUN(NAME format_hollerith_02 LABELS gfortran llvm)` — checks the produced text is correct at runtime.
- `tests/tests.toml` with `semantics_only_cc = true` — pins the diagnostics, so the reference (`tests/reference/asr-format_hollerith_02-962b33a.json`, `stderr: null`) fails the moment any warning comes back.

It covers the issue's exact format, a Hollerith followed by a real descriptor after a comma, and a Hollerith whose text contains `,` and parentheses.

Test fails on `main` (fix reverted, everything else identical) — 8 bogus warnings:

```
=== STDERR DIFF ===
Reference: (missing - expected no stderr)
0a1,47
> warning: Format string missing comma between descriptors (F2023 constraint C1302)
>   --> tests/../integration_tests/format_hollerith_02.f90:19:5
>    |
> 19 | 100 format (12hHello World!)
...
```

Test passes on this branch:

```
$ ./run_tests.py -t ../integration_tests/format_hollerith_02.f90 -s
../integration_tests/format_hollerith_02.f90 * asr ✓
TESTS PASSED
```

Suites (Debug build, `-DWITH_LLVM=ON`):

- Integration: `cd integration_tests && ./run_tests.py -j4 -b llvm` → `100% tests passed, 0 tests failed out of 4111` (`format_hollerith_02` Passed).
- Reference: `./run_tests.py --no-llvm` → `TESTS PASSED`. `--no-llvm` is used because this machine has LLVM 18 (opaque pointers) while the checked-in `llvm-*` reference outputs were generated with an older LLVM, so the LLVM-IR-text references mismatch here regardless of this change. The LLVM reference tests were therefore not run locally and are left to CI.

No existing reference output changed: the five pre-existing C1302 warnings in `tests/reference/asr-continue_compilation_2-a6145a1.stderr` involve no Hollerith descriptor and are untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qswb5qZf7pAyUdHUspspDu)_