### PR TITLE
Write each character value of an implied do loop at its own length

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -3538,6 +3538,7 @@ RUN(NAME implied_do_loops43 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays
 RUN(NAME implied_do_loops44 LABELS gfortran llvm)
 RUN(NAME implied_do_loops45 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME implied_do_loops46 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
+RUN(NAME implied_do_loops47 LABELS gfortran llvm)
 
 RUN(NAME minpack_01 LABELS gfortran llvm_rtlib EXTRAFILES
         minpack_01_module.f90 minpack_01_func.f90)

--- a/integration_tests/implied_do_loops47.f90
+++ b/integration_tests/implied_do_loops47.f90
@@ -1,0 +1,49 @@
+program implied_do_loops47
+implicit none
+integer :: i
+character(len=2) :: fixed(3)
+character(len=:), allocatable :: a, b, c
+character(len=64) :: line
+
+! Every value of an implied do loop must be written at its own length,
+! not padded (or truncated) to the length of one of the other values.
+write(line, '(*(g0))') ('XXXX', 'YYY', 'ZZ', i=1,2)
+if (line /= "XXXXYYYZZXXXXYYYZZ") error stop "literals, longest first"
+
+write(line, '(*(g0))') ('ZZ', 'YYY', 'XXXX', i=1,2)
+if (line /= "ZZYYYXXXXZZYYYXXXX") error stop "literals, shortest first"
+
+a = 'XXXX'
+b = 'YYY'
+c = 'ZZ'
+write(line, '(*(g0))') (a, b, c, i=1,2)
+if (line /= "XXXXYYYZZXXXXYYYZZ") error stop "deferred length, longest first"
+
+write(line, '(*(g0))') (c, b, a, i=1,2)
+if (line /= "ZZYYYXXXXZZYYYXXXX") error stop "deferred length, shortest first"
+
+! A value list of one and the same length must keep on working
+fixed(1) = 'ab'
+fixed(2) = 'cd'
+fixed(3) = 'ef'
+write(line, '(*(g0))') (fixed(i), fixed(i), i=1,3)
+if (line /= "ababcdcdefef") error stop "equal lengths"
+
+! Values of other types in the list must not disturb the character values
+write(line, '(*(g0))') ('XXXX', 'YYY', 'ZZ', 7, i=1,2)
+if (line /= "XXXXYYYZZ7XXXXYYYZZ7") error stop "mixed with an integer"
+
+! An explicit edit descriptor per value keeps its own width
+write(line, '(a4,a3,a2)') ('XXXX', 'YYY', 'ZZ', i=1,1)
+if (line /= "XXXXYYYZZ") error stop "explicit format"
+
+! Values outside the implied do loop are written along with it
+write(line, '(*(g0))') 'pre', ('XXXX', 'YYY', 'ZZ', i=1,2), 'post'
+if (line /= "preXXXXYYYZZXXXXYYYZZpost") error stop "sibling values"
+
+! List directed output writes the values at their own length as well
+write(line, *) ('XXXX', 'YYY', 'ZZ', i=1,2)
+if (adjustl(line) /= "XXXXYYYZZXXXXYYYZZ") error stop "list directed"
+
+print *, "ok"
+end program implied_do_loops47

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -2704,10 +2704,14 @@ public:
             a_fmt_constant = ASRUtils::EXPR(ASR::make_StringConstant_t(
                 al, a_fmt->base.loc, s2c(al, format_statements[label]), a_fmt_type));
         }
-        // Don't use stringFormat with single character argument
+        // Don't use stringFormat with single character argument. An implied
+        // do loop is a list of output items rather than a single character
+        // value, even when all its items happen to be of character type, so
+        // it is excluded here and wrapped in a StringFormat below.
         if (!a_fmt
             && _type == AST::decl_stmtType::Write
             && a_values_vec.size() == 1
+            && !ASR::is_a<ASR::ImpliedDoLoop_t>(*a_values_vec[0])
             && ASR::is_a<ASR::String_t>(*ASRUtils::expr_type(a_values_vec[0]))){
             tmp = ASR::make_FileWrite_t(al, loc, m_label, a_unit,
             a_iomsg, a_iostat, a_id, a_values_vec.p,

--- a/src/libasr/pass/implied_do_loops.cpp
+++ b/src/libasr/pass/implied_do_loops.cpp
@@ -987,6 +987,49 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
             return false;
         }
 
+        // Check if the values of an implied do loop hold character values that
+        // do not all share one and the same compile time length. Such a loop
+        // must not be gathered into a temporary array: an array has a single
+        // element length, so every character value would be padded (or
+        // truncated) to it. Each value has to be emitted at its own length
+        // instead.
+        bool implied_do_loop_has_varying_string_length(ASR::ImpliedDoLoop_t* idl) {
+            size_t string_values = 0;
+            int64_t common_len = -1;
+            bool has_runtime_len = false;
+            for (size_t i = 0; i < idl->n_values; i++) {
+                ASR::expr_t* value = idl->m_values[i];
+                if (ASR::is_a<ASR::ImpliedDoLoop_t>(*value)) {
+                    // A nested loop carries its own values, leave it alone.
+                    return false;
+                }
+                ASR::ttype_t* value_type = ASRUtils::extract_type(
+                    ASRUtils::expr_type(value));
+                if (!ASR::is_a<ASR::String_t>(*value_type)) {
+                    continue;
+                }
+                string_values += 1;
+                ASR::expr_t* len = ASR::down_cast<ASR::String_t>(value_type)->m_len;
+                int64_t len_value = -1;
+                if (len == nullptr ||
+                    !ASRUtils::extract_value(ASRUtils::expr_value(len), len_value)) {
+                    has_runtime_len = true;
+                    continue;
+                }
+                if (common_len == -1) {
+                    common_len = len_value;
+                } else if (common_len != len_value) {
+                    return true;
+                }
+            }
+            if (string_values < 2) {
+                return false;
+            }
+            // A length known only at runtime cannot be shown to agree with the
+            // lengths of the other values.
+            return has_runtime_len;
+        }
+
         void transform_stmts(ASR::stmt_t **&m_body, size_t &n_body) {
             Vec<ASR::stmt_t*> body;
             body.reserve(al, n_body);
@@ -1367,6 +1410,30 @@ class ArrayConstantVisitor : public ASR::CallReplacerOnExpressionsVisitor<ArrayC
                 ASR::expr_t* value = x.m_args[i];
                 if (ASR::is_a<ASR::ImpliedDoLoop_t>(*value)) {
                     ASR::ImpliedDoLoop_t* implied_do_loop = ASR::down_cast<ASR::ImpliedDoLoop_t>(value);
+                    // Character values of differing lengths cannot share one
+                    // temporary array, so expand the loop and keep every value
+                    // at its own length.
+                    if (implied_do_loop_has_varying_string_length(implied_do_loop)) {
+                        Vec<ASR::expr_t*> expanded_values;
+                        expanded_values.reserve(al, 16);
+                        if (expand_implied_do_loop_flat(implied_do_loop, expanded_values)) {
+                            Vec<ASR::expr_t*> new_args;
+                            new_args.reserve(al, x.n_args + expanded_values.size());
+                            for (size_t j = 0; j < i; j++) {
+                                new_args.push_back(al, x.m_args[j]);
+                            }
+                            for (size_t j = 0; j < expanded_values.size(); j++) {
+                                new_args.push_back(al, expanded_values.p[j]);
+                            }
+                            for (size_t j = i + 1; j < x.n_args; j++) {
+                                new_args.push_back(al, x.m_args[j]);
+                            }
+                            string_format_stmt->m_args = new_args.p;
+                            string_format_stmt->n_args = new_args.size();
+                            i = i + expanded_values.size() - 1;
+                            continue;
+                        }
+                    }
                     // Use do-loop approach ONLY for formatted I/O (not list-directed)
                     // with Tuple types or when values contain StringTrim
                     // (to preserve variable-length trimmed strings instead of storing in fixed-length array)


### PR DESCRIPTION
Fixes #12427

## Summary

An implied do loop in an output list whose values are character values of differing lengths was gathered into a single temporary array. An array has one element length, and it was taken from the first value of the loop, so every value was padded (or truncated) to that one length.

```fortran
program demo_continuation
implicit none
integer :: i
   write(*,'(*(g0))') ('XXXX','YYY','ZZ',i=1,5)
end program demo_continuation
```

| | output |
| --- | --- |
| gfortran 13 | `XXXXYYYZZXXXXYYYZZXXXXYYYZZXXXXYYYZZXXXXYYYZZ` |
| lfortran, main | `XXXXYYY ZZ  XXXXYYY ZZ  XXXXYYY ZZ  XXXXYYY ZZ  XXXXYYY ZZ  ` |
| lfortran, this branch | `XXXXYYYZZXXXXYYYZZXXXXYYYZZXXXXYYYZZXXXXYYYZZ` |

The reporter's follow-up case, where the values are deferred length allocatables and the shortest one comes first, was truncated rather than padded (`(c,b,a,i=1,5)` printed `ZZYYXX...`). It now matches gfortran too.

## Scope

- `src/libasr/pass/implied_do_loops.cpp`: `implied_do_loop_has_varying_string_length()` reports an implied do loop whose values hold character values that cannot be shown to share one compile time length. `visit_StringFormat()` expands such a loop into its individual output items, exactly as it already does for a loop of mixed types, so every value keeps its own length. A loop whose character values all have one and the same constant length is untouched and still uses the temporary array.
- `src/lfortran/semantics/ast_body_visitor.cpp`: a list directed `write` skipped the `StringFormat` wrapper when its single output item was of character type. An implied do loop passed that test, because its ASR type is the type of its first value, so `write(*,*) (a,b,c,i=1,5)` reached the pass as a lone character value. An implied do loop is a list of output items, not a single character value, so it is now excluded from that shortcut and wrapped like any other output list.
- `integration_tests/implied_do_loops47.f90`: new test, registered in `integration_tests/CMakeLists.txt` with labels `gfortran llvm`.

## Verification

Reference compiler for every comparison below is gfortran 13.

New test `integration_tests/implied_do_loops47.f90` writes to an internal file and checks the exact text with `error stop`, so it is backend independent. It covers literals longest first and shortest first, deferred length allocatables in both orders, equal length values (must not regress), a list holding a value of another type, an explicit `(a4,a3,a2)` format, values sitting beside the loop in the same statement, and list directed output.

- On `main` the test does not even compile: `write(line,'(*(g0))') ('XXXX','YYY','ZZ',7,i=1,2)` aborts with `ASR verify pass error [asr.verify.assignment.value_type_matches_target] ... phase=pass pass=implied_do_loops`. With that one line removed it compiles and fails at run time with `ERROR STOP literals, longest first`.
- On this branch it passes, and so does gfortran on the same file.
- `cd integration_tests && ./run_tests.py -j4 -b llvm`: `100% tests passed, 0 tests failed out of 4111` (`implied_do_loops47` included).
- `cd integration_tests && ./run_tests.py -j4 -b gfortran`: `100% tests passed, 0 tests failed out of 4156`.
- `./run_tests.py --no-llvm`: `TESTS PASSED`. `--no-llvm` because this container has LLVM 18 (opaque pointers) while the checked in `llvm-*` reference outputs were generated with an older LLVM, so the LLVM IR text reference tests fail here regardless of any change. This is not a clean full reference run. No `asr` or `run` reference output needed regenerating.

## Rationale

The wrong length is introduced when the loop is lowered, not when it is typed, so the fix is in the implied do loops pass and in the semantic phase that decides how the loop reaches that pass. No backend was touched: codegen keeps lowering exactly what ASR hands it.

The pass already had this exact mechanism for a loop of mixed types and for a loop holding `trim()` calls, both of which cannot live in a fixed length array either. Reusing it keeps one story for the whole class of problem instead of adding a second one.

Falling back on the untouched array path when the loop bounds are not compile time constants is deliberate. The alternative fallback, one write statement per iteration, breaks the record structure (it emits one record per iteration instead of one for the whole statement), which is a pre-existing defect of the mixed type path and is out of scope here. So `write(*,'(*(g0))') ('XXXX','YYY','ZZ',i=1,n)` with a runtime `n` is still padded; it is a remaining limitation of the same lowering, not a regression.

Two things are outside this fix and are left alone: #12666 (invalid map key), and the leading blank that gfortran writes for list directed output and LFortran does not.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qswb5qZf7pAyUdHUspspDu)_