### PR TITLE
gpu: refuse two shapes the device emitter cannot express

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -5272,6 +5272,10 @@ RUN(NAME gpu_metal_334 LABELS gfortran llvm metal cuda_cpu EXTRA_ARGS $<$<STREQU
 RUN(NAME gpu_metal_335 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_336 LABELS gfortran llvm metal cuda_cpu)
 RUN(NAME gpu_metal_337 FAIL LABELS gfortran llvm metal cuda_cpu EXTRA_ARGS $<$<STREQUAL:${LFORTRAN_BACKEND},metal>:--gpu-allow-cpu-fallback>)
+# Refused by every gpu backend on purpose -- see the reference test in
+# tests/tests.toml for the diagnostic. Registered here for the answer the
+# host gives, which is the one the kernel used to get wrong in silence.
+RUN(NAME gpu_metal_338 LABELS gfortran llvm)
 # No gfortran label: `reduce` is F2023, and the gfortran the CI builds with
 # rejects it outright ("Syntax error in DO statement"). Same reason
 # gpu_metal_21 above carries none. Checked by hand against gfortran 16,

--- a/integration_tests/gpu_metal_338.f90
+++ b/integration_tests/gpu_metal_338.f90
@@ -1,0 +1,52 @@
+module gpu_metal_338_mod
+implicit none
+integer, parameter :: n = 8
+contains
+
+    ! `p` is bound to every second element of `col`. A device pointer is an
+    ! address and carries no stride, so a gpu kernel can say how many
+    ! elements `p` has -- the extent honours the step -- but cannot address
+    ! them. Reading `p(k)` there walked `col` one element at a time and
+    ! returned the right number of the wrong elements, with no diagnostic.
+    ! The gpu backends refuse this now; on the host it means what it says.
+    pure function strided_sum(col) result(s)
+        real, intent(in) :: col(:)
+        real :: s
+        integer :: k
+        associate (p => col(1:n:2))
+            s = 0.0
+            do k = 1, size(p)
+                s = s + p(k)
+            end do
+        end associate
+    end function
+
+end module
+
+program gpu_metal_338
+use gpu_metal_338_mod
+implicit none
+integer, parameter :: nt = 2
+real :: a(n, nt), r(nt)
+integer :: i, j
+
+do j = 1, nt
+    do i = 1, n
+        a(i, j) = real(i)
+    end do
+end do
+r = 0.0
+
+do concurrent (j = 1:nt)
+    r(j) = strided_sum(a(:, j))
+end do
+
+! col(1:8:2) is [1, 3, 5, 7]; the first four elements sum to 10, which is
+! what dropping the step used to give.
+do j = 1, nt
+    if (abs(r(j) - 16.0) > 1.0e-4) error stop "strided associate"
+end do
+
+print *, r
+print *, "PASS"
+end program

--- a/src/libasr/codegen/asr_to_gpu_c.h
+++ b/src/libasr/codegen/asr_to_gpu_c.h
@@ -1672,6 +1672,18 @@ public:
             return;
         }
         ASR::ArraySection_t *as = ASR::down_cast<ASR::ArraySection_t>(expr);
