### PR TITLE
gpu: warn where an offloaded loop's stop cannot deliver its stop code

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -5259,6 +5259,7 @@ RUN(NAME gpu_metal_333 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_334 LABELS gfortran llvm metal cuda_cpu EXTRA_ARGS $<$<STREQUAL:${LFORTRAN_BACKEND},metal>:--gpu-allow-cpu-fallback>)
 RUN(NAME gpu_metal_335 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_336 LABELS gfortran llvm metal cuda_cpu)
+RUN(NAME gpu_metal_337 FAIL LABELS gfortran llvm metal cuda_cpu EXTRA_ARGS $<$<STREQUAL:${LFORTRAN_BACKEND},metal>:--gpu-allow-cpu-fallback>)
 RUN(NAME inline_scoped_01 LABELS gfortran llvm EXTRA_ARGS --fast)
 
 RUN(NAME gpu_kernel_source_01 LABELS gfortran llvm)

--- a/integration_tests/gpu_metal_337.f90
+++ b/integration_tests/gpu_metal_337.f90
@@ -1,0 +1,34 @@
+program gpu_metal_337
+  ! Test: an `error stop` in a concurrent body that is actually taken.
+  !
+  ! gpu_metal_334 covers the guard that is never reached, so the trap is
+  ! emitted and never raised. This one raises it: every thread's guard
+  ! holds, so the loop stops wherever it ran. What the test pins down is
+  ! that the program does stop -- it never reaches the print below -- on
+  ! the host, where `error stop 7` is error termination with status 7, and
+  ! on a device, where the trap ends the launch and the status is the
+  ! runtime's rather than the one the statement names.
+  !
+  ! That difference is why the offload pass warns on the statement. The
+  ! test is registered FAIL because the two ways of stopping agree only on
+  ! ending the program without reaching the end of it.
+  !
+  ! It has to be `error stop` and not `stop`: a plain STOP is an image
+  ! control statement, which F2018 11.1.7.5 forbids in a DO CONCURRENT
+  ! construct, and GFortran rejects it. ERROR STOP initiates error
+  ! termination, needs no synchronisation, and is allowed here.
+  implicit none
+
+  integer, parameter :: n = 8
+  integer :: a(n), i
+
+  a = 0
+
+  do concurrent (i = 1:n)
+    a(i) = i * 3
+    if (a(i) > 0) error stop 7
+  end do
+
+  ! Not reached: the loop above stops the program whichever way it ran.
+  print *, "NOT REACHED", sum(a)
+end program gpu_metal_337

--- a/src/libasr/pass/gpu_offload.cpp
+++ b/src/libasr/pass/gpu_offload.cpp
@@ -57,6 +57,22 @@ void GpuOffloadVisitor::report_clause_ignored(
         diag::Level::Warning, diag::Stage::ASRPass);
 }
 
+// A `stop` the device runs as a trap. The loop is offloaded and the
+// statement does halt the launch, which is the part of it a device can
+// honour, but a grid returns no status: the stop code is not delivered and
+// a normal termination cannot be told apart from an error one. The program
+// ends with a failure status either way, so say what was dropped rather
+// than let the difference go unmentioned.
+void GpuOffloadVisitor::report_stop_degraded(
+        const Location &where, const std::string &name) {
+    if (pass_options.diagnostics == nullptr) return;
+    pass_options.diagnostics->message_label(
+        "'" + name + "' in an offloaded loop does not deliver its stop code",
+        {where}, "the device halts the launch here and the program exits "
+            "with a failure status",
+        diag::Level::Warning, diag::Stage::ASRPass);
+}
+
 // What a clause a launch cannot honour is called, or an empty name for
 // one it can.
 std::string GpuOffloadVisitor::unhonoured_clause(

--- a/src/libasr/pass/gpu_offload_launch.cpp
+++ b/src/libasr/pass/gpu_offload_launch.cpp
@@ -4,6 +4,8 @@
 #include <libasr/asr.h>
 #include <libasr/asr_utils.h>
 #include <libasr/containers.h>
+#include <libasr/pass/gpu_offload_collect.h>
+#include <libasr/pass/gpu_offload_preflight.h>
 #include <libasr/pass/gpu_offload_undo.h>
 #include <libasr/pass/gpu_offload_visitor.h>
 #include <libasr/pass/parallel_canonicalize.h>
@@ -26,6 +28,27 @@ void GpuOffloadVisitor::build_kernel_launch(const ASR::OMPRegion_t &region,
         if (!clause_name.empty()) {
             report_clause_ignored(region.m_clauses[i]->base.loc,
                 clause_name);
+        }
+    }
+
+    // A `stop` the kernel runs as a trap is reported for the same reason:
+    // the launch does halt where the program said to halt, but the stop
+    // code and the kind of termination do not survive the crossing. A
+    // device with no trap never gets here -- the loop was declined above
+    // and runs on the host, where the statement means all of what it says.
+    {
+        GpuStopStatementFinder stops;
+        for (size_t i = 0; i < work.n_body; i++) {
+            stops.visit_stmt(*work.body[i]);
+        }
+        for (ASR::Function_t *fn : reachable_routines(work.body,
+                work.n_body)) {
+            for (size_t i = 0; i < fn->n_body; i++) {
+                stops.visit_stmt(*fn->m_body[i]);
+            }
+        }
+        for (auto &stop : stops.stops) {
+            report_stop_degraded(stop.second, stop.first);
         }
     }
 

--- a/src/libasr/pass/gpu_offload_preflight.h
+++ b/src/libasr/pass/gpu_offload_preflight.h
@@ -305,6 +305,33 @@ public:
     }
 };
 
