### PR TITLE
Associate a pointer-returning function result instead of copying it

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2820,6 +2820,7 @@ RUN(NAME associate_53 LABELS gfortran llvm)
 RUN(NAME associate_54 LABELS gfortran llvm)
 RUN(NAME associate_55 LABELS gfortran llvm)
 RUN(NAME associate_56 LABELS llvm)
+RUN(NAME associate_57 LABELS gfortran llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_57.f90
+++ b/integration_tests/associate_57.f90
@@ -1,0 +1,42 @@
+module associate_57_mod
+    implicit none
+    real, target :: tgt(2:4) = [20., 30., 40.]
+    integer, target :: scalar_tgt = 7
+contains
+    function f_ptr() result(p)
+        real, pointer :: p(:)
+        p => tgt
+    end function
+
+    function f_scalar_ptr() result(p)
+        integer, pointer :: p
+        p => scalar_tgt
+    end function
+end module
+
+program associate_57
+    use associate_57_mod
+    implicit none
+
+    associate (fp => f_ptr())
+        if (size(fp) /= 3) error stop
+        if (abs(fp(lbound(fp,1)) - 20.) > 1e-6) error stop
+        if (abs(sum(fp) - 90.) > 1e-6) error stop
+    end associate
+
+    associate (sp => f_scalar_ptr())
+        if (sp /= 7) error stop
+    end associate
+
+    call contained_case()
+
+contains
+
+    subroutine contained_case()
+        associate (fp => f_ptr())
+            if (size(fp) /= 3) error stop
+            if (abs(sum(fp) - 90.) > 1e-6) error stop
+        end associate
+    end subroutine
+
+end program

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3239,6 +3239,13 @@ public:
                 create_associate_stmt = true;
             } else if (ASR::is_a<ASR::ArrayReshape_t>(*tmp_expr)) {
                 create_associate_stmt = true;
+            } else if (ASR::is_a<ASR::FunctionCall_t>(*tmp_expr) &&
+                       ASRUtils::is_pointer(tmp_type)) {
+                // A reference to a function with a data pointer result is a
+                // variable, so the associate name must be associated with the
+                // target the pointer refers to instead of being assigned a
+                // copy of its value.
+                create_associate_stmt = true;
             }
 
             if ( create_associate_stmt && !ASR::is_a<ASR::Pointer_t>(*tmp_type) ) {


### PR DESCRIPTION
## Summary

Fixes #12674 — the compiler crashed while compiling an `ASSOCIATE` construct whose selector is a reference to a function with a data pointer result:

```fortran
associate (fp => f_ptr())   ! f_ptr() has a `real, pointer :: p(:)` result
```

In `visit_AssociateBlock` such a selector fell through every designator case and was treated as a plain value expression. Its type is `Pointer(Array(real, :))`; since the deferred-shape array has empty dimensions, the associating entity's type was then wrapped in `Allocatable`, yielding an invalid `Allocatable(Pointer(...))` type.

- Debug build (assertions on): `ASR verify pass error: Allocatable type conflicts with Pointer type`
- Release build (0.62.0, as reported): segmentation fault

Per F2018 a function reference with a data pointer result is a *variable*, so the associate name must be associated with the pointer target rather than assigned a copy. The fix emits an `Associate` statement for it — exactly the ASR that a pointer assignment `p => f_ptr()` already produces and that codegen already handles — leaving the entity's `Pointer` type intact.

## Scope

One change, in AST→ASR semantics (`src/lfortran/semantics/ast_body_visitor.cpp`), plus one integration test. The bug was that semantics produced invalid ASR, so the fix belongs there; no backend or ASR-pass change was needed.

The new branch is deliberately narrow (`FunctionCall` with a pointer result). A broader "any pointer-typed selector" condition regressed `gpu_metal_165`, where `associate(nv => v * 2.0)` has a pointer-typed binary operation as selector — that a `RealBinOp` carries a `Pointer` type at all is a separate pre-existing issue and is not touched here.

Two nearby behaviours are intentionally left alone as separate issues:

- `lbound(f_ptr())` returns `2` (the target's bound) where the standard and GFortran give `1`, because a function reference is not a whole array. This is pre-existing and reproduces without `ASSOCIATE`, so the integration test does not assert `lbound` on the associate name.
- Definability of an associate name (#12687 / #12694). With this change writing through `fp` does correctly reach the pointer target, but the test does not exercise it since GFortran 13 rejects that write.

## Verification

Before (unmodified `main`, Debug build), both reproducers from the issue:

```
ASR verify pass error: Allocatable type conflicts with Pointer type
  --> re_issue_12674.f90:21:35
21 |   associate (fv => f_val(), fp => f_ptr())
   |                                   ^^^^^^^ failed here
```

After: both compile and run; the write through `fp` reaches `tgt`:

```
lbound(f_val())     = 1
tgt after write via fp = -20.0000000 30.0000000 40.0000000
```

New test `integration_tests/associate_57.f90` (registered in `integration_tests/CMakeLists.txt` with labels `gfortran llvm`):

- On `main`: fails to compile — `semantic error: Input to 'Sum' is expected to be numeric, but got real[:] pointer allocatable`
- On this branch: passes under both `-b llvm` and `-b gfortran`
- Compiles and runs clean under GFortran 13.3.0 directly

Suites (Debug build, LLVM 18):

- `cd integration_tests && ./run_tests.py -j4 -b llvm` — 100% tests passed, 0 failed out of 4111
- `cd integration_tests && ./run_tests.py -j4 -b gfortran` — 100% tests passed, 0 failed out of 4156
- `./run_tests.py --no-llvm` — TESTS PASSED

Note on `--no-llvm`: this container has LLVM 18 (opaque pointers) while the checked-in `llvm-*` reference outputs were generated with an older LLVM, so the LLVM-IR-text reference tests mismatch here independently of this change. The reference run above therefore excludes them; it is not a clean *full* reference run.

## Rationale

ASR is the semantic contract, and `Allocatable(Pointer(...))` is not a valid type — the verifier says so explicitly. The invalid node was constructed in AST→ASR, so that is where it is fixed; no workaround is added downstream. Re-using the existing `Associate` path also means the pointer-result case now lowers through code that pointer assignment already exercises, rather than through a new special case.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qswb5qZf7pAyUdHUspspDu)_