### PR TITLE
ci: cut CI queue time without losing coverage

### DIFF
--- a/.github/workflows/Exhaustive-Checks-CI.yml
+++ b/.github/workflows/Exhaustive-Checks-CI.yml
@@ -219,7 +219,19 @@ jobs:
         # exactly the same manner, to ensure that users can just change the
         # `llvmdev` version in their conda environment and everything will just
         # work.
-        llvm-version: ["8", "10", "11", "15", "17", "18", "19", "21", "22", "23"]
+        #
+        # Rotation: every LLVM version is tested on every push to main (i.e.
+        # on every merge), so a version-specific break is caught within one
+        # merge. On a pull request we test only the versions where breakage
+        # actually originates:
+        #   8  - oldest supported; catches use of newer LLVM APIs
+        #   11 - our default version
+        #   19 - the only job that runs the llvm_wasm / llvm_wasm_emcc tests
+        #   23 - newest; catches removed/deprecated LLVM APIs
+        # The intermediate versions differ from their neighbours only in ways
+        # these four already bracket. macOS LLVM 22 is in `include` below and
+        # so runs in both cases.
+        llvm-version: "${{ github.event_name == 'push' && fromJSON('[\"8\",\"10\",\"11\",\"15\",\"17\",\"18\",\"19\",\"21\",\"22\",\"23\"]') || fromJSON('[\"8\",\"11\",\"19\",\"23\"]') }}"
         python-version: ["3.10"]
         include:
           - os: macos-latest
@@ -398,7 +410,7 @@ jobs:
         run: micromamba install -y -n lf libunwind=1.7.2
 
       - name: Setup WASI SDK
-        if: contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')
+        if: contains(matrix.llvm-version, '19')
         shell: bash -e -l {0}
         run: |
           mkdir -p $HOME/ext
@@ -411,7 +423,7 @@ jobs:
           $WASI_SDK_PATH/bin/clang --version
 
       - name: Install wasmtime
-        if: contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')
+        if: contains(matrix.llvm-version, '19')
         shell: bash -e -l {0}
         run: |
           cd $HOME
@@ -421,7 +433,7 @@ jobs:
           wasmtime --version
 
       - name: Setup Emscripten SDK
-        if: contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')
+        if: contains(matrix.llvm-version, '19')
         shell: bash -e -l {0}
         run: |
           mkdir -p $HOME/ext
@@ -436,7 +448,7 @@ jobs:
           ./emsdk activate 3.1.35
 
       - name: Build Linux ( WASM )
-        if: contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19')
+        if: contains(matrix.llvm-version, '19')
         shell: bash -e -l {0}
         run: |
             export WASI_SDK_PATH=$HOME/ext/wasi-sdk
@@ -469,7 +481,7 @@ jobs:
             ./run_tests.py -b llvm_wasm llvm_wasm_emcc
 
       - name: Build
-        if: ${{! (contains(matrix.llvm-version, '10') || contains(matrix.llvm-version, '19'))}}
+        if: ${{! contains(matrix.llvm-version, '19')}}
         shell: bash -e -l {0}
         run: |
             ./build0.sh
@@ -493,7 +505,10 @@ jobs:
         run: |
             export PATH="$(pwd)/src/bin:$PATH"
             LAPACK_MODE="smoke"
-            if [[ "${{ matrix.llvm-version }}" == "11" || "${{ matrix.llvm-version }}" == "21" ]]; then
+            # The full Reference-LAPACK suite costs ~10 min more than smoke.
+            # It exercises LFortran, not LLVM, so run it on the default
+            # version only; every other version still runs it in smoke mode.
+            if [[ "${{ matrix.llvm-version }}" == "11" ]]; then
                 LAPACK_MODE="full"
             fi
             echo "Running LAPACK third-party mode: ${LAPACK_MODE}"

--- a/.github/workflows/Quick-Checks-CI.yml
+++ b/.github/workflows/Quick-Checks-CI.yml
@@ -33,10 +33,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS runs LLVM 11 only. A full integration-test pass costs ~7x
+          # more on the 3-core macOS runners than on Linux, and macOS + a
+          # recent LLVM is covered on every merge by the Exhaustive checks
+          # "Test LLVM 22 (macos-latest)" job.
           - os: macos-latest
             llvm-version: "11"
