### PR TITLE
Keep assumed-rank arrays when duplicating types

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -976,6 +976,7 @@ COMPILE(NAME assumed_rank_12 COMPILERS gfortran llvm llvm_wasm) # move to RUN wi
 
 RUN(NAME assumed_rank_14 LABELS gfortran llvm)
 RUN(NAME assumed_rank_15 LABELS gfortran llvm)
+RUN(NAME assumed_rank_16 LABELS gfortran llvm)
 RUN(NAME assume_rank_shape_product_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME select_rank_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME select_rank_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)

--- a/integration_tests/assumed_rank_16.f90
+++ b/integration_tests/assumed_rank_16.f90
@@ -1,0 +1,72 @@
+! An assumed-rank dummy argument that is host-associated into a contained
+! procedure gets hoisted into a nested-variable context module by the
+! nested_vars pass. The hoisted variable has to keep its assumed-rank array
+! type; collapsing it to the bare element type used to make the `select rank`
+! inside the contained procedure fail with
+! "Cannot extract the physical type of 2 type."
+! See https://github.com/lfortran/lfortran/issues/12683
+module assumed_rank_16_mod
+   implicit none
+contains
+
+   subroutine elementcopy(src, dst)
+      real, intent(in) :: src(..)
+      real :: dst(..)
+      select rank (src)
+      rank (1)
+         call step2(src)
+      end select
+   contains
+
+      ! `dst` is only reachable here through host association, so the pass
+      ! has to move it into the nested context with its type intact.
+      subroutine step2(s)
+         real, intent(in) :: s(:)
+         select rank (dst)
+         rank (1)
+            call ecopy(s, dst)
+         rank (2)
+            call ecopy(s, dst(:, 1))
+         end select
+      end subroutine step2
+
+      subroutine ecopy(a, b)
+         real, intent(in) :: a(:)
+         real :: b(:)
+         integer :: i
+         do i = 1, size(a)
+            b(i) = 2.0 * a(i)
+         end do
+      end subroutine ecopy
+
+   end subroutine elementcopy
+
+end module assumed_rank_16_mod
+
+program assumed_rank_16
+   use assumed_rank_16_mod
+   implicit none
+
+   real :: x(4)
+   real :: y(4)
+   real :: z(4, 2)
+   integer :: i
+
+   x = [1.0, 2.0, 3.0, 4.0]
+
+   y = 0.0
+   call elementcopy(x, y)
+   print *, y
+   do i = 1, 4
+      if (abs(y(i) - 2.0 * x(i)) > 1.0e-6) error stop "rank 1 dst"
+   end do
+
+   z = 0.0
+   call elementcopy(x, z)
+   print *, z(:, 1)
+   do i = 1, 4
+      if (abs(z(i, 1) - 2.0 * x(i)) > 1.0e-6) error stop "rank 2 dst"
+      if (abs(z(i, 2)) > 1.0e-6) error stop "rank 2 dst untouched column"
+   end do
+
+end program assumed_rank_16

