### PR TITLE
Use BOZ literal bits as the representation in dble, real and cmplx

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3404,6 +3404,7 @@ RUN(NAME cpu_time_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME system_clock_01 LABELS gfortran llvm)
 RUN(NAME boz_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME boz_02 LABELS llvm llvm_wasm llvm_wasm_emcc) #remove gfortran label, as functionality is not supported by gfortran
+RUN(NAME boz_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME cmd_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME cmd_02 LABELS gfortran llvm)
 RUN(NAME cmd_03 LABELS gfortran llvm) # get_command_argument loop until empty

--- a/integration_tests/boz_03.f90
+++ b/integration_tests/boz_03.f90
@@ -1,0 +1,53 @@
+program boz_03
+! A BOZ literal constant is typeless: it is an ordered sequence of bits. When
+! it is an argument of DBLE, REAL or CMPLX those bits are used directly as the
+! internal representation of the result, they are not converted from an integer
+! value.
+implicit none
+
+real(4) :: r4
+real(8) :: r8
+complex(4) :: c4
+complex(8) :: c8
+
+! DBLE reinterprets the bits as a real(8)
+r8 = dble(z'3ff0000000000000')
+if (r8 /= 1.0_8) error stop
+r8 = dble(z'c000000000000000')
+if (r8 /= -2.0_8) error stop
+r8 = dble(b'0011111111110000000000000000000000000000000000000000000000000000')
+if (r8 /= 1.0_8) error stop
+r8 = dble(o'400000000000000000000')
+if (r8 /= 2.0_8) error stop
+r8 = dble(z'ff')
+if (r8 /= 255.0_8 * tiny(1.0_8) / 4503599627370496.0_8) error stop
+
+! REAL reinterprets the bits at the kind it returns
+r4 = real(z'3f800000')
+if (r4 /= 1.0_4) error stop
+r4 = real(z'bf800000', kind=4)
+if (r4 /= -1.0_4) error stop
+r4 = real(o'7770000000')
+if (r4 /= 1.75_4) error stop
+r4 = real(b'00111111100000000000000000000000')
+if (r4 /= 1.0_4) error stop
+r8 = real(z'3ff0000000000000', kind=8)
+if (r8 /= 1.0_8) error stop
+r8 = real(z'4010000000000000', 8)
+if (r8 /= 4.0_8) error stop
+
+! CMPLX reinterprets the bits of both parts
+c4 = cmplx(z'3f800000', z'40000000')
+if (c4 /= (1.0_4, 2.0_4)) error stop
+c8 = cmplx(z'3ff0000000000000', z'c000000000000000', kind=8)
+if (c8 /= (1.0_8, -2.0_8)) error stop
+c4 = cmplx(z'3f800000')
+if (c4 /= (1.0_4, 0.0_4)) error stop
+
+! INT keeps using the bits as an integer value
+if (int(z'ff') /= 255) error stop
+if (int(b'01011101') /= 93) error stop
+if (int(o'2347') /= 1255) error stop
+
+print *, r4, r8, c4, c8
+end program boz_03

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -24,6 +24,7 @@
 #include <queue>
 #include <limits>
 #include <utility>
+#include <cstring>
 
 using LCompilers::diag::Level;
 using LCompilers::diag::Stage;
@@ -13972,17 +13973,8 @@ public:
                 throw SemanticAbort();
             }
             LCOMPILERS_ASSERT(x.m_args[i].m_end != nullptr);
-            // Handle BOZ constants in real() function
-            ASR::ttype_t* temp_current_variable_type = current_variable_type_;
-            if (intrinsic_name == "real" && i == 0 && x.m_args[i].m_end && 
-                AST::is_a<AST::BOZ_t>(*x.m_args[i].m_end)) {
-                // Set current_variable_type to Real for BOZ conversion in real() function
-                current_variable_type_ = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, 
-                    compiler_options.po.default_integer_kind));
-            }
             AST::expr_t* arg_expr = x.m_args[i].m_end;
             this->visit_expr(*x.m_args[i].m_end);
-            current_variable_type_ = temp_current_variable_type;
             ASR::expr_t* temp = ASRUtils::EXPR(tmp);
             if (ASRUtils::is_assumed_rank_array(ASRUtils::expr_type(temp))) {
                 ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(temp);
@@ -16551,6 +16543,7 @@ public:
                             args.p[1] = ASRUtils::EXPR(ASR::make_RealConstant_t(al, x.base.base.loc, 0.0, real8_type));
                         }
                     }
