### PR TITLE
Copy scalar allocatable components on derived type assignment

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4439,6 +4439,7 @@ RUN(NAME elemental_20 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME elemental_21 LABELS gfortran llvm)
 RUN(NAME elemental_22 LABELS gfortran llvm)
 RUN(NAME elemental_23 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME elemental_24 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 
 RUN(NAME types_21 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME types_22 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/elemental_24.f90
+++ b/integration_tests/elemental_24.f90
@@ -1,0 +1,78 @@
+module elemental_24_mod
+    implicit none
+
+    type :: con_type
+        integer, allocatable :: val
+    end type
+
+    interface con_type
+        module procedure :: con_type_getter
+    end interface
+
+contains
+
+    pure elemental function endswith(con, suffix) result(itis)
+        type(con_type), intent(in) :: con, suffix
+        logical :: itis
+        itis = con%val == suffix%val
+    end function
+
+    pure elemental function con_type_getter(val) result(con)
+        integer, intent(in) :: val
+        type(con_type) :: con
+        con%val = val
+    end function
+
+end module elemental_24_mod
+
+program elemental_24
+    use elemental_24_mod, only: con_type, endswith
+    implicit none
+
+    type(con_type) :: a, b
+    type(con_type) :: pair(2)
+    type(con_type), allocatable :: suffixes(:)
+    logical :: r2(2)
+
+    ! An allocatable component must be copied, not aliased, by intrinsic
+    ! assignment of a derived type.
+    a = con_type(5)
+    b = a
+    b%val = 6
+    if (a%val /= 5) error stop
+    if (b%val /= 6) error stop
+
+    ! Elemental call with scalar arguments.
+    if (.not. endswith(a, con_type(5))) error stop
+    if (endswith(a, b)) error stop
+
+    ! Elemental function returning a derived type, called with a rank-1 array.
+    pair = con_type([1, 2])
+    if (pair(1)%val /= 1) error stop
+    if (pair(2)%val /= 2) error stop
+
+    ! Rank-1 array arguments on both sides.
+    r2 = endswith(pair, pair)
+    if (.not. r2(1)) error stop
+    if (.not. r2(2)) error stop
+
+    suffixes = [con_type(1), con_type(2)]
+    if (size(suffixes) /= 2) error stop
+    if (suffixes(1)%val /= 1) error stop
+    if (suffixes(2)%val /= 2) error stop
+
+    ! Mixed scalar and array actual arguments: the scalar is broadcast.
+    r2 = endswith(con_type(1), suffixes)
+    if (.not. r2(1)) error stop
+    if (r2(2)) error stop
+
+    r2 = endswith(suffixes, con_type(2))
+    if (r2(1)) error stop
+    if (.not. r2(2)) error stop
+
+    ! The array elements keep independent storage for their components.
+    suffixes(1)%val = 9
+    if (pair(1)%val /= 1) error stop
+    if (suffixes(2)%val /= 2) error stop
+
+end program elemental_24

--- a/src/libasr/codegen/llvm_utils.cpp
+++ b/src/libasr/codegen/llvm_utils.cpp
@@ -10983,11 +10983,67 @@ llvm::Value* LLVMUtils::handle_global_nonallocatable_stringArray(
                                 builder->CreatePtrToInt(src_member_char, llvm::Type::getInt64Ty(context)),
                                 llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), llvm::APInt(64, 0)));
                         }