--- a/src/libasr/asr_utils.h
+++ b/src/libasr/asr_utils.h
@@ -4163,7 +4163,17 @@ inline ASR::ttype_t* make_Array_t_util(Allocator& al, const Location& loc,
     bool override_physical_type=false, bool is_dimension_star=false, bool for_type=true,
     ASR::memory_spaceType memory_space=ASR::memory_spaceType::Global) {
     if( n_dims == 0 ) {
-        return type;
+        // An Array with no dimensions is a scalar, with one exception: an
+        // assumed-rank array is represented as an Array carrying no
+        // dimensions, because its rank is unknown until a `select rank`
+        // selects one. Asking for that physical type is therefore a request
+        // for an assumed-rank array, not for the element type.
+        if( physical_type != ASR::array_physical_typeType::AssumedRankArray ) {
+            return type;
+        }
+        // The detection below infers the physical type from the dimensions,
+        // and there are none here, so keep the one the caller asked for.
+        override_physical_type = true;
     }
 
     for( size_t i = 0; i < n_dims; i++ ) {
@@ -4360,6 +4370,19 @@ static inline ASR::ttype_t* duplicate_type(Allocator& al, const ASR::ttype_t* t,
                     physical_type = ASR::array_physical_typeType::UnboundedPointerArray;
                     override_physical_type = true;
                 }
+            }
+            // An assumed-rank array is the one Array that carries no
+            // dimensions, so duplicating it would otherwise hand
+            // make_Array_t_util zero dimensions and collapse it to its element
+            // type. Its physical type cannot be re-derived from dimensions
+            // that do not exist either, which is the same reason
+            // UnboundedPointerArray is preserved above. Only preserve it when
+            // the duplicate really ends up rankless: a caller supplying
+            // dimensions is selecting a rank, as `select rank` does.
+            if (!override_physical_type && dimsn == 0 &&
+                tnew->m_physical_type == ASR::array_physical_typeType::AssumedRankArray) {
+                physical_type = ASR::array_physical_typeType::AssumedRankArray;
+                override_physical_type = true;
             }
             return ASRUtils::make_Array_t_util(al, tnew->base.base.loc,
                 duplicated_element_type, dimsp, dimsn, ASR::abiType::Source,

--- a/src/libasr/pass/transform_optional_argument_functions.cpp
+++ b/src/libasr/pass/transform_optional_argument_functions.cpp
@@ -438,7 +438,17 @@ bool fill_new_args(Vec<ASR::call_arg_t>& new_args, Allocator& al,
                     }
                 }
                 ASR::symbol_t* arg_decl = func_arg_j->m_type_declaration;
-                if( ASR::is_a<ASR::Array_t>(*arg_type) ) { // Create dummy array dims
+                if( ASR::is_a<ASR::Array_t>(*arg_type) &&
+                    ASR::down_cast<ASR::Array_t>(arg_type)->m_physical_type ==
+                        ASR::array_physical_typeType::AssumedRankArray ) {
+                    // An assumed-rank dummy has no rank to copy dimensions
+                    // from, and assumed rank is only meaningful on a dummy
+                    // argument anyway. This placeholder stands in for an
+                    // argument that is absent, so it is never accessed and
+                    // the element type is enough.
+                    arg_type = ASRUtils::duplicate_type(al,
+                        ASR::down_cast<ASR::Array_t>(arg_type)->m_type);
+                } else if( ASR::is_a<ASR::Array_t>(*arg_type) ) { // Create dummy array dims
                     ASR::Array_t* array_t = ASR::down_cast<ASR::Array_t>(arg_type);
                     Vec<ASR::dimension_t> dims;
                     dims.reserve(al, array_t->n_dims);


### PR DESCRIPTION
## Summary

Fixes #12683.

An assumed-rank dummy argument that is referenced from a contained procedure is
hoisted by the `nested_vars` ASR pass into a nested-context module variable. The
hoisted variable's type is built with `ASRUtils::duplicate_type_with_empty_dims`,
which asks for "the same type, extents unknown".

An assumed-rank array is represented in ASR as an `Array` with **zero**
dimensions and physical type `AssumedRankArray` — the rank is not known until a
`select rank` selects one. So `duplicate_type_with_empty_dims` handed
`duplicate_type` an empty dimension vector, `duplicate_type` handed it to
`make_Array_t_util`, and `make_Array_t_util`'s `n_dims == 0 -> return element
type` rule collapsed the assumed-rank array down to a bare `Real`. The
nested-context variable was then typed `Pointer(Real)`, and the `select rank` in
the contained procedure hit

```
LCompilersException: Cannot extract the physical type of 2 type.
```

(`2` is `ASR::ttypeType::Real`) at `nested_vars.cpp:453`, where
`replace_ArrayPhysicalCast` re-derives `m_old` from the replaced argument.

## Scope

`src/libasr/asr_utils.h`:

1. `make_Array_t_util` no longer collapses a zero-dimension array to its element
   type when the requested physical type is `AssumedRankArray`. Zero dimensions
   *is* the representation of an assumed-rank array, so asking for that physical
   type is a request for an assumed-rank array, not for the element type. Every
   other physical type keeps the old behaviour. The physical-type detection that
   follows is also skipped in that case: it infers the physical type by
   inspecting dimensions, and with none to inspect it would fall through to
   `PointerArray` and produce a zero-dimension array the ASR verifier rejects.
2. `duplicate_type`'s `Array` case preserves `AssumedRankArray` when the
   duplicate genuinely ends up rankless (`dimsn == 0`) and the caller is not
   overriding the physical type. This mirrors the `UnboundedPointerArray`
   preservation a few lines above, and for the same reason. The `dimsn == 0`
   guard means a caller that supplies real dimensions — which is how
   `select rank` builds a rank-N view of an assumed-rank dummy — is unaffected.

`src/libasr/pass/transform_optional_argument_functions.cpp`:

3. When an optional argument is absent, this pass creates a local placeholder
   variable typed from the dummy, then copies the dummy's dimensions onto it.
   For an assumed-rank dummy it was previously handed the element type, because
   `duplicate_type` silently collapsed it — so the "copy the dimensions" branch
   never ran. With the collapse fixed the branch does run, copies zero
   dimensions, and builds an invalid zero-dimension `PointerArray`. The pass now
   says explicitly what it was getting by accident: a placeholder for an absent
   argument is never accessed, and a local variable cannot carry assumed rank,
   so the element type is used. Generated code is unchanged from before this PR
   (`assumed_rank_04` covers this path).

The fix is in the shared ASR type utilities rather than in `nested_vars.cpp`,
because the invariant broken is "duplicating a type yields the same type"; any
pass that duplicates an assumed-rank type hit the same silent degradation. No
backend or codegen change is needed — ASR now carries the correct type and LLVM
lowers what it is given.

`integration_tests/assumed_rank_16.f90` is the new test, registered with the
`gfortran` and `llvm` labels.

## Verification

The new test fails before the change and passes after.

Before (this branch with the compiler changes reverted, rebuilt):

```
$ ./src/bin/lfortran integration_tests/assumed_rank_16.f90 -o /tmp/ar16
...
  File ".../src/libasr/pass/nested_vars.cpp", line 453
  File ".../src/libasr/asr_utils.h", line 1037
LCompilersException: Cannot extract the physical type of 2 type.
exit=1
```

After:

```
$ ./src/bin/lfortran integration_tests/assumed_rank_16.f90 -o /tmp/ar16
exit=0
$ /tmp/ar16
2.00000000 4.00000000 6.00000000 8.00000000
2.00000000 4.00000000 6.00000000 8.00000000
exit=0
```

gfortran 16.1.0 produces the same values on the same file, and the test's own
`error stop` checks verify them rather than relying on the printed output.

The reproducer posted in the issue also compiles now:

```
$ ./src/bin/lfortran -c re_issue_12683.f90
exit=0
```

Suites (macOS arm64, Debug + LLVM, in-tree build):

```
$ cd integration_tests && ./run_tests.py -j4
100% tests passed, 0 tests failed out of 4133

$ ./run_tests.py
TESTS PASSED      (1286 tests)
```

The reference suite initially reported one failure, `stop_03`, whose only
difference was this machine's `ld: warning: building for macOS-15.0, but
linking with dylib ... built for newer version 15.7`. Re-running that test
alone with `MACOSX_DEPLOYMENT_TARGET=15.7` passes, confirming it is a local
SDK-mismatch artifact rather than anything to do with this change; the run
above sets that variable.

## Rationale

PR #12711 targets the same issue and reached the same conclusion about
`make_Array_t_util`; I traced the crash independently and verified that half
myself before reading it. I differ on the rest: #12711 adds an
`AssumedRankArray` branch to `duplicate_type_for_nested_context` in
`nested_vars.cpp`, which fixes this one pass. Putting the preservation in
`duplicate_type` instead fixes every caller that duplicates an assumed-rank
type, keeps it next to the existing `UnboundedPointerArray` special case that
exists for exactly the same reason, and leaves `nested_vars.cpp` untouched. It
does surface one caller — `transform_optional_argument_functions` — that was
depending on the collapse; that is change 3 above, and it is a no-op on
generated code.

On the second half of the report — the diagnostic. `extract_physical_type`
throws a bare `LCompilersException` carrying an ASR enum ordinal and no source
location, which is why the reporter got nothing actionable out of a
thousands-of-lines file. Improving it means threading a `Location` through
`ASRUtils::extract_physical_type` and its callers; that is worth doing but is a
separate change, and AGENTS.md asks that refactoring not be mixed into a bug
fix, so it is not part of this PR.
