### PR TITLE
Copy a parenthesized ASSOCIATE selector

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2828,6 +2828,8 @@ RUN(NAME associate_54 LABELS gfortran llvm)
 RUN(NAME associate_55 LABELS gfortran llvm)
 RUN(NAME associate_56 LABELS llvm)
 RUN(NAME associate_57 LABELS gfortran llvm)
+RUN(NAME associate_58 LABELS gfortran llvm)
+RUN(NAME associate_59 LABELS llvm)
 
 RUN(NAME attr_dim_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)
 RUN(NAME attr_dim_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc fortran)

--- a/integration_tests/associate_58.f90
+++ b/integration_tests/associate_58.f90
@@ -1,0 +1,67 @@
+! ASSOCIATE with a parenthesized selector.
+!
+! A parenthesized selector `(x)` is a primary (R1001), not a designator, so per
+! F2018 11.1.3.3 the selector is an expression: it is evaluated when the
+! ASSOCIATE statement executes and the associate name holds a copy of its value.
+! Redefining `x` inside the block must not be visible through the associate
+! name. Without the parentheses the selector is a variable and the associate
+! name is associated with its storage, so the redefinition *is* visible.
+!
+! This file only covers scalar selectors, which GFortran gets right. The array
+! case lives in associate_59, which cannot be labelled `gfortran`.
+program associate_58
+    implicit none
+    integer :: a, b
+    real :: r
+    logical :: l
+    character(len=3) :: c
+
+    ! Parenthesized integer scalar: the associate name is a copy
+    a = 1
+    b = 2
+    associate (p => (a))
+        a = b
+        if (p /= 1) error stop 1
+    end associate
+    if (a /= 2) error stop 2
+
+    ! Nested parentheses are still just an expression
+    a = 1
+    associate (p => ((a)))
+        a = 9
+        if (p /= 1) error stop 3
+    end associate
+
+    ! Real scalar
+    r = 1.5
+    associate (p => (r))
+        r = 2.5
+        if (abs(p - 1.5) > 1.0e-6) error stop 4
+    end associate
+
+    ! Logical scalar
+    l = .true.
+    associate (p => (l))
+        l = .false.
+        if (.not. p) error stop 5
+    end associate
+
+    ! Character scalar
+    c = "abc"
+    associate (p => (c))
+        c = "xyz"
+        if (p /= "abc") error stop 6
+        if (len(p) /= 3) error stop 7
+    end associate
+
+    ! Without the parentheses the selector is a variable, so the associate name
+    ! must stay associated with its storage and see the redefinition
+    a = 1
+    b = 2
+    associate (p => a)
+        a = b
+        if (p /= 2) error stop 8
+    end associate
+
+    print *, "ok"
+end program associate_58

--- a/integration_tests/associate_59.f90
+++ b/integration_tests/associate_59.f90
@@ -1,0 +1,45 @@
+! ASSOCIATE with a parenthesized array selector.
+!
+! A parenthesized selector `(x)` is a primary (R1001), not a designator, so per
+! F2018 11.1.3.3 the selector is an expression: it is evaluated when the
+! ASSOCIATE statement executes and the associate name holds a copy of its value.
+! The block below therefore swaps a and b.
+!
+! This test is not labelled `gfortran`: GFortran 16.1 aliases the associate
+! name to the selector at every optimization level and prints
+! "a = 4 5 6, b = 4 5 6". The scalar cases, which GFortran gets right, are in
+! associate_58. See https://github.com/lfortran/lfortran/issues/12611.
+program associate_59
+    implicit none
+    integer :: a(3), b(3)
+    real :: r(2)
+
+    a = [1, 2, 3]
+    b = [4, 5, 6]
+    associate (tmp => (a))
+        a = b
+        b = tmp
+    end associate
+    if (any(a /= [4, 5, 6])) error stop 1
+    if (any(b /= [1, 2, 3])) error stop 2
+
+    ! The copy has the shape of the selector and is independent of it
+    r = [1.0, 2.0]
+    associate (p => (r))
+        if (size(p) /= 2) error stop 3
+        r = [3.0, 4.0]
+        if (abs(p(1) - 1.0) > 1.0e-6) error stop 4
+        if (abs(p(2) - 2.0) > 1.0e-6) error stop 5
+    end associate
+
+    ! Without the parentheses the selector is a variable, so the associate name
+    ! must stay associated with its storage and see the redefinition
+    a = [1, 2, 3]
+    b = [4, 5, 6]
+    associate (tmp => a)
+        a = b
+        if (any(tmp /= [4, 5, 6])) error stop 6
+    end associate
+
+    print *, "ok"
+end program associate_59

