### PR TITLE
fix: skip String length checks on unresolved externals

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -1986,6 +1986,7 @@ RUN(NAME modules_70 LABELS gfortran llvm)
 RUN(NAME modules_71 LABELS gfortran llvm)
 RUN(NAME modules_72 LABELS gfortran llvm
         EXTRAFILES modules_72_stypemod.f90 modules_72_otypemod.f90)
+RUN(NAME modules_73 LABELS gfortran llvm EXTRAFILES modules_73_mod.f90)
 RUN(NAME module_func_generic_submodule LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME associate_06 LABELS gfortran EXTRAFILES
         associate_06_module.f90)

--- a/integration_tests/modules_73.f90
+++ b/integration_tests/modules_73.f90
@@ -1,0 +1,8 @@
+program modules_73
+    use modules_73_mod_b, only: s
+    integer :: k1, k2
+    call s(k1, k2)
+    print *, k1, k2
+    if (k1 /= 5) error stop
+    if (k2 /= 3) error stop
+end program modules_73

--- a/integration_tests/modules_73_mod.f90
+++ b/integration_tests/modules_73_mod.f90
@@ -1,0 +1,17 @@
+module modules_73_mod_a
+    integer, parameter :: n = 5
+    integer :: m = 3
+end module modules_73_mod_a
+
+module modules_73_mod_b
+    use modules_73_mod_a, only: n, m
+contains
+    subroutine s(k1, k2)
+        integer, intent(out) :: k1, k2
+        character(len=:), allocatable :: c, d
+        allocate(character(len=n) :: c)
+        allocate(character(len=m) :: d)
+        k1 = len(c)
+        k2 = len(d)
+    end subroutine s
+end module modules_73_mod_b

--- a/src/libasr/asr_verify.cpp
+++ b/src/libasr/asr_verify.cpp
@@ -3408,7 +3408,10 @@ public:
         require(ASRUtils::is_supported_character_kind(x.m_kind),
             "String kind must be 1 or 4, found " + std::to_string(x.m_kind));
 /*General Check on the length*/ 
-        if(x.m_len){
+        // The length may reference an ExternalSymbol, which cannot be
+        // dereferenced before externals are resolved (e.g. during modfile
+        // deserialization), so only check it when check_external is set.
+        if(x.m_len && check_external){
             require(ASR::is_a<ASR::Integer_t>(*ASRUtils::type_get_past_pointer(
                 ASRUtils::type_get_past_allocatable(ASRUtils::expr_type(x.m_len)))),
                 "String length must be of type INTEGER,"
@@ -3416,7 +3419,7 @@ public:
                 ASRUtils::type_to_str_fortran_expr(ASRUtils::expr_type(x.m_len), x.m_len));
         }
 // Check Positive Length
-        if(x.m_len && ASRUtils::is_value_constant(x.m_len)){
+        if(x.m_len && check_external && ASRUtils::is_value_constant(x.m_len)){
             int64_t len{};
             ASRUtils::is_value_constant(x.m_len, len);
             require(len >= 0,


### PR DESCRIPTION
## Summary

Fixes #12786.

A module procedure doing `allocate(character(len=n) :: c)`, with `n`
use-imported from another module, produced a `.mod` file that could not be
loaded: any later `use` of the module crashed with `AssertFailed: e->m_external`.

## Rationale

The Allocate type-spec keeps the length as `(Var n)`, where `n` is an
ExternalSymbol. When a modfile is deserialized, `asr_verify` runs with
`check_external = false`, before external symbols are resolved.
`VerifyVisitor::visit_String` still computed the length's type
(`expr_type`) and checked whether it is a constant (`is_value_constant`).
Both dereference the unresolved ExternalSymbol, which crashed.

Both length checks now run only when `check_external` is set, the same
convention the rest of `asr_verify.cpp` uses for anything that needs resolved
externals. They still run on the fully resolved ASR.

Declarations like `character(len=n) :: x` were not affected, because there the
parameter is folded to an `IntegerConstant`. The type-spec is not folded, and a
non-parameter module variable cannot be folded at all. That makes verification
the right place for the fix, not semantics.

## Scope

- `src/libasr/asr_verify.cpp`: guard the String length checks with `check_external`.
- New integration test `modules_73` (+ `modules_73_mod.f90`), which covers both a
  use-imported parameter and a use-imported variable as the length.

## Verification

- `modules_73` fails on `main` with `AssertFailed: e->m_external` and passes on
  this branch (LFortran LLVM); it also passes with GFortran.
- Integration tests: `cd integration_tests && ./run_tests.py -j16`: all pass.
- Reference tests: `./run_tests.py`: all pass.
