### PR TITLE
tests: cover the two DECIMAL= errors on a data transfer statement

### DIFF
--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -1208,3 +1208,11 @@ subroutine binding_outside_module_2
         procedure, pass(this) :: binding_outside_module_proc  ! {Error} 'binding_outside_module_proc' must be a module procedure or an external procedure with an explicit interface
     end type t_binding_outside_module
 end subroutine binding_outside_module_2
+
+! `decimal=` on a data transfer statement takes a character value, and like any
+! other specifier it may appear at most once in the control list.
+subroutine decimal_specifier_1()
+    implicit none
+    write(*, *, decimal=1) 1.0
+    write(*, *, decimal="POINT", decimal="COMMA") 1.0
+end subroutine

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "b04995993b7289b31801e994d72a4f9bec66f125d49dfcaf8143dfae",
+    "infile_hash": "fa38d26599693c58fd86b7f167845fb207c03cbc7d1ce67923198fcd",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "b02cfce55d94192ec5ceb968208663e1cbe0d65233def9207f129c0b",
+    "stderr_hash": "221186835099d0c853433ecc9fe32983f1d0ce3e9917b262ff075875",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -2132,3 +2132,15 @@ semantic error: Call to impure procedure 'conditional_expr_impure' is not allowe
      |
 1183 |         conditional_expr_pure = ( c ? 1 : conditional_expr_impure() )  ! {Error} Call to impure procedure 'conditional_expr_impure' is not allowed inside a PURE procedure
      |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^ 
+
+semantic error: `decimal` must be of type character
+    --> tests/errors/continue_compilation_1.f90:1216:25
+     |
+1216 |     write(*, *, decimal=1) 1.0
+     |                         ^ 
+
+semantic error: Duplicate value of `decimal` found
+    --> tests/errors/continue_compilation_1.f90:1217:42
+     |
+1217 |     write(*, *, decimal="POINT", decimal="COMMA") 1.0
+     |                                          ^^^^^^^ 


### PR DESCRIPTION
## Summary

Follow-up to the review comment on #12755 (https://github.com/lfortran/lfortran/pull/12755#discussion_r3990148281): "Add tests for these two errors."

#12755 added `DECIMAL=` to `READ`/`WRITE` in `create_read_write_ASR_node` together with two diagnostics, but neither was exercised by a test. The equivalent `OPEN` errors were already covered at `continue_compilation_1.f90:635-636`; these two were the gap.

## Scope

`tests/errors/continue_compilation_1.f90`, appended at the end to keep the diff minimal:

```fortran
subroutine decimal_specifier_1()
    implicit none
    write(*, *, decimal=1) 1.0
    write(*, *, decimal="POINT", decimal="COMMA") 1.0
end subroutine
```

The first is a non-character value, the second gives the specifier twice in one control list.

## Verification

The two diagnostics the test now pins:

```
semantic error: `decimal` must be of type character
    --> tests/errors/continue_compilation_1.f90:1216:25
     |
1216 |     write(*, *, decimal=1) 1.0
     |                         ^

semantic error: Duplicate value of `decimal` found
    --> tests/errors/continue_compilation_1.f90:1217:42
     |
1217 |     write(*, *, decimal="POINT", decimal="COMMA") 1.0
     |                                          ^^^^^^^
```

`tests/reference/asr-continue_compilation_1-04b6d40.stderr` was regenerated with `./run_tests.py -t continue_compilation_1 -u -s`; the whole diff to it is those two diagnostics and nothing else.

Full reference suite on this branch:

```
$ ./run_tests.py --no-llvm --skip-run-with-dbg
TESTS PASSED
```

`--no-llvm` because this container has LLVM 18 while the checked-in `llvm-*` references are produced with LLVM 11. No `llvm-*` or `run-*` reference is touched by this change, which is tests-only.

## Rationale

Tests only — no compiler change. The errors already behave correctly; this pins them so a later refactor of the `READ`/`WRITE` kwarg loop cannot drop them silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qswb5qZf7pAyUdHUspspDu)_