### PR TITLE
fix: build COMPILE tests as custom targets, not object libraries

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -344,12 +344,12 @@ macro(COMPILE)
             add_custom_command(
                 OUTPUT ${name}_lfortran.mod
                 COMMAND lfortran -c ${CMAKE_CURRENT_SOURCE_DIR}/${name}.f90)
-            add_library(${name}_lfortran OBJECT ${name}_lfortran.mod)
+            add_custom_target(${name}_lfortran ALL DEPENDS ${name}_lfortran.mod)
         elseif(compiler STREQUAL "gfortran" AND ${LFORTRAN_BACKEND} STREQUAL "no")
             add_custom_command(
                 OUTPUT ${name}_gfortran.mod
                 COMMAND gfortran -c ${CMAKE_CURRENT_SOURCE_DIR}/${name}.f90)
-            add_library(${name}_gfortran OBJECT ${name}_gfortran.mod)
+            add_custom_target(${name}_gfortran ALL DEPENDS ${name}_gfortran.mod)
         endif()
     endforeach()
 endmacro(COMPILE)


### PR DESCRIPTION
## Summary

`./run_tests.py -b llvm` and `./run_tests.py -b gfortran` currently fail to
configure on `main`. The `COMPILE` macro in `integration_tests/CMakeLists.txt`
declares a compile-only test as

```cmake
add_library(${name}_${compiler} OBJECT ${name}_${compiler}.mod)
```

A `.mod` file is not a source CMake knows a language for, so the target has no
linker language and CMake aborts at generate time:

```
CMake Error: CMake can not determine linker language for target:
character_len_of_function_12614_lfortran
```

Because it fails during generate, the whole configure aborts and no test runs
at all.

The macro only ever wanted to assert that the file compiles. That is what a
custom target depending on the custom command's output says, so this switches
`add_library(... OBJECT ...)` to `add_custom_target(... ALL DEPENDS ...)`.

## Scope

Three `COMPILE(...)` entries are affected:

- `assumed_rank_12` (line 975) and `string_30` (line 2882) — broke the
  `gfortran` backend
- `character_len_of_function_12614` (line 3009), added in #12615 — extended the
  breakage to the `llvm` backend, which `ci/test.sh` runs

## Verification

CMake 3.29.1, the version pinned in `ci/environment.yml`.

Before, on `main`:

```
$ cd integration_tests && ./run_tests.py -j16 -b llvm
CMake Error: CMake can not determine linker language for target:
character_len_of_function_12614_lfortran
CMake Generate step failed.  Build files cannot be regenerated correctly.
Command failed.

$ ./run_tests.py -j16 -b gfortran
CMake Error: CMake can not determine linker language for target: assumed_rank_12_gfortran
CMake Error: CMake can not determine linker language for target: string_30_gfortran
CMake Error: CMake can not determine linker language for target: character_len_of_function_12614_gfortran
```

After, on this branch:

```
$ cd integration_tests && ./run_tests.py -j16 -b llvm
100% tests passed, 0 tests failed out of 4118
```

The `gfortran` backend now configures and builds past those three targets. It
still stops later at `pdt_16.f90`, which GFortran 16.1.0 rejects with
"Component initializer without name after component named expected" — a
separate, pre-existing issue with that test source and a newer GFortran,
untouched by this change.

`metal` (338/338) and `cuda_cpu` (338/338) are unaffected: the `lfortran`
branch of the macro only fires for `LFORTRAN_BACKEND == "llvm"` and the
`gfortran` branch only for `LFORTRAN_BACKEND == "no"`.

## Rationale

`add_library(OBJECT)` on a generated `.mod` was never meaningful — there is no
object file to produce and nothing links the result. `add_custom_target(ALL
DEPENDS ...)` expresses the actual intent, "run this compile as part of the
default build and fail if it does not succeed", and carries no linker language
requirement.