+                    convert_boz_args_to_real(var_name, args);
                     fill_optional_kind_arg(var_name, args);
                     tmp = nullptr;
                     scalar_kind_arg(var_name, args);
@@ -16891,6 +16884,11 @@ public:
         ASR::ttype_t *to_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, 8));
         if (!arg) {
             return ASR::make_RealConstant_t(al, loc, 0.0, to_type);
+        }
+        // `dble` accepts a BOZ literal constant: its bits are the internal
+        // representation of the real(8) result, no numeric conversion happens
+        if (is_boz_literal_constant(arg)) {
+            return (ASR::asr_t *)boz_literal_to_real(arg, 8);
         }
         if (ASR::is_a<ASR::Array_t>(*type)) {
             ASR::Array_t *arr = ASR::down_cast<ASR::Array_t>(type);
@@ -21011,6 +21009,83 @@ public:
         }
     }
 
+    // A binary, octal or hexadecimal literal constant has no type; it is an
+    // ordered sequence of bits (F2023 7.7). Where such a constant supplies the
+    // value of a real, those bits are used directly as the internal
+    // representation of the result, they are not converted from an integer
+    // value. Reinterpret the low `kind` bytes of `bits` accordingly; `kind` is
+    // 4 or 8, the kinds a 64 bit BOZ literal can fill.
+    static double boz_bits_as_real(uint64_t bits, int kind) {
+        if( kind == 4 ) {
+            uint32_t bits_32 = static_cast<uint32_t>(bits);
+            float value_32 = 0.0f;
+            std::memcpy(&value_32, &bits_32, sizeof(value_32));
+            return static_cast<double>(value_32);
+        }
+        double value_64 = 0.0;
+        std::memcpy(&value_64, &bits, sizeof(value_64));
+        return value_64;
+    }
+
+    // True when `e` is a BOZ literal constant. BOZ literals are represented as
+    // an IntegerConstant carrying a non-Decimal boz kind, which is what marks
+    // them as typeless.
+    static bool is_boz_literal_constant(ASR::expr_t* e) {
+        return e != nullptr && ASR::is_a<ASR::IntegerConstant_t>(*e) &&
+            ASR::down_cast<ASR::IntegerConstant_t>(e)->m_intboz_type !=
+                ASR::integerbozType::Decimal;
+    }
+
+    // Reinterpret a BOZ literal constant as a real of the given kind. Any other
+    // expression, and any kind whose representation a BOZ literal cannot fill,
+    // is returned unchanged.
+    ASR::expr_t* boz_literal_to_real(ASR::expr_t* e, int kind) {
+        if( !is_boz_literal_constant(e) || (kind != 4 && kind != 8) ) {
+            return e;
+        }
+        const Location& loc = e->base.loc;
+        uint64_t bits = static_cast<uint64_t>(
+            ASR::down_cast<ASR::IntegerConstant_t>(e)->m_n);
+        ASR::ttype_t* real_type = ASRUtils::TYPE(ASR::make_Real_t(al, loc, kind));
+        return ASRUtils::EXPR(ASR::make_RealConstant_t(al, loc,
+            boz_bits_as_real(bits, kind), real_type));
+    }
+
+    // `real` and `cmplx` accept BOZ literal constants, whose bits become the
+    // representation of the (real part of the) result. Replace such arguments
+    // with the real constant they denote, at the kind the intrinsic returns, so
+    // that no numeric integer-to-real conversion is performed downstream.
+    void convert_boz_args_to_real(const std::string& intrinsic_name,
+            Vec<ASR::expr_t*>& args) {
+        size_t n_boz_args = 0, kind_arg_index = 0;
+        if( intrinsic_name == "real" ) {
+            n_boz_args = 1;
+            kind_arg_index = 1;
+        } else if( intrinsic_name == "cmplx" ) {
+            n_boz_args = 2;
+            kind_arg_index = 2;
+        } else {
+            return;
+        }
+        if( args.size() <= kind_arg_index ) {
+            return;
+        }
+        bool has_boz_arg = false;
+        for( size_t i = 0; i < n_boz_args; i++ ) {
+            has_boz_arg |= is_boz_literal_constant(args[i]);
+        }
+        if( !has_boz_arg ) {
+            return;
+        }
+        int kind = 4;
+        if( args[kind_arg_index] != nullptr ) {
+            kind = static_cast<int>(handle_kind(args[kind_arg_index]));
+        }
+        for( size_t i = 0; i < n_boz_args; i++ ) {
+            args.p[i] = boz_literal_to_real(args[i], kind);
+        }
+    }
+
     void visit_BOZ(const AST::BOZ_t& x) {
         std::string s = std::string(x.m_s);
         int base = -1;
@@ -21049,16 +21124,16 @@ public:
             );
         }
         uint64_t boz_unsigned_int = std::stoull(boz_str, nullptr, base);