+// Every `stop` and `error stop` a body holds, in the order they are found.
+// A device that can trap runs one of these as a halt of the launch, which
+// is less than the statement asks for: a grid returns no status, so the
+// stop code goes nowhere and normal termination cannot be told apart from
+// error termination. Each one is collected so that what the device drops
+// is said where the statement stands, rather than lowered in silence.
+class GpuStopStatementFinder
+        : public ASRUtils::BlockBodyWalkVisitor<GpuStopStatementFinder> {
+public:
+    // How Fortran spells the statement, and where it is.
+    std::vector<std::pair<std::string, Location>> stops;
+
+    void visit_stmt(const ASR::stmt_t &s) {
+        switch (s.type) {
+            case ASR::stmtType::Stop:
+                stops.push_back({"stop", s.base.loc});
+                break;
+            case ASR::stmtType::ErrorStop:
+                stops.push_back({"error stop", s.base.loc});
+                break;
+            default:
+                break;
+        }
+        ASR::BaseWalkVisitor<GpuStopStatementFinder>::visit_stmt(s);
+    }
+};
+
 // Metal shaders have neither variable-length arrays nor a heap, so a
 // device function (an `inline` callee of a kernel) can only declare
 // locals whose extent the shader compiler can fold to a constant. An

--- a/src/libasr/pass/gpu_offload_visitor.h
+++ b/src/libasr/pass/gpu_offload_visitor.h
@@ -378,6 +378,8 @@ public:
 
     void report_clause_ignored(const Location &where, const std::string &name);
 
+    void report_stop_degraded(const Location &where, const std::string &name);
+
     std::string unhonoured_clause(const ASR::omp_clause_t *clause);
 
     void collect_kernel_arg_names(const ParallelLoopNest &nest,

--- a/src/libasr/runtime/cuda_cpu_device.h
+++ b/src/libasr/runtime/cuda_cpu_device.h
@@ -12,6 +12,7 @@
 // compiles as host C++.
 
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 // Device execution configuration
@@ -52,11 +53,16 @@ void lfortran_gpu_cpu_barrier_unsupported(void);
 #define __shared__ static
 #define __forceinline__ inline
 
-// A trap ends the launch. On a real device the thread raises one and the
-// launch fails; the emulation has one process and no launch to fail, so it
-// ends that instead, which is the same thing seen from the program.
+// A trap ends the launch. On a real device the thread raises one, the
+// launch fails, and `lfortran_gpu_launch` reports the failed synchronize
+// and exits 1. The emulation has one process and no launch to fail, so it
+// ends the process the same way: what a program sees of a trap is a
+// message on stderr and a status of 1, and it should see that here too.
+// Ending with `abort()` instead would raise SIGABRT, which is a different
+// thing for anything watching the process.
 static inline void __trap(void) {
-    abort();
+    fprintf(stderr, "lfortran_gpu_launch: kernel trapped\n");
+    exit(1);
 }
 
 // A barrier is only correct when the threads of one block really do run

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_288-44fa74d.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_288-44fa74d.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "gpu_cuda_kernel-gpu_metal_288-44fa74d.stdout",
     "stdout_hash": "a3dd756fed3112a8834c936bef46f62e15c25d506e00d5cee883163d",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "gpu_cuda_kernel-gpu_metal_288-44fa74d.stderr",
+    "stderr_hash": "30448a89bd0b48f5b96799c5f8d98d157b342844237500866b0ecc44",
     "returncode": 0
 }

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_288-44fa74d.stderr
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_288-44fa74d.stderr
@@ -1,0 +1,5 @@
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_288.f90:26:16
+   |
+26 |     if (i < 0) error stop "unreachable"
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_298-e543a30.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_298-e543a30.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "gpu_cuda_kernel-gpu_metal_298-e543a30.stdout",
     "stdout_hash": "b101dacfd6d0363cf17a09171574ed88c65f6f25124c1679991b1593",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "gpu_cuda_kernel-gpu_metal_298-e543a30.stderr",