-          - os: macos-latest
-            llvm-version: "21"
           - os: ubuntu-latest
             llvm-version: "11"
           - os: ubuntu-latest
@@ -147,16 +149,16 @@ jobs:
         run: |
             ./test_lfortran_cmdline
 
+      # --std=f23 is a compile-flag sweep over the whole suite rather than a
+      # distinct set of tests, and it is not platform specific, so run it on
+      # Linux only where a full pass is ~7x cheaper than on macOS.
       - name: Test with specific Fortran standard
         shell: bash -e -l {0}
-        if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+        if: contains(matrix.os, 'ubuntu')
         run: |
             cd ./integration_tests
-            case "$OSTYPE" in darwin*) J_FLAG="-j3";; *) J_FLAG="";; esac
-            ./run_tests.py -b llvm --std=f23 $J_FLAG
-            if [[ "$OSTYPE" != darwin* ]]; then
-                ./run_tests.py -b llvm -f --std=f23 -nf16 $J_FLAG
-            fi
+            ./run_tests.py -b llvm --std=f23
+            ./run_tests.py -b llvm -f --std=f23 -nf16
 
       - name: Test Metal GPU backend (macOS)
         shell: bash -e -l {0}

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -57,11 +57,16 @@ if [[ $WIN != "1" ]]; then
     fi
 
     cd integration_tests
+    # Check that CMake can detect and drive lfortran as a Fortran compiler
+    # without any help. run_tests.py below bypasses this detection with
+    # -DCMAKE_Fortran_COMPILER_WORKS=1, so this configure step is the only
+    # place we exercise it. Build and run just the two CMake-driven tests:
+    # building the whole suite here duplicates `run_tests.py -b llvm` below.
     mkdir build-lfortran-llvm
     cd build-lfortran-llvm
     FC="../../src/bin/lfortran" cmake -DLFORTRAN_BACKEND=llvm -DCURRENT_BINARY_DIR=. ..
-    make -j${NPROC}
-    ctest -L llvm -j${NPROC}
+    make -j${NPROC} program_cmake_01 program_cmake_02
+    ctest -j${NPROC} -R program_cmake
     cd ..
 
     ./run_tests.py -b llvm llvm2 llvm_rtlib llvm_nopragma llvm_integer_8 llvmImplicit -j${NPROC}
@@ -82,7 +87,12 @@ if [[ $WIN != "1" ]]; then
     if [[ $MACOS != "1" ]]; then
         ./run_tests.py -b llvm_submodule -sc -j${NPROC}
     fi
-    ./run_tests.py -b llvm --detect-leaks
+    # Leak detection is a compile-flag sweep over the whole suite; it is not
+    # platform specific, so run it on Linux only (a full pass costs ~7x more
+    # on the 3-core macOS runners).
+    if [[ $MACOS != "1" ]]; then
+        ./run_tests.py -b llvm --detect-leaks -j${NPROC}
+    fi
     cd ..
 
     pip install src/server/tests tests/server


### PR DESCRIPTION
## Summary