-        //If current_variable_type is Real Type, convert BOZ String to ASR::Real 
+        //If current_variable_type is Real Type, the bits of the BOZ literal are
+        //the internal representation of the real value
+        int real_kind = 0;
         if ((current_variable_type_ != nullptr) && (ASR::is_a<ASR::Real_t>(*current_variable_type_)) ){
-            
-            // We need the smallest positive real value, and scale the bits accordingly
-            double min_boz = std::numeric_limits<float>::denorm_min();
-            // Scale the BOZ value: each bit represents smallest_subnormal
-            double boz_double = static_cast<double>(boz_unsigned_int) * min_boz;
-            ASR::ttype_t* real_type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, compiler_options.po.default_integer_kind));
-            tmp = ASR::make_RealConstant_t(al, x.base.base.loc, boz_double,
-                    real_type);
+            real_kind = ASRUtils::extract_kind_from_ttype_t(current_variable_type_);
+        }
+        if (real_kind == 4 || real_kind == 8) {
+            ASR::ttype_t* real_type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, real_kind));
+            tmp = ASR::make_RealConstant_t(al, x.base.base.loc,
+                    boz_bits_as_real(boz_unsigned_int, real_kind), real_type);
         }
 
         //If current_variable_type is Null or INT Type, default to INT 

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -11007,7 +11007,10 @@ public:
         return 1; // default
     }
 
-    bool is_boz_integer_constant(ASR::expr_t* expr) {
+    // True when `expr` is a BOZ literal constant. BOZ literals are represented
+    // as an IntegerConstant carrying a non-Decimal boz kind, which is what
+    // marks them as typeless.
+    bool is_boz_constant(ASR::expr_t* expr) {
         if (!expr || !ASR::is_a<ASR::IntegerConstant_t>(*expr)) {
             return false;
         }
@@ -11154,7 +11157,7 @@ public:
                             Level::Error, Stage::Semantic, {Label("", {m_left_expr->base.loc})}));
                         throw SemanticAbort();
                     }
-                    if (is_boz_integer_constant(m_left_expr)) {
+                    if (is_boz_constant(m_left_expr)) {
                         diag.add(Diagnostic("Substring start index must be of type integer",
                             Level::Error, Stage::Semantic, {Label("", {m_left_expr->base.loc})}));
                         throw SemanticAbort();
@@ -11182,7 +11185,7 @@ public:
                             Level::Error, Stage::Semantic, {Label("", {m_right_expr->base.loc})}));
                         throw SemanticAbort();
                     }
-                    if (is_boz_integer_constant(m_right_expr)) {
+                    if (is_boz_constant(m_right_expr)) {
                         diag.add(Diagnostic("Substring end index must be of type integer",
                             Level::Error, Stage::Semantic, {Label("", {m_right_expr->base.loc})}));
                         throw SemanticAbort();
@@ -11199,7 +11202,7 @@ public:
                             Level::Error, Stage::Semantic, {Label("", {m_step_expr->base.loc})}));
                         throw SemanticAbort();
                     }