+        // A section of a name that is already stepping through its own base
+        // compounds the address this cannot express, so it is refused here
+        // as an indexed use would be.
+        reject_strided_section_use(as->m_v, as->base.base.loc);
+        last_section_dropped_step = false;
+        for (size_t d = 0; d < as->n_args; d++) {
+            bool is_range = as->m_args[d].m_left && as->m_args[d].m_right
+                && as->m_args[d].m_step;
+            if (is_range && !section_step_is_one(as->m_args[d].m_step)) {
+                last_section_dropped_step = true;
+            }
+        }
         std::string arr_name;
         if (ASR::is_a<ASR::Var_t>(*as->m_v)) {
             arr_name = ASRUtils::symbol_name(
@@ -1756,6 +1768,48 @@ public:
     // emit_array_section_pointer, so that a routine the section is passed to
     // can be given them one by one.
     std::vector<std::string> last_section_dim_sizes;
+
+    // Whether the section last rendered by emit_array_section_pointer steps
+    // through its base array by something other than one.
+    bool last_section_dropped_step = false;
+
+    // The names an Associate bound to such a section. A device pointer is an
+    // address and nothing else: it cannot carry a step, so walking one reads
+    // consecutive elements of the base array rather than every step-th one.
+    // The element *count* is right -- an extent is derived through
+    // gpu_device_range_extent(), which does honour the step -- so the wrong
+    // elements get read exactly the right number of times, which is a wrong
+    // answer with nothing to show for it. Sizing such a name is still exact,
+    // and `size(p)` is what most of them are for, so the name is recorded
+    // here and only indexing it is refused.
+    std::set<ASR::symbol_t*> section_pointers_dropping_step;
+
+    // Whether `e` names a step the device pointer can express, which is a
+    // step of one: absent, or folding to the literal 1. A step only known at
+    // run time cannot be shown to be one, so it is not.
+    static bool section_step_is_one(ASR::expr_t *step) {
+        if (step == nullptr) return true;
+        int64_t value = 0;
+        if (!ASRUtils::extract_value(ASRUtils::expr_value(step), value)) {
+            return false;
+        }
+        return value == 1;
+    }
+
+    // Refuses an indexed read or write through a name bound to a section the
+    // device pointer cannot express. Called wherever such a name could be
+    // subscripted, so that the shape is a compile error rather than a silent
+    // wrong answer.
+    void reject_strided_section_use(ASR::expr_t *base, const Location &loc) {
+        if (base == nullptr || !ASR::is_a<ASR::Var_t>(*base)) return;
+        ASR::symbol_t *sym = ASR::down_cast<ASR::Var_t>(base)->m_v;
+        if (section_pointers_dropping_step.count(sym) == 0) return;
+        throw CodeGenError(std::string("gpu offload: '")
+            + ASRUtils::symbol_name(sym) + "' is associated with an array "
+            "section whose stride is not one, and a gpu kernel addresses it "
+            "with a pointer that cannot carry a stride; only its size can be "
+            "used inside the kernel", loc);
+    }
 
     // Renders an expression to device source without disturbing the output
     // being built.
@@ -4109,12 +4163,22 @@ public:
             case ASR::stmtType::Associate: {
                 ASR::Associate_t *assoc = ASR::down_cast<ASR::Associate_t>(stmt);
                 last_section_size.clear();
+                last_section_dropped_step = false;
                 src << get_indent();
                 visit_expr(assoc->m_target);
                 src << " = ";
                 emit_array_section_pointer(assoc->m_value);
                 src << ";\n";
                 if (ASR::is_a<ASR::Var_t>(*assoc->m_target)) {
+                    // The pointer just written holds the address of the
+                    // section's first element. Where the section steps by
+                    // more than one that address is all it holds, so record
+                    // the name: its size is still exact, and every indexed
+                    // use of it is refused.
+                    if (last_section_dropped_step) {
+                        section_pointers_dropping_step.insert(
+                            ASR::down_cast<ASR::Var_t>(assoc->m_target)->m_v);
+                    }
                     std::string tgt_name = ASRUtils::symbol_name(
                         ASR::down_cast<ASR::Var_t>(assoc->m_target)->m_v);
                     if (!last_section_size.empty()) {
@@ -4622,6 +4686,10 @@ public:
             }
             case ASR::exprType::ArrayItem: {
                 ASR::ArrayItem_t *ai = ASR::down_cast<ASR::ArrayItem_t>(expr);
+                // Refused here rather than in emit_linearized_index below:
+                // a rank-1 subscript is written out directly and never
+                // reaches it.
+                reject_strided_section_use(ai->m_v, ai->base.base.loc);
                 // For allocatable struct member access like s%a(i),
                 // use the separate data pointer parameter instead of
                 // the struct member (which is not a valid array in device code).
@@ -5050,6 +5118,7 @@ public:
 
     void emit_linearized_index(ASR::ArrayItem_t *ai,
                                ASR::ttype_t *arr_type) {
+        reject_strided_section_use(ai->m_v, ai->base.base.loc);
         ASR::Array_t *arr = nullptr;
         ASR::ttype_t *inner = ASRUtils::type_get_past_allocatable(
             ASRUtils::type_get_past_pointer(arr_type));

--- a/src/libasr/codegen/asr_to_gpu_c.h
+++ b/src/libasr/codegen/asr_to_gpu_c.h
@@ -443,6 +443,47 @@ public:
         return true;
     }
 
+    // The entry of a "<struct>.<component>" table that describes component
+    // `member`, when the struct half of the key is not the name this
+    // argument is spelled with. Both tables are keyed by the name the
+    // parameters were registered under, and a struct reaching a callee
+    // under another spelling has no exact key to look up, so the component
+    // is matched on its own.
+    //
+    // That is only an answer while one struct in scope has such a
+    // component. Where several do, the component name alone does not say
+    // which buffer this argument is, and handing over whichever the map
+    // happened to order first is how a kernel reads another variable's
+    // elements and says nothing. Refuse instead.
+    const std::string* component_entry_by_member(
+            const std::map<std::string, std::string> &table,
+            const std::string &member, const std::string &what,
+            const Location &loc) {
+        const std::string suffix = "." + member;
+        const std::string *found = nullptr;
+        std::string owner, other;
+        for (auto &entry : table) {
+            if (entry.first.size() < suffix.size()) continue;
+            if (entry.first.compare(entry.first.size() - suffix.size(),
+                    suffix.size(), suffix) != 0) {
+                continue;
+            }
+            if (found != nullptr) {
+                other = entry.first.substr(
+                    0, entry.first.size() - suffix.size());
+                throw CodeGenError("gpu offload: the " + what + " of the "
+                    "component `" + member + "` cannot be told apart here: "
+                    "it could be the one of `" + owner + "` or of `" + other
+                    + "`, and a gpu kernel handed the wrong one would read "
+                    "another variable's elements", loc);
+            }
+            found = &entry.second;
+            owner = entry.first.substr(
+                0, entry.first.size() - suffix.size());
+        }
+        return found;
+    }
+
     // Tracks local struct variables that were assigned from an element
     // of an array-of-struct. Maps local_var_name -> (array_name, index_expr_string).
     // Used by emit_struct_member_data_ptrs/sizes to offset into flat buffers.
@@ -2451,20 +2492,12 @@ public:
                             &mv->base), key, data)) {
                     src << ", " << data;
                 } else {
-                    std::string suffix = std::string(".")
-                        + mem_name;
-                    bool found = false;
-                    for (auto &entry : func_array_data_params) {
-                        if (entry.first.size() >= suffix.size() &&
-                                entry.first.compare(
-                                    entry.first.size() - suffix.size(),
-                                    suffix.size(), suffix) == 0) {
-                            src << ", " << entry.second;
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
+                    const std::string *entry = component_entry_by_member(
+                        func_array_data_params, mem_name, "device buffer",
+                        expr->base.loc);
+                    if (entry) {
+                        src << ", " << *entry;
+                    } else {
                         src << ", " << GpuNames::member_data(var_name,
                             mem_name);
                     }
@@ -2491,20 +2524,12 @@ public:
                 if (it != func_array_size_params.end()) {
                     src << ", " << it->second;
                 } else {
-                    std::string suffix = std::string(".")
-                        + mem_name;
-                    bool found = false;
-                    for (auto &entry : func_array_size_params) {
-                        if (entry.first.size() >= suffix.size() &&
-                                entry.first.compare(
-                                    entry.first.size() - suffix.size(),
-                                    suffix.size(), suffix) == 0) {
-                            src << ", " << entry.second;
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) {
+                    const std::string *entry = component_entry_by_member(
+                        func_array_size_params, mem_name, "element count",
+                        expr->base.loc);
+                    if (entry) {
+                        src << ", " << *entry;
+                    } else {
                         src << ", " << GpuNames::member_size(var_name,
                             mem_name);
                     }

--- a/tests/reference/gpu_offload_strict-gpu_metal_338-61c4170.json
+++ b/tests/reference/gpu_offload_strict-gpu_metal_338-61c4170.json
@@ -1,0 +1,13 @@
+{
+    "basename": "gpu_offload_strict-gpu_metal_338-61c4170",
+    "cmd": "lfortran --no-color --gpu=cuda -c {infile} -o {outfile}",
+    "infile": "tests/../integration_tests/gpu_metal_338.f90",
+    "infile_hash": "0f3f7944d0f0e4e9c9b6e9ce4b084a4b4704c33452b511ec0f02e8da",
+    "outfile": null,
+    "outfile_hash": null,
+    "stdout": null,
+    "stdout_hash": null,
+    "stderr": "gpu_offload_strict-gpu_metal_338-61c4170.stderr",
+    "stderr_hash": "6394115f04fe0e7011b6f6f9855fdc67ea5fb6ad06e88b3410407847",
+    "returncode": 5
+}

--- a/tests/reference/gpu_offload_strict-gpu_metal_338-61c4170.stderr
+++ b/tests/reference/gpu_offload_strict-gpu_metal_338-61c4170.stderr
@@ -1,0 +1,5 @@
+code generation error: gpu offload: 'p' is associated with an array section whose stride is not one, and a gpu kernel addresses it with a pointer that cannot carry a stride; only its size can be used inside the kernel
+  --> tests/../integration_tests/gpu_metal_338.f90:19:25
+   |
+19 |                 s = s + p(k)
+   |                         ^^^^ 

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -4410,6 +4410,13 @@ gpu_offload_strict = true
 filename = "../integration_tests/gpu_decline_09.f90"
 gpu_offload_strict = true
 
+# Indexing an ASSOCIATE bound to a strided section inside a kernel. The
+# extent honours the step, so the count was right; the device pointer holds
+# only an address, so the elements were not. Refused rather than answered.
+[[test]]
+filename = "../integration_tests/gpu_metal_338.f90"
+gpu_offload_strict = true
+
 [[test]]
 filename = "errors/array_bounds_check_01.f90"
 run = true


### PR DESCRIPTION
## Summary

Two places in the GPU emitter answered a question they had no right answer to, and said nothing about it. Both are silent-wrong-answer bugs; both are fixed by refusing rather than guessing.

**1. A strided array section bound by ASSOCIATE.** A device pointer is an address and carries nothing else. `emit_array_section_pointer` wrote the address of the section's first element and read `m_step` only to test it for null, so the step was dropped. The element *count* comes from `gpu_device_range_extent()`, which does honour the step, so a kernel read the right number of the wrong elements:

```fortran
associate (p => col(1:8:2))     ! [1, 3, 5, 7]
    do k = 1, size(p)           ! 4 -- correct
        s = s + p(k)            ! col(1), col(2), col(3), col(4)
    end do
end associate
```

gives `10` where every other compiler gives `16`, with no diagnostic anywhere. Nothing in the tree hit it only because `gpu_offload` gathers or declines a strided section first, and because the two tests that do associate one (`gpu_metal_324`, `gpu_metal_335`) ask for `size(p)` and never index it -- convention, not construction.

The fix records the names an `Associate` binds to such a section and refuses every indexed use of them, at each of the three places a subscript is written out. The rank-1 fast path writes its subscript directly and never reaches `emit_linearized_index`, which is why one guard is not enough. Sizing stays exact, so those two tests keep offloading unchanged.

**2. Which struct a component's buffer belongs to.** Two places handed a struct component's device buffer and element count to a callee by searching the `"<struct>.<component>"` tables for any key ending in `".<component>"` and taking the first hit, so map order decided which struct variable answered. Where two structs in scope have a component of the same name -- the common case, since they usually have the same type -- the kernel would be handed the other variable's buffer.

That search exists because a struct reaching a callee under a spelling the tables were not keyed under has no exact key to look up, and matching the component on its own is an answer while only one struct has it. That is kept; where more than one does, there is nothing to pick, so it refuses. Both copies of the search are now one helper.

## Scope

Both changes refuse rather than lower. Carrying the step would mean rendering `base[(lo-1) + (k-1)*step]` at every index site, which is more knowledge in the emitter, not less.

## Verification

| suite | result |
| --- | --- |
| `integration_tests -b metal` | 343/343 |
| `integration_tests -b cuda_cpu` | 343/343 |
| `integration_tests -b llvm` | 4133/4133 |
| `tests/` gpu reference subset | 34/34 |
| `src/lfortran/tests` | 166/166 doctest cases |

`gpu_metal_338` indexes a strided associate inside an offloaded loop. It is registered for `gfortran` and `llvm`, where it must give 16, and as a `gpu_offload_strict` reference test for the refusal. Reverting the emitter change and rebuilding reproduces the `10` shown above.

The second change has no test of its own: it replaces a guess that had no right answer rather than fixing an observed failure, and I could not construct a program that reaches the ambiguous branch. Behaviour is unchanged wherever at most one entry matches, which is everywhere in the tree today.

Two pre-existing local failures, both confirmed unrelated by reverting the change and reproducing them: `asr_text_compile_01` (LLVM opaque-pointer text in this environment) and `pdt_16` under this machine's gfortran (a PDT constructor it rejects).