--- a/src/lfortran/semantics/ast_body_visitor.cpp
+++ b/src/lfortran/semantics/ast_body_visitor.cpp
@@ -3222,53 +3222,70 @@ public:
             ASR::storage_typeType tmp_storage = ASR::storage_typeType::Default;
             bool create_associate_stmt = false;
 
-            if( ASR::is_a<ASR::Var_t>(*tmp_expr) ) {
-                create_associate_stmt = true;
-                ASR::Variable_t* variable = ASRUtils::EXPR2VAR(tmp_expr);
-                tmp_storage = variable->m_storage;
-                tmp_type = variable->m_type;
-            } else if (ASR::is_a<ASR::StructInstanceMember_t>(*tmp_expr)) {
-                create_associate_stmt = true;
-                ASR::StructInstanceMember_t* sim = ASR::down_cast<ASR::StructInstanceMember_t>(tmp_expr);
-                tmp_type = sim->m_type;
-            } else if (ASR::is_a<ASR::StringSection_t>(*tmp_expr)) {
-                create_associate_stmt = true;
-            } else if (ASR::is_a<ASR::ComplexRe_t>(*tmp_expr) ||
-                       ASR::is_a<ASR::ComplexIm_t>(*tmp_expr)) {
-                // Complex parts are designators. Associate them with the
-                // original storage instead of copying their current value.
-                create_associate_stmt = true;
-            } else if( ASR::is_a<ASR::ArraySection_t>(*tmp_expr) ) {
-                create_associate_stmt = true;
-                ASR::ArraySection_t* tmp_array_section = ASR::down_cast<ASR::ArraySection_t>(tmp_expr);
-                ASR::ttype_t* base_type = nullptr;
-                if (ASR::is_a<ASR::Var_t>(*tmp_array_section->m_v)) {
-                    ASR::Variable_t* variable = ASRUtils::EXPR2VAR(tmp_array_section->m_v);
+            // A parenthesized selector `(x)` is a primary (R1001), not a
+            // designator, so per F2018 11.1.3.3 the selector is an expression.
+            // It is evaluated when the ASSOCIATE statement executes and the
+            // associate name holds a copy of its value, so a later redefinition
+            // of `x` is not visible through the associate name. None of the
+            // designator cases below, which alias the associate name to the
+            // selector's storage, may therefore apply. The parentheses are
+            // dropped by visit_Parenthesis, so this is decided on the AST.
+            if( !AST::is_a<AST::Parenthesis_t>(*x.m_syms[i].m_initializer) ) {
+                if( ASR::is_a<ASR::Var_t>(*tmp_expr) ) {
+                    create_associate_stmt = true;
+                    ASR::Variable_t* variable = ASRUtils::EXPR2VAR(tmp_expr);
                     tmp_storage = variable->m_storage;
-                    base_type = variable->m_type;
-                } else {
-                    base_type = ASRUtils::expr_type(tmp_array_section->m_v);
-                }
-                ASR::dimension_t *var_dims;
-                ASRUtils::extract_dimensions_from_ttype(base_type, var_dims);
-                Vec<ASR::dimension_t> tmp_dims; tmp_dims.reserve(al, 1);
-                for ( size_t i = 0; i < tmp_array_section->n_args; i++ ) {
-                    if (tmp_array_section->m_args[i].m_left) {
-                        tmp_dims.push_back(al, var_dims[i]);
+                    tmp_type = variable->m_type;
+                } else if (ASR::is_a<ASR::StructInstanceMember_t>(*tmp_expr)) {
+                    create_associate_stmt = true;
+                    ASR::StructInstanceMember_t* sim = ASR::down_cast<ASR::StructInstanceMember_t>(tmp_expr);
+                    tmp_type = sim->m_type;
+                } else if (ASR::is_a<ASR::StringSection_t>(*tmp_expr)) {
+                    create_associate_stmt = true;
+                } else if (ASR::is_a<ASR::ComplexRe_t>(*tmp_expr) ||
+                           ASR::is_a<ASR::ComplexIm_t>(*tmp_expr)) {
+                    // Complex parts are designators. Associate them with the
+                    // original storage instead of copying their current value.
+                    create_associate_stmt = true;
+                } else if( ASR::is_a<ASR::ArraySection_t>(*tmp_expr) ) {
+                    create_associate_stmt = true;
+                    ASR::ArraySection_t* tmp_array_section = ASR::down_cast<ASR::ArraySection_t>(tmp_expr);
+                    ASR::ttype_t* base_type = nullptr;
+                    if (ASR::is_a<ASR::Var_t>(*tmp_array_section->m_v)) {
+                        ASR::Variable_t* variable = ASRUtils::EXPR2VAR(tmp_array_section->m_v);
+                        tmp_storage = variable->m_storage;
+                        base_type = variable->m_type;
+                    } else {
+                        base_type = ASRUtils::expr_type(tmp_array_section->m_v);
                     }
+                    ASR::dimension_t *var_dims;
+                    ASRUtils::extract_dimensions_from_ttype(base_type, var_dims);
+                    Vec<ASR::dimension_t> tmp_dims; tmp_dims.reserve(al, 1);
+                    for ( size_t i = 0; i < tmp_array_section->n_args; i++ ) {
+                        if (tmp_array_section->m_args[i].m_left) {
+                            tmp_dims.push_back(al, var_dims[i]);
+                        }
+                    }
+                    tmp_type = ASRUtils::duplicate_type(al, base_type, &tmp_dims);
+                } else if (ASR::is_a<ASR::ArrayItem_t>(*tmp_expr)) {
+                    create_associate_stmt = true;
+                } else if (ASR::is_a<ASR::ArrayReshape_t>(*tmp_expr)) {
+                    create_associate_stmt = true;
+                } else if (ASR::is_a<ASR::FunctionCall_t>(*tmp_expr) &&
+                           ASRUtils::is_pointer(tmp_type)) {
+                    // A reference to a function with a data pointer result is a
+                    // variable, so the associate name must be associated with the
+                    // target the pointer refers to instead of being assigned a
+                    // copy of its value.
+                    create_associate_stmt = true;
                 }
-                tmp_type = ASRUtils::duplicate_type(al, base_type, &tmp_dims);
-            } else if (ASR::is_a<ASR::ArrayItem_t>(*tmp_expr)) {
-                create_associate_stmt = true;
-            } else if (ASR::is_a<ASR::ArrayReshape_t>(*tmp_expr)) {
-                create_associate_stmt = true;
-            } else if (ASR::is_a<ASR::FunctionCall_t>(*tmp_expr) &&
-                       ASRUtils::is_pointer(tmp_type)) {
-                // A reference to a function with a data pointer result is a
-                // variable, so the associate name must be associated with the
-                // target the pointer refers to instead of being assigned a
-                // copy of its value.
-                create_associate_stmt = true;
+            }
+
+            if ( !create_associate_stmt && ASR::is_a<ASR::Pointer_t>(*tmp_type) ) {
+                // The value of a pointer expression is copied into the
+                // associate name, which is an ordinary variable holding that
+                // copy and is not itself a pointer.
+                tmp_type = ASRUtils::type_get_past_pointer(tmp_type);
             }
 
             if ( create_associate_stmt && !ASR::is_a<ASR::Pointer_t>(*tmp_type) ) {


### PR DESCRIPTION
Fixes #12611.

## Summary

`associate (tmp => (a))` aliased `tmp` to `a` instead of copying it, so a
redefinition of `a` inside the block was silently visible through `tmp` and the
program below printed `a = 4 5 6 / b = 4 5 6` instead of swapping.

Per F2018 11.1.3.3, a parenthesized selector is a primary (R1001), not a
designator: the selector is an *expression*, it is evaluated when the ASSOCIATE
statement executes, and the associate name holds a copy of its value. A later
redefinition of the selector must not be visible through the associate name.

`BodyVisitor::visit_AssociateBlock` classified the selector purely from the ASR
expression it had just built. Because `visit_Parenthesis` forwards straight to
its operand, `(a)` arrived at that classification as a bare `ASR::Var_t` and
took the `ASR::Associate` (aliasing) branch, exactly as a bare `a` would.

The fix makes the decision in AST->ASR semantics, on the AST, ahead of the ASR
classification: when the selector's AST node is `AST::Parenthesis_t`, the whole
designator chain is skipped and the existing copying path is used, which emits
an explicit `ASR::Assignment` into a local of the associate block's symbol
table. The ASR therefore carries an explicit copy and the LLVM backend lowers
what it is given; no backend change was needed.

A second hunk strips `ASR::Pointer_t` from the type of the copy. The associate
name holds the *value* of a pointer expression, not the pointer itself, so it
needs storage of its own. Without this, `associate (t => (p))` for
`real, pointer :: p(:)` built an `Allocatable(Pointer(...))` variable and failed
ASR verification with "Allocatable type conflicts with Pointer type". This also
makes `is_contiguous` correct for a parenthesized non-contiguous pointer
section, which is the second program reported in the issue.

## Scope

Only the missing-copy bug of #12611.

- #12687 ("associated expression should not be definable") is a separate bug
  with its own PR (#12694) and is deliberately not addressed here. This change
  does not make it harder: the associate name is now an ordinary local variable
  rather than a pointer alias, which gives a definability check a cleaner thing
  to reject. No test here writes through an expression-bound associate name, so
  the two changes should not collide.
- Known remaining limitation, deliberately left for a follow-up:
  `parenthesis()` in `src/lfortran/parser/semantics.h` only builds an
  `AST::Parenthesis_t` when the operand is a `Name`; for every other operand the
  parser discards the parentheses outright. So `associate (t => (x(2:3)))`,
  `(s%c)` and `(z%re)` still alias, and by the time semantics runs the
  information needed to fix them no longer exists. Preserving parentheses around
  the other designator forms is a parser change that also changes
  actual-argument semantics (`call sub((x(1)))`), so it belongs in its own PR.
  The whole-variable form reported in #12611 is what this PR fixes.
- `lbound` of an expression-selector associate name is still the selector's
  lower bound rather than 1 (raised in a comment on #12611). That is a bounds
  question rather than a copying question, it is unchanged by this PR, and it is
  also left for a follow-up.

## Relation to #12626

@jassem-manita's PR #12626 targets the same bug and lands in the same function.
I wrote and verified this patch independently, and it differs deliberately in
two ways:

1. #12626 repeats a `!selector_is_parenthesized` guard on six branches of the
   `if`/`else if` chain. Two branches that landed on `main` after that PR was
   opened -- `ComplexRe`/`ComplexIm` and the pointer-result `FunctionCall` --
   are not guarded there, so a parenthesized selector reaching either of them
   would still alias. Guarding the chain as a whole is shorter and stays correct
   as branches are added.
2. #12626 does not handle a pointer-typed selector, which fails ASR
   verification rather than producing wrong results.

## Verification

Test placement, and the `gfortran` label. GFortran 16.1 has the same bug for
array selectors and still gets the issue's own program wrong at every
optimization level, so the array case cannot carry the `gfortran` label:

```
$ gfortran --version | head -1
GNU Fortran (conda-forge gcc 16.1.0-3) 16.1.0
$ gfortran -O0 -o t issue_12611.f90 && ./t
a =  4  5  6
b =  4  5  6
FAIL: parenthesized selector was not copied
$ gfortran -O2 -o t issue_12611.f90 && ./t      # same at -O2
```

GFortran does get the *scalar* cases right. So rather than drop the label
silently, the tests are split:

- `integration_tests/associate_58.f90`, labels `gfortran llvm` -- integer,
  real, logical and character scalar selectors, nested parentheses, and a
  control case checking that a selector *without* parentheses still aliases.
  This is a full demonstration of the fix that GFortran also passes.
- `integration_tests/associate_59.f90`, label `llvm` only -- the array case
  from the issue. The file header states why `gfortran` is absent, following
  the precedent of `conditional_expr_06.f90`.

Both files are verified against `flang -std=f2018` as the reference compiler.

Fails before the change, passes after (in-tree build, same worktree):

```
# before (this commit's source change reverted, everything else identical)
$ cd integration_tests && ./run_tests.py -b llvm -t associate_58
1/1 Test #2152: associate_58 .....................***Failed    0.11 sec
ERROR STOP 1
0% tests passed, 1 tests failed out of 1

$ ./run_tests.py -b llvm -t associate_59
1/1 Test #2153: associate_59 .....................***Failed    0.13 sec
ERROR STOP 2
0% tests passed, 1 tests failed out of 1

# after
$ ./run_tests.py -b llvm -t associate_58
1/1 Test #2152: associate_58 .....................   Passed    0.13 sec
100% tests passed, 0 tests failed out of 1

$ ./run_tests.py -b llvm -t associate_59
1/1 Test #2153: associate_59 .....................   Passed    0.13 sec
100% tests passed, 0 tests failed out of 1

$ ./run_tests.py -b gfortran -t associate_58
1/1 Test #2183: associate_58 .....................   Passed    0.10 sec
100% tests passed, 0 tests failed out of 1
```

The issue's own two programs, with the fix:

```
$ lfortran issue_12611.f90 && ./a.out
a =  4  5  6
b =  1  2  3
PASS

$ lfortran issue_12611_props.f90 && ./a.out
is_contiguous(y) = T      # was F
is_contiguous(t) = T
lbound(y) = -2            # still -2, see Scope above
```

Full suites, both green:

```
$ ./run_tests.py &> log_ref            # 1286 tests
TESTS PASSED

$ cd integration_tests && ./run_tests.py -j4 &> log_int
100% tests passed, 0 tests failed out of 4134
```

## Rationale

Whether an ASSOCIATE selector is a variable or an expression is a semantic
question about the source, so it is answered in AST->ASR and recorded
explicitly in the ASR: the aliasing case emits `ASR::Associate`, the expression
case emits `ASR::Assignment` into a local. Backends see the difference already
made for them and lower it mechanically.

The distinguishing information only exists on the AST -- `visit_Parenthesis`
drops the parentheses on the way to ASR -- so the check has to happen before
the ASR expression is classified, which is where it now is. Guarding the chain
as a whole, rather than each branch, keeps the rule stated once: a parenthesized
selector is never a designator.