The CI queue has grown to 4–8 hours. Measured on run [34610019120](https://github.com/lfortran/lfortran/actions/runs/34610019120) (Quick checks) and [34610477141](https://github.com/lfortran/lfortran/actions/runs/34610477141) (Exhaustive checks), both on `main`:

| | jobs | machine-min | worst queue |
|---|---|---|---|
| Quick checks | 6 | 416 | 284 min (macOS) |
| Exhaustive checks | 20 | 537 | 519 min (macOS) |

The integration suite has grown from 2044 to 4424 `RUN()` entries in twelve months. The key measurement: **running** the tests is nearly free — `ctest -L llvm -j3` executed all 4126 binaries in **9 seconds** — but **compiling** them is not. One full pass costs **4.3 min on Linux and 28.6 min on the 3-core macOS runners**, so every extra pass costs ~7x more on macOS. macOS was doing eight of them.

Step breakdown for `LFortran CI (OS=macos-latest, LLVM=11)`, 143 min total:

| phase | min |
|---|---|
| build lfortran | 4.0 |
| `ctest` + reference `run_tests.py` | 7.3 |
| `make -j3` in `build-lfortran-llvm` | 28.6 |
| `run_tests.py -b llvm llvm2 …` | 29.2 |
| `run_tests.py -b llvm --detect-leaks` | 28.9 |
| `run_tests.py -b llvm --std=f23` | 30.2 |
| metal / cuda_cpu | 9.1 |

## Scope

**Quick checks**

- `ci/test.sh` built the whole suite **twice**. The hand-written `cmake`/`make`/`ctest -L llvm` in `build-lfortran-llvm` does exactly what `run_tests.py -b llvm` does on the next line (both reported the same 4126 tests). Its only unique value is letting CMake *detect* lfortran as a Fortran compiler, which `run_tests.py` bypasses with `-DCMAKE_Fortran_COMPILER_WORKS=1`. The configure step is kept; only `program_cmake_01`/`program_cmake_02` are built and run there.
- `--detect-leaks` and `--std=f23` are compile-flag sweeps over the same tests, not distinct tests, and are not platform specific. They now run on Linux only.
- The macOS LLVM 21 job is dropped.

**Exhaustive checks**

- LLVM 10 built a Debug WASM-target compiler it never used: `Test Linux ( WASM )` was narrowed to LLVM 19 in e3b9d2e5dc, but the WASI/wasmtime/emsdk setup and `Build Linux ( WASM )` steps were left on `'10' || '19'`. Running third-party codes against that Debug build is why LLVM 10 took **60 min vs 24** for every other version. It now takes the same Release build as the rest.
- The LLVM matrix rotates: all ten versions on every push to `main`, and `{8, 11, 19, 23}` + macOS 22 on pull requests.
- Full Reference-LAPACK runs on LLVM 11 only (it was on 11 and 21); every other version still runs it in smoke mode.

## Coverage

Effective `run_tests.py` / `make` / `ctest` invocations in `ci/test.sh`, before vs after:

| config | change |
|---|---|
| Linux LLVM 11 | duplicate full build removed; `--detect-leaks` kept (now `-j${NPROC}`) — **11 → 11** |
| Linux LLVM 21 | same — **10 → 10** |
| macOS LLVM 11 | duplicate removed, `--detect-leaks` moved to Linux — **7 → 6** |

Every LLVM matrix entry still resolves to exactly one micromamba env and exactly one build step, on both the push and the pull-request path. Retained on pull requests: `llvm_wasm` + `llvm_wasm_emcc` (LLVM 19), third-party codes against a **Debug** build (LLVM 19), full LAPACK (LLVM 11), macOS + recent LLVM (macOS 22), caffeine coarray tests (all).

One genuine reduction, stated plainly: **macOS/ARM with a recent LLVM no longer runs the integration suite on every PR.** macOS is still covered on every PR by LLVM 11, LLVM 21 is still covered on every PR by ubuntu, and macOS + LLVM 22 still builds and runs third-party codes on every merge. A failure needing *both* a macOS-specific path *and* LLVM-version-specific behaviour would now surface at merge rather than on the PR.

## Verification

- LLVM 10 builds clean in Release with the exact flags of the `Build` step (`pixi -e llvm10`, exit 0) — this is the config change LLVM 10 picks up.
- The new `ci/test.sh` block was run locally: CMake's Fortran compiler detection against `FC=lfortran` configures (exit 0), `make -j8 program_cmake_01 program_cmake_02` builds, `ctest -R program_cmake` selects exactly 2 tests, both pass.
- Both workflow files parse; matrix `if:` conditions were simulated for all 11 push entries and all 5 pull-request entries.

## Expected effect

| | before | after |
|---|---|---|
| macOS per Quick run | 266 min | ~55 min |
| Quick checks total | 416 | ~197 |
| Exhaustive on a PR | 537 | ~320 |
| Exhaustive on merge | 537 | ~495 |

Roughly 34,000 machine-minutes/day today; this should remove around half.

Not included here (discussed but out of scope): batching test compiles via `llvm_single_invocation`, and caching built test binaries. Those address the underlying per-file compile cost, which is what will bring this back as the suite keeps growing ~200 tests/month.