### PR TITLE
Keep implicit interface stable across repeated references

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2239,6 +2239,7 @@ RUN(NAME implicit_interface_63 LABELS gfortran llvm EXTRA_ARGS --implicit-interf
     EXTRAFILES implicit_interface_63b.f90)
 RUN(NAME implicit_interface_64 LABELS gfortran llvm EXTRA_ARGS --implicit-interface
     EXTRAFILES implicit_interface_64b.f90)
+RUN(NAME implicit_interface_65 LABELS gfortran llvm EXTRA_ARGS --implicit-interface)
 
 RUN(NAME implicit_typing_01 LABELS gfortran llvmImplicit)
 RUN(NAME implicit_typing_02 LABELS gfortran llvmImplicit)

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -4394,6 +4394,7 @@ RUN(NAME transfer_28 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
 RUN(NAME transfer_29 LABELS gfortran llvm)
 RUN(NAME transfer_30 LABELS gfortran llvm)
 RUN(NAME transfer_31 LABELS gfortran llvm EXTRA_ARGS --realloc-lhs-arrays)
+RUN(NAME transfer_32 LABELS gfortran llvm)
 RUN(NAME transfer_assumed_shape_01 LABELS gfortran llvm)
 
 RUN(NAME present_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/implicit_interface_65.f90
+++ b/integration_tests/implicit_interface_65.f90
@@ -1,0 +1,49 @@
+! A procedure declared `external` in the specification part of a module and
+! referenced more than once from the same module procedure. Every reference
+! re-derives the implicit interface, and the derived symbol must stay the one
+! the earlier references already point at.
+module implicit_interface_65_mod
+    implicit none
+    private
+    integer, external :: scale_by_two
+    public :: twice_scaled, thrice_scaled
+contains
+
+    integer function twice_scaled(n)
+        integer, intent(in) :: n
+        twice_scaled = scale_by_two(n)
+        twice_scaled = twice_scaled + scale_by_two(n + 1)
+    end function twice_scaled
+
+    integer function thrice_scaled(n)
+        integer, intent(in) :: n
+        integer :: acc
+        acc = scale_by_two(n)
+        acc = acc + scale_by_two(n + 1)
+        acc = acc + scale_by_two(n + 2)
+        thrice_scaled = acc
+    end function thrice_scaled
+
+end module implicit_interface_65_mod
+
+integer function scale_by_two(k)
+    implicit none
+    integer :: k
+    scale_by_two = 2*k
+end function scale_by_two
+
+program implicit_interface_65
+    use implicit_interface_65_mod, only: twice_scaled, thrice_scaled
+    implicit none
+    integer :: r
+
+    r = twice_scaled(3)
+    print *, r
+    if (r /= 14) error stop
+
+    r = thrice_scaled(3)
+    print *, r
+    if (r /= 24) error stop
+
+    print *, "OK"
+end program implicit_interface_65

--- a/integration_tests/transfer_32.f90
+++ b/integration_tests/transfer_32.f90
@@ -1,0 +1,61 @@
+program transfer_32
+! transfer() with CHARACTER on the array side: the byte offset of a result
+! element inside the source is not an element index of the source, so the
+! result must not be computed element by element from byte 0.
+implicit none
+integer :: a(3), b(3), i
+integer, allocatable :: c(:)
+character(12) :: buf
+character(1) :: c1(12)
+character(4) :: c4(3)
+
+a = [11, 22, 33]
+
+! integer array -> character scalar
+buf = transfer(a, buf)
+do i = 1, 3
+    if (iachar(buf(4*i-3:4*i-3)) /= a(i)) error stop "int array -> char scalar"
+    if (iachar(buf(4*i-2:4*i-2)) /= 0) error stop "int array -> char scalar pad"
+end do
+
+! character scalar -> integer array
+b = 0
+b = transfer(buf, b)
+if (any(b /= a)) error stop "char scalar -> int array"
+
+! character scalar -> integer array, with SIZE=
+b = 0
+b = transfer(buf, b, 3)
+if (any(b /= a)) error stop "char scalar -> int array with size"
+
+! character scalar -> allocatable integer array
+allocate(c(3))
+c = 0
+c = transfer(buf, c)
+if (any(c /= a)) error stop "char scalar -> allocatable int array"
+deallocate(c)
+
+! integer array -> character(1) array mold
+c1 = achar(7)
+c1 = transfer(a, c1)
+do i = 1, 3
+    if (iachar(c1(4*i-3)) /= a(i)) error stop "int array -> char(1) array"
+    if (iachar(c1(4*i-2)) /= 0) error stop "int array -> char(1) array pad"
+end do
+
+! integer array -> character(1) array mold, with SIZE=
+c1 = achar(7)
+c1 = transfer(a, c1, 12)
+do i = 1, 3
+    if (iachar(c1(4*i-3)) /= a(i)) error stop "int array -> char(1) array size"
+end do
+
+! integer array -> character(4) array mold, and back again
+c4 = "    "
+c4 = transfer(a, c4)
+do i = 1, 3
+    if (transfer(c4(i), 0) /= a(i)) error stop "int array -> char(4) array"
+end do
+
+print *, b, iachar(c1(1)), iachar(c1(5)), iachar(c1(9))
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -18296,28 +18296,39 @@ public:
                 // Which is a function call.
                 // We remove "x" from the symbol table and instead recreate it.
                 // We use the type of the old "x" as the return value type.
-                std::map<std::string, ASR::symbol_t*> scope_ = current_scope->get_scope();
-                bool in_current_scope = (scope_.find(var_name) != scope_.end());
-                SymbolTable* sym_scope = current_scope;
-                if (in_current_scope) {
-                    current_scope->erase_symbol(var_name);
-                } else {
-                    ASR::symbol_t* sym_ = current_scope->get_symbol(var_name);
-                    while(!sym_) {
-                        sym_scope = sym_scope->parent;
-                        sym_ = sym_scope->get_symbol(var_name);
+                // A second reference to the same external in this scope already
+                // resolves to the Interface synthesized for the first one, and
+                // `create_implicit_interface_function` above has reconciled
+                // this reference with it. Re-deriving it here would erase that
+                // symbol and put a fresh one in its place, leaving the earlier
+                // FunctionCall pointing outside the symbol table.
+                bool already_synthesized_here =
+                    current_scope->get_symbol(var_name) == v &&
+                    is_synthesized_implicit_interface(v);
+                if (!already_synthesized_here) {
+                    std::map<std::string, ASR::symbol_t*> scope_ = current_scope->get_scope();
+                    bool in_current_scope = (scope_.find(var_name) != scope_.end());
+                    SymbolTable* sym_scope = current_scope;
+                    if (in_current_scope) {
+                        current_scope->erase_symbol(var_name);
+                    } else {
+                        ASR::symbol_t* sym_ = current_scope->get_symbol(var_name);
+                        while(!sym_) {
+                            sym_scope = sym_scope->parent;
+                            sym_ = sym_scope->get_symbol(var_name);
+                        }
                     }
-                }
-                ASR::ttype_t* old_type = ASRUtils::symbol_type(v);
-                create_implicit_interface_function(x, var_name, true, old_type);
-                v = current_scope->resolve_symbol(var_name);
-                LCOMPILERS_ASSERT(v!=nullptr);
-                if (!in_current_scope && is_external_procedure) {
-                    SymbolTable* temp_scope = current_scope;
-                    current_scope = sym_scope;
+                    ASR::ttype_t* old_type = ASRUtils::symbol_type(v);
                     create_implicit_interface_function(x, var_name, true, old_type);
-                    current_scope = temp_scope;
-                    LCOMPILERS_ASSERT(sym_scope->resolve_symbol(var_name)!=nullptr);
+                    v = current_scope->resolve_symbol(var_name);
+                    LCOMPILERS_ASSERT(v!=nullptr);
+                    if (!in_current_scope && is_external_procedure) {
+                        SymbolTable* temp_scope = current_scope;
+                        current_scope = sym_scope;
+                        create_implicit_interface_function(x, var_name, true, old_type);
+                        current_scope = temp_scope;
+                        LCOMPILERS_ASSERT(sym_scope->resolve_symbol(var_name)!=nullptr);
+                    }
                 }
 
                 // erase from external_procedures_mapping

--- a/src/libasr/codegen/asr_to_llvm.cpp
+++ b/src/libasr/codegen/asr_to_llvm.cpp
@@ -11209,44 +11209,8 @@ public:
         DeallocateStringsScope _scope(this);
         if (compiler_options.emit_debug_info) debug_emit_loc(x);
 
-        // Special-case: transfer(character, int8_array, size) lowered as BitCast.
-        // When scalarized into element-wise assignments, extract the corresponding
-        // byte from the source string.
         if (ASR::is_a<ASR::BitCast_t>(*x.m_value)) {
             ASR::BitCast_t* bc = ASR::down_cast<ASR::BitCast_t>(x.m_value);
-            if (ASR::is_a<ASR::ArrayItem_t>(*x.m_target) &&
-                ASRUtils::is_integer(*ASRUtils::expr_type(x.m_target)) &&
-                ASR::down_cast<ASR::Integer_t>(ASRUtils::expr_type(x.m_target))->m_kind == 1 &&
-                ASRUtils::is_string_only(ASRUtils::expr_type(bc->m_source))) {
-                ASR::ArrayItem_t* ai = ASR::down_cast<ASR::ArrayItem_t>(x.m_target);
-                if (ai->n_args == 1 && ai->m_args[0].m_right) {
-                    bool is_assignment_target_copy = is_assignment_target;
-                    is_assignment_target = true;
-                    visit_expr(*x.m_target);
-                    is_assignment_target = is_assignment_target_copy;
-                    llvm::Value* dest_ptr = builder->CreateBitCast(tmp, llvm_utils->i8_ptr);
-
-                    int64_t ptr_loads_copy = ptr_loads;
-                    ptr_loads = 0;
-                    visit_expr_wrapper(bc->m_source, true);
-                    ptr_loads = ptr_loads_copy;
-                    llvm::Value* src_desc = tmp;
-                    llvm::Value* src_data = llvm_utils->get_string_data(
-                        ASRUtils::get_string_type(bc->m_source), src_desc);
-                    src_data = builder->CreateBitCast(src_data, llvm_utils->i8_ptr);
-
-                    visit_expr_wrapper(ai->m_args[0].m_right, true);
-                    llvm::Value* idx = tmp;
-                    idx = builder->CreateZExtOrTrunc(idx, llvm::Type::getInt64Ty(context));
-                    llvm::Value* zero_based = builder->CreateSub(idx, llvm::ConstantInt::get(idx->getType(), 1));
-                    llvm::Value* src_byte_ptr = builder->CreateGEP(
-                        llvm::Type::getInt8Ty(context), src_data, zero_based);
-                    llvm::Value* byte_val = llvm_utils->CreateLoad2(
-                        llvm::Type::getInt8Ty(context), src_byte_ptr);
-                    builder->CreateStore(byte_val, dest_ptr);
-                    return;
-                }
-            }
 
             ASR::ttype_t* target_type = ASRUtils::expr_type(x.m_target);
             ASR::ttype_t* target_type_past_alloc =

--- a/src/libasr/pass/array_op.cpp
+++ b/src/libasr/pass/array_op.cpp
@@ -1827,6 +1827,201 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
         }
     }
 
+    // Size in bytes of one element of `elem_type`, or -1 when it is not
+    // known at compile time.
+    int64_t get_element_byte_size(ASR::ttype_t* elem_type) {
+        if( ASR::is_a<ASR::String_t>(*elem_type) ) {
+            int64_t len = -1;
+            if( !ASRUtils::extract_value(
+                    ASR::down_cast<ASR::String_t>(elem_type)->m_len, len) ) {
+                return -1;
+            }
+            return len;
+        }
+        int64_t nbytes = ASRUtils::get_type_byte_size(elem_type);
+        return nbytes > 0 ? nbytes : -1;
+    }
+
+    // `transfer()` with CHARACTER on the array side cannot be scalarised into
+    // an element-wise loop. The bytes of result element `i` start at byte
+    // `i * storage_size(mold)/8` of the source, an offset that is not
+    // expressible as an element index of the source, so an element-wise loop
+    // would bit-cast every element from byte 0 of the source (and, for a
+    // CHARACTER result, hand the backend a whole-array source it cannot
+    // lower at all).
+    //
+    // Lower such an assignment into a loop over the result elements that
+    // slices a CHARACTER buffer holding the source bytes, one slice of
+    // `elem_bytes` characters per element. Returns false when the assignment
+    // is not of a shape handled here, and the caller then falls back to the
+    // generic lowering.
+    bool lower_character_bitcast(const ASR::Assignment_t& x,
+            ASR::BitCast_t* bc, const Location& loc) {
+        ASR::expr_t* target = ASRUtils::get_past_array_physical_cast(
+            const_cast<ASR::expr_t*>(x.m_target));
+        if( !ASR::is_a<ASR::Var_t>(*target) &&
+            !ASR::is_a<ASR::StructInstanceMember_t>(*target) ) {
+            return false;
+        }
+        ASR::ttype_t* target_type = ASRUtils::type_get_past_allocatable_pointer(
+            ASRUtils::expr_type(target));
+        if( !ASRUtils::is_array(target_type) ||
+            ASRUtils::extract_n_dims_from_ttype(target_type) != 1 ) {
+            return false;
+        }
+        ASR::ttype_t* source_type = ASRUtils::expr_type(bc->m_source);
+        bool source_is_string = ASRUtils::is_string_only(source_type);
+        ASR::ttype_t* elem_type = ASRUtils::extract_type(target_type);
+        bool target_is_string = ASR::is_a<ASR::String_t>(*elem_type);
+        if( !source_is_string && !target_is_string ) {
+            return false;
+        }
+        // Only default character kind can be sliced byte by byte.
+        if( (source_is_string &&
+             ASRUtils::extract_kind_from_ttype_t(source_type) != 1) ||
+            (target_is_string &&
+             ASRUtils::extract_kind_from_ttype_t(elem_type) != 1) ) {
+            return false;
+        }
+        int64_t elem_bytes = get_element_byte_size(elem_type);
+        if( elem_bytes <= 0 ) {
+            return false;
+        }
+
+        ASRUtils::ASRBuilder b(al, loc);
+        ASR::expr_t* buffer = nullptr;
+        if( source_is_string ) {
+            buffer = bc->m_source;
+        } else {
+            // Materialise the source bytes into a CHARACTER buffer first;
+            // `buffer = transfer(source, buffer)` with a scalar CHARACTER
+            // result is already a plain byte copy in the backend.
+            int64_t n_elems = -1;
+            if( bc->m_size && ASRUtils::expr_value(bc->m_size) ) {
+                ASRUtils::extract_value(ASRUtils::expr_value(bc->m_size), n_elems);
+            }
+            if( n_elems <= 0 ) {
+                n_elems = ASRUtils::get_fixed_size_of_array(bc->m_type);
+            }
+            if( n_elems <= 0 ) {
+                n_elems = ASRUtils::get_fixed_size_of_array(target_type);
+            }
+            if( n_elems <= 0 ) {
+                return false;
+            }
+            ASR::ttype_t* buffer_type = b.String(b.i32(n_elems * elem_bytes),
+                ASR::string_length_kindType::ExpressionLength,
+                ASR::string_physical_typeType::DescriptorString, 1);
+            std::string buffer_name = current_scope->get_unique_name(
+                "__libasr_bitcast_buf_");
+            ASR::symbol_t* buffer_sym = ASR::down_cast<ASR::symbol_t>(
+                ASRUtils::make_Variable_t_util(
+                    al, loc, current_scope, s2c(al, buffer_name), nullptr, 0,
+                    ASR::intentType::Local, nullptr, nullptr,
+                    ASR::storage_typeType::Default, buffer_type, nullptr,
+                    ASR::abiType::Source, ASR::accessType::Public,
+                    ASR::presenceType::Required, false));
+            current_scope->add_symbol(buffer_name, buffer_sym);
+            buffer = ASRUtils::EXPR(ASR::make_Var_t(al, loc, buffer_sym));
+            ASR::expr_t* buffer_value = ASRUtils::EXPR(ASR::make_BitCast_t(
+                al, loc, bc->m_source, buffer, nullptr, buffer_type, nullptr));
+            pass_result.push_back(al, ASRUtils::STMT(
+                ASRUtils::make_Assignment_t_util(al, loc, buffer, buffer_value,
+                    nullptr, false, false)));
+        }
+
+        int index_kind = get_index_kind();
+        ASR::ttype_t* index_type = get_index_type(loc);
+        std::string index_name = current_scope->get_unique_name(
+            "__libasr_index_0_");
+        ASR::symbol_t* index_sym = ASR::down_cast<ASR::symbol_t>(
+            ASRUtils::make_Variable_t_util(
+                al, loc, current_scope, s2c(al, index_name), nullptr, 0,
+                ASR::intentType::Local, nullptr, nullptr,
+                ASR::storage_typeType::Default, index_type, nullptr,
+                ASR::abiType::Source, ASR::accessType::Public,
+                ASR::presenceType::Required, false));
+        current_scope->add_symbol(index_name, index_sym);
+        ASR::expr_t* index = ASRUtils::EXPR(ASR::make_Var_t(al, loc, index_sym));
+
+        ASRUtils::ExprStmtDuplicator duplicator(al);
+        // start = (index - lbound(target, 1)) * elem_bytes + 1
+        ASR::expr_t* offset = b.Mul(
+            b.Sub(index, PassUtils::get_bound(
+                    duplicator.duplicate_expr(target), 1, "lbound", al, index_kind)),
+            b.i_t(elem_bytes, index_type));
+        ASR::expr_t* start = b.Add(offset, b.i_t(1, index_type));
+        ASR::expr_t* end = b.Add(duplicator.duplicate_expr(start),
+            b.i_t(elem_bytes - 1, index_type));
+        ASR::ttype_t* section_type = b.String(b.i32(elem_bytes),
+            ASR::string_length_kindType::ExpressionLength,
+            ASR::string_physical_typeType::DescriptorString, 1);
+        ASR::expr_t* section = ASRUtils::EXPR(ASR::make_StringSection_t(
+            al, loc, buffer, start, end, b.i_t(1, index_type),
+            section_type, nullptr));
+
+        Vec<ASR::array_index_t> indices;
+        indices.reserve(al, 1);
+        ASR::array_index_t array_index;
+        array_index.loc = loc;
+        array_index.m_left = nullptr;
+        array_index.m_right = index;
+        array_index.m_step = nullptr;
+        indices.push_back(al, array_index);
+        ASR::expr_t* target_item = ASRUtils::EXPR(
+            ASRUtils::make_ArrayItem_t_util(al, loc,
+                duplicator.duplicate_expr(target), indices.p, indices.size(),
+                elem_type, ASR::arraystorageType::ColMajor, nullptr));
+
+        ASR::expr_t* value = section;
+        if( !target_is_string ) {
+            value = ASRUtils::EXPR(ASR::make_BitCast_t(al, loc, section,
+                duplicator.duplicate_expr(target_item), nullptr, elem_type,
+                nullptr));
+        }
+
+        Vec<ASR::stmt_t*> body;
+        body.reserve(al, 1);
+        ASR::stmt_t* assign = ASRUtils::STMT(ASRUtils::make_Assignment_t_util(
+            al, loc, target_item, value, nullptr, false, false));
+        // The standard leaves the trailing part of the result undefined when
+        // the source is shorter than the result. Skip those elements instead
+        // of slicing past the end of the buffer.
+        int64_t buffer_len = -1;
+        ASR::String_t* buffer_str_type = ASR::down_cast<ASR::String_t>(
+            ASRUtils::type_get_past_allocatable_pointer(
+                ASRUtils::expr_type(buffer)));
+        if( buffer_str_type->m_len ) {
+            ASRUtils::extract_value(
+                ASRUtils::expr_value(buffer_str_type->m_len), buffer_len);
+        }
+        int64_t n_target_elems = ASRUtils::get_fixed_size_of_array(target_type);
+        if( buffer_len < 0 || n_target_elems < 0 ||
+            n_target_elems * elem_bytes > buffer_len ) {
+            Vec<ASR::stmt_t*> if_body;
+            if_body.reserve(al, 1);
+            if_body.push_back(al, assign);
+            ASR::expr_t* buffer_len_expr = ASRUtils::EXPR(ASR::make_StringLen_t(
+                al, loc, duplicator.duplicate_expr(buffer), index_type, nullptr));
+            assign = ASRUtils::STMT(ASR::make_If_t(al, loc, nullptr,
+                b.LtE(duplicator.duplicate_expr(end), buffer_len_expr),
+                if_body.p, if_body.size(), nullptr, 0));
+        }
+        body.push_back(al, assign);
+
+        ASR::do_loop_head_t head;
+        head.loc = loc;
+        head.m_v = index;
+        head.m_start = PassUtils::get_bound(
+            duplicator.duplicate_expr(target), 1, "lbound", al, index_kind);
+        head.m_end = PassUtils::get_bound(
+            duplicator.duplicate_expr(target), 1, "ubound", al, index_kind);
+        head.m_increment = nullptr;
+        pass_result.push_back(al, ASRUtils::STMT(ASR::make_DoLoop_t(
+            al, loc, nullptr, head, body.p, body.size(), nullptr, 0)));
+        return true;
+    }
+
 
     void visit_Assignment(const ASR::Assignment_t& x) {
         // A non-elemental defined assignment is entirely carried out by the
@@ -2059,6 +2254,10 @@ class ArrayOpVisitor: public ASR::CallReplacerOnExpressionsVisitor<ArrayOpVisito
         if (ASR::is_a<ASR::BitCast_t>(*xx.m_value)) {
             ASR::BitCast_t* bc = ASR::down_cast<ASR::BitCast_t>(xx.m_value);
             ASR::ttype_t* src_type = ASRUtils::expr_type(bc->m_source);
+
+            if (lower_character_bitcast(x, bc, loc)) {
+                return;
+            }
 
             if (bc->m_size != nullptr &&
                 ASRUtils::is_array(src_type) &&

--- a/tests/reference/asr-allow_implicit_interface3-7ef92cc.json
+++ b/tests/reference/asr-allow_implicit_interface3-7ef92cc.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-allow_implicit_interface3-7ef92cc.stdout",
-    "stdout_hash": "c72f101b7729dfa2977797836b45f490813c83b44475b80122ec65dd",
+    "stdout_hash": "fe35957eb335e54733899ecd35dc641cfbeae0a7f2cabcf65fd464dc",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-allow_implicit_interface3-7ef92cc.stdout
+++ b/tests/reference/asr-allow_implicit_interface3-7ef92cc.stdout
@@ -34,11 +34,11 @@
                             lsame:
                                 (Function
                                     (SymbolTable
-                                        5
+                                        4
                                         {
                                             lsame_arg_0:
                                                 (Variable
-                                                    5
+                                                    4
                                                     lsame_arg_0
                                                     []
                                                     Unspecified
@@ -62,7 +62,7 @@
                                                 ),
                                             lsame_arg_1:
                                                 (Variable
-                                                    5
+                                                    4
                                                     lsame_arg_1
                                                     []
                                                     Unspecified
@@ -86,7 +86,7 @@
                                                 ),
                                             lsame_return_var_name:
                                                 (Variable
-                                                    5
+                                                    4
                                                     lsame_return_var_name
                                                     []
                                                     ReturnVar
@@ -127,10 +127,10 @@
                                         Host
                                     )
                                     []
-                                    [(Var 5 lsame_arg_0)
-                                    (Var 5 lsame_arg_1)]
+                                    [(Var 4 lsame_arg_0)
+                                    (Var 4 lsame_arg_1)]
                                     []
-                                    (Var 5 lsame_return_var_name)
+                                    (Var 4 lsame_return_var_name)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-external3-2aafcb3.json
+++ b/tests/reference/asr-external3-2aafcb3.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external3-2aafcb3.stdout",
-    "stdout_hash": "98fdb7f6c33b54167e8240ab9a0c712c220966350dbcd467400a9578",
+    "stdout_hash": "bccabb0a91094eb71a2cfd7bdaaa29715772fcf32917946203b38f6f",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external3-2aafcb3.stdout
+++ b/tests/reference/asr-external3-2aafcb3.stdout
@@ -58,11 +58,11 @@
                             bcorr:
                                 (Function
                                     (SymbolTable
-                                        5
+                                        4
                                         {
                                             bcorr_arg_0:
                                                 (Variable
-                                                    5
+                                                    4
                                                     bcorr_arg_0
                                                     []
                                                     Unspecified
@@ -86,7 +86,7 @@
                                                 ),
                                             bcorr_arg_1:
                                                 (Variable
-                                                    5
+                                                    4
                                                     bcorr_arg_1
                                                     []
                                                     Unspecified
@@ -110,7 +110,7 @@
                                                 ),
                                             bcorr_return_var_name:
                                                 (Variable
-                                                    5
+                                                    4
                                                     bcorr_return_var_name
                                                     []
                                                     ReturnVar
@@ -151,10 +151,10 @@
                                         Host
                                     )
                                     []
-                                    [(Var 5 bcorr_arg_0)
-                                    (Var 5 bcorr_arg_1)]
+                                    [(Var 4 bcorr_arg_0)
+                                    (Var 4 bcorr_arg_1)]
                                     []
-                                    (Var 5 bcorr_return_var_name)
+                                    (Var 4 bcorr_return_var_name)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-external4-4e8bc7b.json
+++ b/tests/reference/asr-external4-4e8bc7b.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external4-4e8bc7b.stdout",
-    "stdout_hash": "70789b7de6d261d88f92afa752dab01da4068625c1a081a072539382",
+    "stdout_hash": "21bf7c96667bdab7a7a9debbd2693bc0b7df55e136742e8f2addba45",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external4-4e8bc7b.stdout
+++ b/tests/reference/asr-external4-4e8bc7b.stdout
@@ -104,11 +104,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        6
+                                        5
                                         {
                                             f_arg_0:
                                                 (Variable
-                                                    6
+                                                    5
                                                     f_arg_0
                                                     []
                                                     Unspecified
@@ -132,7 +132,7 @@
                                                 ),
                                             f_return_var_name:
                                                 (Variable
-                                                    6
+                                                    5
                                                     f_return_var_name
                                                     []
                                                     ReturnVar
@@ -172,9 +172,9 @@
                                         Host
                                     )
                                     []
-                                    [(Var 6 f_arg_0)]
+                                    [(Var 5 f_arg_0)]
                                     []
-                                    (Var 6 f_return_var_name)
+                                    (Var 5 f_return_var_name)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-external_01-6754623.json
+++ b/tests/reference/asr-external_01-6754623.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external_01-6754623.stdout",
-    "stdout_hash": "b656b804fab53403be0e25e44bdfed218498be1f53194e4602e42d74",
+    "stdout_hash": "41da6e9f31ca0cc61d2db0563f91f5cb51f2803c6e3a2f46602c54c1",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external_01-6754623.stdout
+++ b/tests/reference/asr-external_01-6754623.stdout
@@ -58,11 +58,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        5
+                                        4
                                         {
                                             f_arg_0:
                                                 (Variable
-                                                    5
+                                                    4
                                                     f_arg_0
                                                     []
                                                     Unspecified
@@ -86,7 +86,7 @@
                                                 ),
                                             f_return_var_name:
                                                 (Variable
-                                                    5
+                                                    4
                                                     f_return_var_name
                                                     []
                                                     ReturnVar
@@ -126,9 +126,9 @@
                                         Host
                                     )
                                     []
-                                    [(Var 5 f_arg_0)]
+                                    [(Var 4 f_arg_0)]
                                     []
-                                    (Var 5 f_return_var_name)
+                                    (Var 4 f_return_var_name)
                                     Public
                                     .false.
                                     .false.

--- a/tests/reference/asr-external_03-fe60427.json
+++ b/tests/reference/asr-external_03-fe60427.json
@@ -6,7 +6,7 @@
     "outfile": null,
     "outfile_hash": null,
     "stdout": "asr-external_03-fe60427.stdout",
-    "stdout_hash": "f121e41a30853b7cee08d7cdca253be128abbf76c8003247a3a3b905",
+    "stdout_hash": "347885b7da2d615b6da95c9a5403e1703e50d3474e67ddd62c324d7d",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/asr-external_03-fe60427.stdout
+++ b/tests/reference/asr-external_03-fe60427.stdout
@@ -10,11 +10,11 @@
                             f:
                                 (Function
                                     (SymbolTable
-                                        9
+                                        7
                                         {
                                             f_arg_0:
                                                 (Variable
-                                                    9
+                                                    7
                                                     f_arg_0
                                                     []
                                                     Unspecified
@@ -38,7 +38,7 @@
                                                 ),
                                             f_return_var_name:
                                                 (Variable
-                                                    9
+                                                    7
                                                     f_return_var_name
                                                     []
                                                     ReturnVar
@@ -78,9 +78,9 @@
                                         Host
                                     )
                                     []
-                                    [(Var 9 f_arg_0)]
+                                    [(Var 7 f_arg_0)]
                                     []
-                                    (Var 9 f_return_var_name)
+                                    (Var 7 f_return_var_name)
                                     Public
                                     .false.
                                     .false.


### PR DESCRIPTION
A procedure declared `external` in a module specification part stays listed as an external procedure for every scope below it, so under --implicit-interface each reference from a module procedure re-entered the "turn this variable into a function" path in
`visit_FunctionCallOrArray`. On the second reference that path erased the Interface symbol synthesized for the first one and installed a fresh symbol of the same name, leaving the first FunctionCall pointing at a symbol no longer in the symbol table:

    ASR verify pass error: The symbol table was found and the symbol in
        it shares the name, but is not equal to `sym`
    ASR verify pass error: FunctionCall::m_name `nf_set_chunk_cache`
        cannot point outside of its symbol table

This is how netcdf-fortran's fortran/netcdf4.F90 failed to compile.

Skip the erase-and-recreate when the current scope already holds the symbol the reference resolved to and that symbol is a synthesized implicit interface: `create_implicit_interface_function` has by then already reconciled the reference with it (reusing the signature when it matches, building a cast view when it does not). The containing function's signature update still runs, so nothing else changes.

Reference outputs change only in symbol table numbering, since a throwaway symbol table is no longer created per reference.

Adds integration test implicit_interface_65.