-                    if (is_boz_integer_constant(m_step_expr)) {
+                    if (is_boz_constant(m_step_expr)) {
                         diag.add(Diagnostic("Substring stride must be of type integer",
                             Level::Error, Stage::Semantic, {Label("", {m_step_expr->base.loc})}));
                         throw SemanticAbort();
@@ -16887,7 +16890,7 @@ public:
         }
         // `dble` accepts a BOZ literal constant: its bits are the internal
         // representation of the real(8) result, no numeric conversion happens
-        if (is_boz_literal_constant(arg)) {
+        if (is_boz_constant(arg)) {
             return (ASR::asr_t *)boz_literal_to_real(arg, 8);
         }
         if (ASR::is_a<ASR::Array_t>(*type)) {
@@ -21027,20 +21030,11 @@ public:
         return value_64;
     }
 
-    // True when `e` is a BOZ literal constant. BOZ literals are represented as
-    // an IntegerConstant carrying a non-Decimal boz kind, which is what marks
-    // them as typeless.
-    static bool is_boz_literal_constant(ASR::expr_t* e) {
-        return e != nullptr && ASR::is_a<ASR::IntegerConstant_t>(*e) &&
-            ASR::down_cast<ASR::IntegerConstant_t>(e)->m_intboz_type !=
-                ASR::integerbozType::Decimal;
-    }
-
     // Reinterpret a BOZ literal constant as a real of the given kind. Any other
     // expression, and any kind whose representation a BOZ literal cannot fill,
     // is returned unchanged.
     ASR::expr_t* boz_literal_to_real(ASR::expr_t* e, int kind) {
-        if( !is_boz_literal_constant(e) || (kind != 4 && kind != 8) ) {
+        if( !is_boz_constant(e) || (kind != 4 && kind != 8) ) {
             return e;
         }
         const Location& loc = e->base.loc;
@@ -21072,7 +21066,7 @@ public:
         }
         bool has_boz_arg = false;
         for( size_t i = 0; i < n_boz_args; i++ ) {
-            has_boz_arg |= is_boz_literal_constant(args[i]);
+            has_boz_arg |= is_boz_constant(args[i]);
         }
         if( !has_boz_arg ) {
             return;
@@ -21124,24 +21118,16 @@ public:
             );
         }
         uint64_t boz_unsigned_int = std::stoull(boz_str, nullptr, base);
-        //If current_variable_type is Real Type, the bits of the BOZ literal are
-        //the internal representation of the real value
-        int real_kind = 0;
-        if ((current_variable_type_ != nullptr) && (ASR::is_a<ASR::Real_t>(*current_variable_type_)) ){
-            real_kind = ASRUtils::extract_kind_from_ttype_t(current_variable_type_);
-        }
-        if (real_kind == 4 || real_kind == 8) {
-            ASR::ttype_t* real_type = ASRUtils::TYPE(ASR::make_Real_t(al, x.base.base.loc, real_kind));
-            tmp = ASR::make_RealConstant_t(al, x.base.base.loc,
-                    boz_bits_as_real(boz_unsigned_int, real_kind), real_type);
-        }
-
-        //If current_variable_type is Null or INT Type, default to INT 
-        else{            
-            int64_t boz_int = static_cast<int64_t>(boz_unsigned_int);
-            ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, compiler_options.po.default_integer_kind));
-            tmp = ASR::make_IntegerConstant_t(al, x.base.base.loc, boz_int,
-                    int_type, boz_type);
+        int64_t boz_int = static_cast<int64_t>(boz_unsigned_int);
+        ASR::ttype_t* int_type = ASRUtils::TYPE(ASR::make_Integer_t(al, x.base.base.loc, compiler_options.po.default_integer_kind));
+        tmp = ASR::make_IntegerConstant_t(al, x.base.base.loc, boz_int,
+                int_type, boz_type);
+        // Where the literal supplies the value of a real, its bits are the
+        // internal representation of that real. boz_literal_to_real leaves the
+        // constant as it is for a kind those bits cannot fill.
+        if (current_variable_type_ != nullptr && ASR::is_a<ASR::Real_t>(*current_variable_type_)) {
+            tmp = (ASR::asr_t*)boz_literal_to_real(ASRUtils::EXPR(tmp),
+                    ASRUtils::extract_kind_from_ttype_t(current_variable_type_));
         }
     }
 


### PR DESCRIPTION
Fixes #12417

## Summary

A BOZ literal constant has no type; it is an ordered sequence of bits (F2023 7.7). When one is an actual argument of `DBLE`, `REAL` or `CMPLX`, those bits are the internal representation of the result — they are not an integer value to convert numerically.

Before this change:

- `DBLE` and `CMPLX` converted the literal as an integer, so `dble(z'ff')` gave `255.0d0`.
- `REAL` multiplied the value by the smallest subnormal float. That happens to agree with the standard only while the result stays subnormal, so `real(z'ff')` was right by coincidence while `real(z'3f800000')` gave `1.49e-36` instead of `1.0`. The `kind` argument was ignored, so `real(z'...', kind=8)` reinterpreted at kind 4.

## Scope

All of the work is in AST→ASR semantics (`src/lfortran/semantics/ast_common_visitor.h`); no backend is touched. The BOZ literal is already carried in ASR as an `IntegerConstant` tagged with a non-`Decimal` `integerboz` kind, which is what marks it as typeless. Three small helpers use that tag:

