### PR TITLE
fix: reject an equivalence between two common block variables

### DIFF
--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -6676,12 +6676,14 @@ public:
 
                                     target_var_ref = array_item2->m_v;
                                     if (!ASR::is_a<ASR::Var_t>(*target_var_ref)) {
-                                        // Both objects belong to a common block,
-                                        // so neither of them can be made an alias
-                                        // of the other.
+                                        // Both sides are in a common block, which
+                                        // already fixes their storage: the
+                                        // equivalence either contradicts that
+                                        // layout or associates two different
+                                        // blocks, and both are prohibited.
                                         diag.semantic_error_label(
-                                            "equivalence between two common block objects is not supported",
-                                            {x.base.base.loc}, "unsupported equivalence");
+                                            "equivalence between two common block variables is not allowed",
+                                            {loc}, "both variables are in a common block");
                                         throw SemanticAbort();
                                     }
                                     ASR::Var_t* var = ASR::down_cast<ASR::Var_t>(target_var_ref);

--- a/tests/errors/continue_compilation_1.f90
+++ b/tests/errors/continue_compilation_1.f90
@@ -1216,3 +1216,15 @@ subroutine decimal_specifier_1()
     write(*, *, decimal=1) 1.0
     write(*, *, decimal="POINT", decimal="COMMA") 1.0
 end subroutine
+
+! A common block fixes the storage of its variables, so equivalencing two of
+! them either contradicts that layout or associates two different blocks.
+module equivalence_two_commons_1
+    implicit none
+contains
+    subroutine equivalence_two_common_arrays()
+        real :: lhs(4), rhs(4)
+        common /equivalence_two_commons/ lhs, rhs
+        equivalence (lhs(1), rhs(1))  ! {Error} equivalence between two common block variables is not allowed
+    end subroutine
+end module

--- a/tests/reference/asr-continue_compilation_1-04b6d40.json
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.json
@@ -2,12 +2,12 @@
     "basename": "asr-continue_compilation_1-04b6d40",
     "cmd": "lfortran --semantics-only --continue-compilation --no-color {infile}",
     "infile": "tests/errors/continue_compilation_1.f90",
-    "infile_hash": "fa38d26599693c58fd86b7f167845fb207c03cbc7d1ce67923198fcd",
+    "infile_hash": "0ff4ef92247d6e89d523b43d0ceef519663f7a7c20f9d3feff0a5bed",
     "outfile": null,
     "outfile_hash": null,
     "stdout": null,
     "stdout_hash": null,
     "stderr": "asr-continue_compilation_1-04b6d40.stderr",
-    "stderr_hash": "221186835099d0c853433ecc9fe32983f1d0ce3e9917b262ff075875",
+    "stderr_hash": "363b131aa2f9f4dc82093fd7d4e4c5c22af10d23ee472ef526ad8f3b",
     "returncode": 1
 }

--- a/tests/reference/asr-continue_compilation_1-04b6d40.stderr
+++ b/tests/reference/asr-continue_compilation_1-04b6d40.stderr
@@ -652,6 +652,12 @@ semantic error: 'binding_outside_module_proc' must be a module procedure or an e
 1208 |         procedure, pass(this) :: binding_outside_module_proc  ! {Error} 'binding_outside_module_proc' must be a module procedure or an external procedure with an explicit interface
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
+semantic error: equivalence between two common block variables is not allowed
+    --> tests/errors/continue_compilation_1.f90:1228:22
+     |
+1228 |         equivalence (lhs(1), rhs(1))  ! {Error} equivalence between two common block variables is not allowed
+     |                      ^^^^^^ both variables are in a common block
+
 semantic error: Statement function 'statement_function_name_conflict' conflicts with function name
   --> tests/errors/continue_compilation_1.f90:72:9
    |


### PR DESCRIPTION
## Summary

This is #12735 by @himanshumahajan138, rebased on top of current `main` (after #12770 was merged). The commit keeps its original author.

#12770 and #12735 fixed #12678 with the same swap logic, so after the rebase the only change left from #12735 is the handling of an `EQUIVALENCE` between two `COMMON` block variables. `main` already rejects it, but with a vague message pointing at the whole statement:

```
semantic error: equivalence between two common block objects is not supported
 --> two_common.f90:7:9
  |
7 |         equivalence (lhs(1), rhs(1))
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
```

This PR says the statement is not allowed (GFortran rejects both the same-block and the two-block case), labels the offending object, and adds a `continue_compilation_1` test for it, which `main` does not have:

```
semantic error: equivalence between two common block variables is not allowed
 --> two_common.f90:7:22
  |
7 |         equivalence (lhs(1), rhs(1))
  |                      ^^^^^^ both variables are in a common block
```

## Scope

- `src/lfortran/semantics/ast_common_visitor.h`: error message, location and label for the both-in-`COMMON` case.
- `tests/errors/continue_compilation_1.f90`: new test case appended at the end.
- `tests/reference/asr-continue_compilation_1-04b6d40.{json,stderr}`: regenerated.

What happened to the commits of #12735 during the rebase:

- a44c9ef (swap fix plus `equivalence_47`) was dropped. `main` already has the same logic from #12770, and its `equivalence_47` is a superset of the one here, since it also checks writes through the three-element alias.
- cf09505 was cherry-picked. Conflicts were resolved to `main`, keeping only this commit's hunk, and the references were regenerated in the same commit.
- The merge commits, `rerun-trigger`, and the two reference fixups after merges were dropped as no longer needed.

Refs #12678. Case I of that issue (no `COMMON` block, `equivalence (w(1), ws(7501))`) still fails at runtime on both `main` and this branch, with `Array 'w' index out of bounds. Tried to access index -7499`. That is the offset problem noted in the #12770 review. It is a separate bug and is not addressed here.

## Verification

The new `continue_compilation_1` case fails with a `main` build:

```
$ ./run_tests.py -t errors/continue_compilation_1.f90
< semantic error: equivalence between two common block variables is not allowed
<     --> tests/errors/continue_compilation_1.f90:1228:22
> semantic error: equivalence between two common block objects is not supported
>     --> tests/errors/continue_compilation_1.f90:1228:9
<      |                      ^^^^^^ both variables are in a common block
>      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unsupported equivalence
(exit 1)
```

It passes on this branch:

```
$ ./run_tests.py -t errors/continue_compilation_1.f90
errors/continue_compilation_1.f90 * asr ✓
TESTS PASSED
```

Suites on this branch (macOS ARM, Debug, LLVM):

- `integration_tests/run_tests.py -j16`: 4147/4147 pass.
- `./run_tests.py --no-llvm`: passes. The LLVM-IR reference outputs were skipped because my local build uses LLVM 21 (opaque pointers, `ptr` vs `i8**`). That makes those outputs differ identically on `main`, so the difference is unrelated.

## Rationale

A `COMMON` block already fixes the storage of its variables. An equivalence between two of them either contradicts that layout (same block) or associates the storage sequences of two different blocks. Both are prohibited, so "not allowed" is more accurate than "not supported", which suggests missing functionality. Pointing the label at the object helps when an `EQUIVALENCE` statement lists several sets.