+    "stderr_hash": "00bbf969a7445f583e9f00f2ba5f48f7495b1e910238b8d31f8bf1a8",
     "returncode": 0
 }

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_298-e543a30.stderr
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_298-e543a30.stderr
@@ -1,0 +1,23 @@
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_298.f90:28:16
+   |
+28 |     if (i < 0) error stop "unreachable"
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status
+
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_298.f90:38:16
+   |
+38 |     if (i < 0) error stop "unreachable"
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status
+
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_298.f90:54:16
+   |
+54 |     if (i < 0) error stop "unreachable"
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status
+
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_298.f90:70:16
+   |
+70 |     if (i < 0) error stop "unreachable"
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_302-c945ed1.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_302-c945ed1.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "gpu_cuda_kernel-gpu_metal_302-c945ed1.stdout",
     "stdout_hash": "05026777972fd6609bde5e22a930e1a6863a9ab7c5c2816cfcaef775",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "gpu_cuda_kernel-gpu_metal_302-c945ed1.stderr",
+    "stderr_hash": "856ba26c2ab8266eacf48682e2b8890ad23a9e8c7bda56ee6c963355",
     "returncode": 0
 }

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_302-c945ed1.stderr
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_302-c945ed1.stderr
@@ -1,0 +1,5 @@
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_302.f90:17:16
+   |
+17 |     if (i < 0) error stop "unreachable"
+   |                ^^^^^^^^^^^^^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_334-124b176.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_334-124b176.json
@@ -7,7 +7,7 @@
     "outfile_hash": null,
     "stdout": "gpu_cuda_kernel-gpu_metal_334-124b176.stdout",
     "stdout_hash": "3c337dff66b8896bbb28954511cb6b012ebfb215ccd30354948e384e",
-    "stderr": null,
-    "stderr_hash": null,
+    "stderr": "gpu_cuda_kernel-gpu_metal_334-124b176.stderr",
+    "stderr_hash": "ab3f04f7c53b737182550bc1608fea47453d364105693a1f47e484a4",
     "returncode": 0
 }

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_334-124b176.stderr
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_334-124b176.stderr
@@ -1,0 +1,11 @@
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_334.f90:25:19
+   |
+25 |     if (a(i) < 0) error stop "negative"
+   |                   ^^^^^^^^^^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status
+
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_334.f90:36:22
+   |
+36 |     if (b(i) > 1000) error stop 1
+   |                      ^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_337-9610a4e.json
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_337-9610a4e.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_cuda_kernel-gpu_metal_337-9610a4e",
+    "cmd": "lfortran --no-color --gpu=cuda --show-gpu-kernel-source {infile}",
+    "infile": "tests/../integration_tests/gpu_metal_337.f90",
+    "infile_hash": "b84b2d2c2ae99541489780c37689cd0cbb054ba1cfbadcf04bd5e788",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": "gpu_cuda_kernel-gpu_metal_337-9610a4e.stdout",
+    "stdout_hash": "9628cdee3b6df04983d21aa5c39c0c13ec990278dfd08b57a685b005",
+    "stderr": "gpu_cuda_kernel-gpu_metal_337-9610a4e.stderr",
+    "stderr_hash": "029b48117e4bd6b7cdaf02db4d0429d7ed38835261f8b392ecc9d98c",
+    "returncode": 0
+}

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_337-9610a4e.stderr
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_337-9610a4e.stderr
@@ -1,0 +1,5 @@
+warning: 'error stop' in an offloaded loop does not deliver its stop code
+  --> tests/../integration_tests/gpu_metal_337.f90:29:19
+   |
+29 |     if (a(i) > 0) error stop 7
+   |                   ^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status

--- a/tests/reference/gpu_cuda_kernel-gpu_metal_337-9610a4e.stdout
+++ b/tests/reference/gpu_cuda_kernel-gpu_metal_337-9610a4e.stdout
@@ -1,0 +1,25 @@
+#include <stdint.h>
+
+struct __ScalarArgs___lfortran_gpu_kernel_0 {
+    int __loop_end_0;
+};
+
+extern "C" __global__ void __lfortran_gpu_kernel_0(
+    int* a,
+    __ScalarArgs___lfortran_gpu_kernel_0 __scalar_args)
+{
+    int __loop_end_0 = __scalar_args.__loop_end_0;
+    int __flat_idx;
+    int i;
+    const int n = 8;
+    if ((((blockIdx.x * blockDim.x) + threadIdx.x) >= ((__loop_end_0 - 1) + 1))) {
+        return;
+    }
+    __flat_idx = ((blockIdx.x * blockDim.x) + threadIdx.x);
+    i = (__flat_idx + 1);
+    a[((int)(i) - (1))] = (i * 3);
+    if ((a[((int)(i) - (1))] > 0)) {
+        __trap();
+    }
+}
+

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4363,6 +4363,13 @@ options = "--realloc-lhs-arrays"
 filename = "../integration_tests/gpu_metal_334.f90"
 gpu_cuda_kernel = true
 