- `boz_bits_as_real` reinterprets the low 4 or 8 bytes of the literal as a `real(4)`/`real(8)` value.
- `boz_literal_to_real` replaces a tagged `IntegerConstant` with the `RealConstant` those bits denote, and leaves anything else (including kinds a 64-bit BOZ literal cannot fill, e.g. `real(16)`) untouched.
- `convert_boz_args_to_real` applies this to the arguments of `real` and `cmplx` after the argument list is complete, so the kind the intrinsic actually returns is known; `handle_intrinsic_dble` does the same at kind 8.

Because the conversion now happens where the result kind is known, the `real`-specific `current_variable_type_` hack in `handle_intrinsic_node_args` is no longer needed and is removed. `visit_BOZ` — which handles a BOZ literal supplying the value of a real in a declaration or data statement, an extension gfortran accepts under `-fallow-invalid-boz` — used the same subnormal scaling and now uses the same bit reinterpretation, at the kind of the target rather than the default integer kind.

`INT` and `TRANSFER` are unchanged; `int(z'ff')` was already correct and stays `255`.

## Verification

Reference values are gfortran 13.

Issue reproducer, on `main` vs this branch:

| expression | main | this branch | gfortran |
| --- | --- | --- | --- |
| `dble(z"ff")` | `255.00000000000000` | `1.2598673968951787E-321` | `0.12598673968951787E-320` |
| `real(z"ff")` | `3.57331108E-43` | `3.57331108E-43` | `0.357331108E-42` |
| `cmplx(z"ff")` | `255.000000 0.00000000` | `3.57331108E-43 0.00000000` | `0.357331108E-42 0.00000000` |
| `int(z"ff")` | `255` | `255` | `255` |

(The `dble`/`real` columns differ only in `g0` exponent formatting; the values are equal.)

Wider cases, all now matching gfortran exactly and all wrong on `main`:

| expression | main | this branch / gfortran |
| --- | --- | --- |
| `dble(z'3ff0000000000000')` | `4.6071824188000174E+018` | `1.0000000000000000` |
| `real(z'3ff0000000000000', kind=8)` | `6.4560376483287606E-027` | `1.0000000000000000` |
| `real(z'3f800000')` | `1.49287783E-36` | `1.00000000` |
| `real(o'7770000000')` | `1.50169403E-36` | `1.75000000` |
| `dble(z'c000000000000000')` | `-4.6116860184273879E+018` | `-2.0000000000000000` |
| `cmplx(z'3f800000', z'40000000')` | `1.06535322E+09 1.07374182E+09` | `1.00000000 2.00000000` |

New integration test `integration_tests/boz_03.f90`, registered in `integration_tests/CMakeLists.txt` as `RUN(NAME boz_03 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)`. It asserts `dble`, `real` (kind 4 and 8) and `cmplx` over `B`/`O`/`Z` forms and checks `int` is unaffected. Built with the same compiler binary on both sides:

```
main:    ERROR STOP (exit 1)
branch:  exit 0
gfortran: exit 0
```

Suites:

- `cd integration_tests && ./run_tests.py -j4 -b llvm` — `100% tests passed, 0 tests failed out of 4111`, including `boz_01`, `boz_02`, `boz_03` and `integer_boz_01`.
- `cd integration_tests && ./run_tests.py -b gfortran -t boz_03` — `100% tests passed, 0 tests failed out of 1`.
- `./run_tests.py --no-llvm` — `TESTS PASSED` (1426 checks, 0 failures). No reference output needed regenerating. `--no-llvm` is used because this container has LLVM 18 (opaque pointers) while the checked-in `llvm-*` reference outputs were generated with an older LLVM, so the LLVM-IR-text reference tests fail here regardless of any change. This is therefore **not** a clean full reference run; CI should be relied on for the `llvm` reference outputs.

## Rationale

Typelessness of a BOZ literal is a property of the argument's type resolution, so it is resolved in AST→ASR where the intrinsic's arguments and result kind are decided. The resulting ASR holds a plain `RealConstant`, so every backend lowers it without needing any BOZ knowledge, and no `Cast` node has to be introduced for what is a compile-time constant.

`real(16)` is deliberately left alone: a 64-bit BOZ literal cannot fill a 128-bit representation, and ASR's `RealConstant` stores a `double`, so reinterpreting there would produce a malformed constant. That case keeps its existing (pre-PR) behaviour.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qswb5qZf7pAyUdHUspspDu)_