+                        // A scalar allocatable member of intrinsic type is a bare
+                        // pointer in the struct layout, so copying the member as-is
+                        // would make source and destination share one allocation
+                        // (and free it twice). Give the destination its own storage
+                        // and copy the value into it.
+                        ASR::ttype_t* mem_elem_type = ASRUtils::extract_type(member_type);
+                        bool is_alloc_scalar_intrinsic =
+                            ASRUtils::is_allocatable(member_type) &&
+                            !ASRUtils::is_array(member_type) &&
+                            (ASR::is_a<ASR::Integer_t>(*mem_elem_type) ||
+                             ASR::is_a<ASR::UnsignedInteger_t>(*mem_elem_type) ||
+                             ASR::is_a<ASR::Real_t>(*mem_elem_type) ||
+                             ASR::is_a<ASR::Complex_t>(*mem_elem_type) ||
+                             ASR::is_a<ASR::Logical_t>(*mem_elem_type));
+                        llvm::Type* mem_elem_llvm_type = nullptr;
+                        if (is_alloc_scalar_intrinsic) {
+                            mem_elem_llvm_type = llvm_utils->get_type_from_ttype_t_util(
+                                ASRUtils::get_expr_from_sym(al, mem_sym), mem_elem_type, module);
+                        }
                         llvm_utils->create_if_else(is_allocated, [&]() {
+                            if (is_alloc_scalar_intrinsic) {
+                                llvm::Value* dest_data = llvm_utils->CreateLoad2(
+                                    mem_elem_llvm_type->getPointerTo(), dest_member);
+                                llvm::Value* dest_is_null = builder->CreateICmpEQ(
+                                    builder->CreatePtrToInt(dest_data, llvm::Type::getInt64Ty(context)),
+                                    llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), llvm::APInt(64, 0)));
+                                llvm_utils->create_if_else(dest_is_null, [&]() {
+                                    llvm::DataLayout data_layout(module->getDataLayout());
+                                    llvm::Value* alloc_size = llvm::ConstantInt::get(
+                                        llvm_utils->getIntType(4), llvm::APInt(32,
+                                            data_layout.getTypeAllocSize(mem_elem_llvm_type)));
+                                    llvm::Value* new_data = LLVMArrUtils::lfortran_malloc(
+                                        context, *module, *builder, alloc_size);
+                                    builder->CreateStore(builder->CreateBitCast(new_data,
+                                        mem_elem_llvm_type->getPointerTo()), dest_member);
+                                }, [](){});
+                                dest_data = llvm_utils->CreateLoad2(
+                                    mem_elem_llvm_type->getPointerTo(), dest_member);
+                                builder->CreateStore(llvm_utils->CreateLoad2(
+                                    mem_elem_llvm_type, src_member), dest_data);
+                                return;
+                            }
                             llvm_utils->deepcopy(ASRUtils::EXPR(ASR::make_Var_t(al, mem_sym->base.loc, mem_sym)), src_member, dest_member,
                             member_type, member_type,
                             module);
                         }, [&]() {
+                            if (is_alloc_scalar_intrinsic) {
+                                // The source component is unallocated, so the
+                                // destination component must become unallocated too.
+                                llvm::Value* dest_data = llvm_utils->CreateLoad2(
+                                    mem_elem_llvm_type->getPointerTo(), dest_member);
+                                llvm::Value* dest_not_null = builder->CreateICmpNE(
+                                    builder->CreatePtrToInt(dest_data, llvm::Type::getInt64Ty(context)),
+                                    llvm::ConstantInt::get(llvm::Type::getInt64Ty(context), llvm::APInt(64, 0)));
+                                llvm_utils->create_if_else(dest_not_null, [&]() {
+                                    llvm_utils->lfortran_free(dest_data);
+                                }, [](){});
+                                builder->CreateStore(llvm::ConstantPointerNull::get(
+                                    mem_elem_llvm_type->getPointerTo()), dest_member);
+                                return;
+                            }
                             if (is_alloc_str_only) {
                                 // If source allocatable string is not allocated, then
                                 // deallocate the destination allocatable string


### PR DESCRIPTION
## Summary

Fixes #12596.

The program in the issue printed the correct result and then aborted with
`free(): double free detected in tcache 2`.

The elemental call itself was not at fault. Intrinsic assignment of a derived
type copied a **scalar allocatable component of intrinsic type** by copying the
component pointer, so source and destination ended up sharing a single heap
block. Each of them then freed it, hence the double free.

Reduced to the smallest form, without any elemental procedure:

```fortran
program p
    implicit none
    type :: con_type
        integer, allocatable :: val
    end type
    type(con_type) :: a, b
    b%val = 5
    a = b
    a%val = 7
    print *, b%val, a%val   ! gfortran: 5 7 ; lfortran (before): 7 7 + double free
end program
```

`LLVMStruct::struct_deepcopy` already deep-copies allocatable *array*
components, allocatable *string* components and allocatable *struct*
components. Only the scalar intrinsic-type case fell through to
`LLVMUtils::deepcopy`'s `Allocatable` branch, whose final `else` is a plain
`CreateStore(src, dest)` — a pointer copy.

## Scope

`src/libasr/codegen/llvm_utils.cpp` only, in the member loop of
`LLVMStruct::struct_deepcopy`:

- when the source component is allocated: give the destination component its
  own storage (allocating it if it has none) and copy the value into it;
- when the source component is unallocated: free the destination component and
  null it, so the destination component becomes unallocated too.

No ASR, semantics or pass change is involved: the ASR for the assignment is
already correct, this is purely how the backend lowers a deep copy, which is
where the rest of the component deep-copy logic already lives.

## Verification

Reproducer from the issue, on `main`:

```
 T F
free(): double free detected in tcache 2
Aborted (core dumped)
```

With this branch (and with `gfortran` 13.3.0 as the reference):

```
 T F
```

New integration test `integration_tests/elemental_24.f90`, registered in
`integration_tests/CMakeLists.txt` as
`RUN(NAME elemental_24 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)`.
It covers the assignment aliasing directly plus the neighbouring elemental
cases: scalar call, elemental function returning a derived type called with a
rank-1 array, rank-1 array arguments on both sides, and mixed scalar/array
actual arguments in both argument positions (the scalar broadcast).

- fails on `main` (`ERROR STOP`, on the aliasing check), passes on this branch —
  verified by stashing the source change, rebuilding, and re-running;
- passes under both `-b llvm` and `-b gfortran`.

Suites, Debug build with LLVM 18:

- `cd integration_tests && ./run_tests.py -j4 -b llvm` — `100% tests passed, 0 tests failed out of 4111`
- `./run_tests.py --no-llvm` — `TESTS PASSED`, no reference output needed updating.

`--no-llvm` is used for the reference suite because this container has LLVM 18
(opaque pointers) while the checked-in `llvm-*` reference outputs were generated
with an older LLVM, so the LLVM-IR-text reference tests fail here independently
of this change. The `asr`/`ast`/`c`/error reference tests all run and pass.

## Rationale

F2023 10.2.1.3: on intrinsic assignment of a derived-type object, an allocatable
component of the variable is allocated with the value of the corresponding
component of the expression, or deallocated if that component is unallocated.
Copying the component pointer instead gives two objects one allocation, which is
both an aliasing bug (`a%val = 7` was visible through `b%val`) and a double free
at finalization.

## Out of scope

While probing neighbouring cases I hit an unrelated pre-existing crash that does
not involve any assignment and so is untouched by this change — `abs()` applied
to a scalar `complex, allocatable` component trips an LLVM assertion at compile
time (`checkGEPType: Invalid GetElementPtrInst indices for type!`). It is a
separate bug and is deliberately not addressed here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qswb5qZf7pAyUdHUspspDu)_