### PR TITLE
Report a real exit code when debug info generation fails

### DIFF
--- a/src/bin/lfortran.cpp
+++ b/src/bin/lfortran.cpp
@@ -2307,7 +2307,12 @@ int link_executable(const std::vector<std::string> &infiles,
                     "the debug information. This might be caused because either"
                     " `llvm-dwarfdump` or `Python` are not available. "
                     "Please activate the CONDA environment and compile again.\n";
-                return status;
+                // `system()` reports a wait status, not an exit code. Returning
+                // it unchanged would truncate it to its low 8 bits in `main()`,
+                // so a missing `llvm-dwarfdump` (127 << 8 == 32512) would be
+                // silently reported as a successful exit code of 0.
+                int exit_status = LCompilers::LFortran::get_exit_status(status);
+                return exit_status != 0 ? exit_status : 1;
             }
         }
 #endif


### PR DESCRIPTION
`link_executable()` returned the raw `system()` wait status when the `llvm-dwarfdump` / `dwarf_convert.py` step for `-g` failed. That status is not an exit code: `main()` truncates it to its low 8 bits, so any failure whose exit code is a multiple of 256 became a successful exit code of 0.

A missing `llvm-dwarfdump` exits 127, giving a wait status of 32512, which truncates to exactly 0. The error message was printed but build systems saw the compilation succeed and kept going, silently producing executables without the line tables that runtime stacktraces need.

Decode the status with the existing `get_exit_status()` helper, falling back to 1 if the decoded value is 0 (e.g. when the shell was killed by a signal).