### PR TITLE
Advance the record after a stdin list-directed READ

### DIFF
--- a/src/libasr/runtime/lfortran_intrinsics.c
+++ b/src/libasr/runtime/lfortran_intrinsics.c
@@ -12108,14 +12108,23 @@ static void common_formatted_read(InputSource *inputSource,
 
 LFORTRAN_API void _lfortran_empty_read(int32_t unit_num, int32_t* iostat, int32_t no_values) {
     if (iostat) *iostat = 0;
-    if (unit_num == -1) {
-        return;
-    } else if (unit_num == -2) {
-        // Read from stdin
-        int inp = 0;
+    if (unit_num == -1 || unit_num == -2) {
+        // Standard input. Finish the current record. A list-directed read
+        // stops at the record terminator and leaves it in the stream, so
+        // without this advance the next format-directed read would see the
+        // leftover terminator and treat it as a complete, empty record.
+        int c = 0;
+        bool read_any = false;
         do {
-            inp = fgetc(stdin);
-        } while (inp != '\n' && inp != EOF);
+            c = fgetc(stdin);
+            read_any = read_any || (c != EOF);
+        } while (c != '\n' && c != EOF);
+        // Hitting end of file while advancing only ends the statement when
+        // it transferred no values; otherwise the values already read are
+        // what the statement returns.
+        if (c == EOF && !read_any && no_values && iostat) {
+            *iostat = -1;
+        }
         return;
     }
 

--- a/tests/reference/run-stdin_read_list_then_format_01-4d137b6.json
+++ b/tests/reference/run-stdin_read_list_then_format_01-4d137b6.json
@@ -1,0 +1,13 @@
+{
+    "basename": "run-stdin_read_list_then_format_01-4d137b6",
+    "cmd": "lfortran --no-color {infile}",
+    "infile": "tests/stdin_read_list_then_format_01.f90",
+    "infile_hash": "7d4e2bec1d36122e49059709db663f3a1a65d0a1910d6a5b4b4893b4",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/stdin_read_list_then_format_01.f90
+++ b/tests/stdin_read_list_then_format_01.f90
@@ -1,0 +1,58 @@
+program stdin_read_list_then_format_01
+    implicit none
+
+    character(len=10) :: w
+    character(len=1) :: c
+    integer :: n, i, j, p, q, ios
+
+    ! A list-directed read stops at the record terminator. The READ statement
+    ! must still advance past it, otherwise the next format-directed read
+    ! sees the leftover terminator and returns a blank, empty record.
+    read(*, *) n
+    if (n /= 42) error stop 1
+    read(*, '(a1)') c
+    if (c /= "A") error stop 2
+
+    ! Same, with more than one value transferred by the list-directed read.
+    read(*, *) i, j
+    if (i /= 7) error stop 3
+    if (j /= 8) error stop 4
+    read(*, '(a1)') c
+    if (c /= "B") error stop 5
+
+    ! Whatever is left in the record after the last value is discarded by the
+    ! advance, so the format-directed read starts at the next record.
+    read(*, *) w
+    if (w /= "zz") error stop 6
+    read(*, '(a1)') c
+    if (c /= "C") error stop 7
+
+    ! A list-directed read with an empty input list advances one record.
+    read(*, *, iostat=ios)
+    if (ios /= 0) error stop 8
+    read(*, '(a1)') c
+    if (c /= "D") error stop 9
+
+    ! Format-directed followed by list-directed keeps working.
+    read(*, '(a1)') c
+    if (c /= "E") error stop 10
+    read(*, *) w
+    if (w /= "hello") error stop 11
+
+    ! List-directed followed by list-directed keeps working.
+    read(*, *) p
+    if (p /= 99) error stop 12
+    read(*, *) q
+    if (q /= 100) error stop 13
+
+    ! The advance past the final record must not turn a successful read into
+    ! an end-of-file condition.
+    read(*, *, iostat=ios) n
+    if (ios /= 0) error stop 14
+    if (n /= 55) error stop 15
+
+    ! Now the stream really is exhausted.
+    read(*, '(a1)', iostat=ios) c
+    if (ios >= 0) error stop 16
+
+end program stdin_read_list_then_format_01

--- a/tests/stdin_read_list_then_format_01.in
+++ b/tests/stdin_read_list_then_format_01.in
@@ -1,0 +1,13 @@
+42
+A
+7 8
+B
+zz junk here
+C
+skip this record
+D
+E
+hello
+99
+100
+55

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -5455,6 +5455,11 @@ run = true
 options = "< tests/stdin_read_blank_lines_01.in"
 
 [[test]]
+filename = "stdin_read_list_then_format_01.f90"
+run = true
+options = "< tests/stdin_read_list_then_format_01.in"
+
+[[test]]
 filename = "mangle_underscore_external_01.f90"
 llvm = true
 options = "--mangle-underscore-external"


### PR DESCRIPTION
Fixes #12656.

## Summary

A `READ` from standard input never advanced past the end of its record, so a
list-directed read left the record terminator sitting in the stream and the
next format-directed read consumed it as a complete, empty record:

```fortran
read (*, *, iostat=ios) n      ! reads 42, leaves the '\n' in stdin
read (*, '(A1)', iostat=ios) c ! sees that '\n' -> blank record, iostat = 0
```

```console
$ printf '42\nA\n' | ./a.out   # before
42
[ ]
$ printf '42\nA\n' | ./a.out   # after
42
[A]
```

The record-advance hook is `_lfortran_empty_read`, which `visit_FileRead`
emits once per list-directed `READ` statement. It drained the record for every
unit except the default input unit (`-1`, used by `read(*, ...)` and
`read(5, ...)`), where it was a plain `return`. Unit `-2` (bare `read()`)
already drained, so the two default-input encodings disagreed with each other.

This is why the issue only reproduces in one direction. Format-directed reads
do not go through `_lfortran_empty_read` at all — `emit_formatted_read` does
its own advance — so format-then-list was fine, and list-then-list was fine
because the token reader's leading-whitespace skip happens to swallow the
stray terminator. Only list-then-format saw it.

## Scope

Runtime-only, one function in `src/libasr/runtime/lfortran_intrinsics.c`:
`_lfortran_empty_read` now advances to the end of the current record for unit
`-1` as well as `-2`, using the same loop the file-backed units use. No
compiler, ASR or codegen changes.

End-of-file during the advance only ends the statement when the statement
transferred no values; otherwise the values already read are what the
statement returns. That mirrors the condition `common_formatted_read` already
applies (`c == EOF && !read_any && no_of_args == 0`) and is what keeps
`printf '42' | ...` (no trailing newline) reporting `iostat = 0` for the read
that got `42`.

Behaviour for unit `-2` is unchanged: that encoding is only produced when
`x.m_iostat == nullptr`, so its `iostat` argument is a throwaway alloca that
codegen never reads back.

## Verification

The test is `tests/stdin_read_list_then_format_01.f90`, registered in
`tests/tests.toml` as a `run` test with its input piped in:

```toml
[[test]]
filename = "stdin_read_list_then_format_01.f90"
run = true
options = "< tests/stdin_read_list_then_format_01.in"
```

Integration tests have no way to feed a program stdin, so this follows the
existing `stdin_read_blank_lines_01` precedent — the only stdin `READ` test in
the tree and the same `run = true` + `options = "< ..."` mechanism. `run` mode
compiles and executes the program with the LLVM backend, so it is still an
end-to-end test; `error stop` codes turn into the reference `returncode`.

Fails on the parent commit, passes on this branch:

```console
$ ./run_tests.py -t stdin_read_list_then_format_01.f90 -s   # parent commit
stdin_read_list_then_format_01.f90 * run
The JSON metadata differs against reference results
{'returncode': 2} != {'returncode': 0}
> ERROR STOP 2

$ ./run_tests.py -t stdin_read_list_then_format_01.f90 -s   # this branch
stdin_read_list_then_format_01.f90 * run ✓
TESTS PASSED
```

`ERROR STOP 2` is the issue's own case — the format-directed read after the
list-directed one returning blank instead of `A`.

The test also pins the cases the issue reports as already working, so the fix
cannot regress them: format-then-list, list-then-list, the record-advance
discarding trailing text in a record, a list-directed read with an empty input
list skipping exactly one record, and the final read not being turned into an
end-of-file by the advance behind it.

Differential check against gfortran on the edge cases, all matching after the
fix (all three were wrong before):

| stdin | statement | gfortran | before | after |
| --- | --- | --- | --- | --- |
| `42\nA\n` | `read(*,*) n` then `read(*,'(A1)') c` | `c = A` | `c = ' '` | `c = A` |
| `42 xx\nA\n` | same | `c = A` | `c = x` | `c = A` |
| `42\n` | second read at EOF | `iostat = -1` | `iostat = 0` | `iostat = -1` |
| `42` (no final newline) | first read | `iostat = 0` | `iostat = 0` | `iostat = 0` |
| `aa\nbb\ncc\n` | `read(*,*,iostat=)` empty list, then `read(*,'(A2)')` | `bb` | `aa` | `bb` |

The same sequence through a `newunit` file, which the issue notes already
works, is unaffected — that path was already draining.

Suites, both green:

```console
$ ./run_tests.py &> log_ref
TESTS PASSED

$ cd integration_tests && ./run_tests.py -b llvm -j4 &> log_int
100% tests passed, 0 tests failed out of 4132
Total Test time (real) = 1537.07 sec
```

The integration run is the `llvm` pass. That is the pass that matters here:
`_lfortran_empty_read` is emitted only by `asr_to_llvm.cpp`, so no other
backend can reach the changed code, and the gfortran pass compiles with
gfortran and never touches this runtime at all. The machine this was run on is
badly oversubscribed (load average above 40), which is why the remaining
backend passes were not also run locally; CI covers them.

The three integration tests that read standard input at all are unaffected, by
inspection as well as by the run above: `read_83`'s reads sit behind a
`--empty-read` argument that ctest does not pass, `read_94` redirects stdin to
a file and performs a single `READ`, and `read_97` is a formatted read, which
does not go through this function.

## Rationale

`_lfortran_empty_read` is the right layer. It is the one hook codegen emits per
`READ` statement, so it knows the statement is over; the per-value token
readers do not, and draining there would break `read(*,*) i, j`.

Relation to the two open PRs in this area:

- **#12654** (stop interactive formatted `READ` from hanging on Emscripten
  stdin) is disjoint. It makes stdin unbuffered under `__EMSCRIPTEN__` via
  `use_stdin_char_mode()` and touches only the value-reading paths; this
  changes only the record advance. Its own description parks this bug as
  separate and points at #12656. The one thing to carry over once it merges is
  calling `use_stdin_char_mode()` before the drain added here, so the drain
  works on an open interactive Emscripten pipe — a one-line follow-up, and no
  conflict either way since the two patches touch different functions.
- **#12668** also fixes #12656 and reaches the same conclusion about
  `_lfortran_empty_read` and the default unit. It is stacked on #12654 and is
  considerably wider: it adds an `ADVANCE=`-aware
  `_lfortran_empty_read_advance` entry point with a codegen change to route
  non-advancing reads through it, plus a node-based stdin loader so
  `read_stdin_01` can run natively. That `ADVANCE=` work is a real second bug
  (it is why #12668 needs the extra entry point) but it is not this one:
  `ADVANCE=` is only conforming on an explicitly formatted transfer, and those
  never reach `_lfortran_empty_read`. This PR is deliberately the narrow fix
  for the reported bug, with no codegen change and no new test harness. If
  #12668 lands first this becomes redundant and should be closed; if this
  lands first, #12668 rebases down to its `ADVANCE=` half.