+# The same trap, on a branch every thread takes. Registered here for the
+# warning the offload pass emits on the statement: the launch halts, but the
+# stop code the program named is not delivered.
+[[test]]
+filename = "../integration_tests/gpu_metal_337.f90"
+gpu_cuda_kernel = true
+
 [[test]]
 filename = "errors/array_bounds_check_01.f90"
 run = true


### PR DESCRIPTION
## Summary

Builds on #12760 (`gpu-all`), and fixes one blocker found reviewing it. Until #12760 merges the diff here carries its 36 commits too; afterwards it collapses to the two commits below.

#12760 makes an `error stop` inside an offloaded loop lower to a device trap, so a loop that guards its work with one can offload to CUDA instead of being turned down. The trap halts the launch, which is the part of the statement a device can honour. The rest does not survive the crossing: a grid returns no status, so the stop code is not delivered and a normal termination cannot be told apart from an error one.

That was happening silently. On `main` such a loop declined, so it was either a hard error or -- with `--gpu-allow-cpu-fallback` -- ran on the host with exact semantics. With #12760 it simply offloads and the program's exit status changes:

```fortran
do concurrent (i = 1:n)
  a(i) = i * 3
  if (a(i) > 0) error stop 7   ! host: ERROR STOP 7, status 7
end do                         ! --gpu=cuda_cpu: status 134, no message
```

## Scope

Two commits.

**1. Warn where the statement stands.** The offload still happens; it is now reported, alongside the clauses a launch cannot honour and at the same point, where the offload has become certain. Callees and BLOCK scopes are walked too, so a stop reached through a device function is reported at the statement inside the function rather than at the loop.

```
warning: 'error stop' in an offloaded loop does not deliver its stop code
  --> gpu_metal_337.f90:29:19
   |
29 |     if (a(i) > 0) error stop 7
   |                   ^^^^^^^^^^^^ the device halts the launch here and the program exits with a failure status
```

**2. End the emulated trap the way a real one ends the program.** On a real device the trap makes the launch fail, `lfortran_gpu_launch` reports the failed synchronize, and the process exits 1. The CPU emulation called `abort()`, so one program ended with SIGABRT and status 134 under `--gpu=cuda_cpu` and with status 1 under `--gpu=cuda`. What a program sees of a trap should not depend on which of the two ran it.

This one was found by the new test: `WILL_FAIL` inverts a nonzero exit status but not a crash, so a test that raises the trap could not pass while the emulation aborted.

## Verification

`gpu_metal_334` covers the guard that is never taken, so the trap is emitted and never raised. `gpu_metal_337` is new and takes it: every thread's guard holds, so the trap is raised wherever the loop ran. Both are registered as reference tests, which is what pins the warning text and its location; `288`, `298` and `302` pick up the same warning and their references are updated.

Fails before, passes after:

- before commit 1, no warning is emitted, so the five `.stderr` references are absent or stale;
- before commit 2, `gpu_metal_337` fails under `cuda_cpu` as `Subprocess aborted`.

Both new tests spell it `error stop` rather than `stop`. A plain `STOP` is an image control statement, which F2018 11.1.7.5 forbids in a `DO CONCURRENT` construct and which GFortran rejects outright (`Error: Image control statement STOP at (1) in DO CONCURRENT block`); `ERROR STOP` initiates error termination, needs no synchronisation, and is allowed. The warning covers both spellings through one code path, so the `'stop'` wording is not separately pinned -- there is no conforming test that could pin it.

Local runs, all green:

| Suite | Result |
| --- | --- |
| `./run_tests.py` | TESTS PASSED |
| `integration_tests/run_tests.py -j16` | 4123/4123 |
| `integration_tests/run_tests.py -b gfortran -j16` | pass |
| `integration_tests/run_tests.py -b metal -j16` | 343/343 |
| `integration_tests/run_tests.py -b cuda_cpu -j16` | 343/343 |

## Rationale

An offloaded `error stop` is a deliberate deviation: it buys the offload, and the alternative is turning down every loop that guards its work with one. The project's rule for a deviation is that it is named where it happens rather than taken in silence, and that the warning itself is tested -- which is what the two reference tests are for. The emulation change is not a deviation but a discrepancy: the two CUDA paths disagreed about what a trap looks like from outside the process, and now they do not.
