### PR TITLE
fix: fold constant substrings only for parameters

### DIFF
--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -2980,6 +2980,7 @@ RUN(NAME string_117 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_118 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_119 LABELS gfortran llvm)
 RUN(NAME string_120 LABELS gfortran llvm)
+RUN(NAME string_121 LABELS gfortran llvm)
 RUN(NAME string_array_concat_01 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 RUN(NAME string_array_concat_02 LABELS gfortran llvm llvm_wasm llvm_wasm_emcc)
 

--- a/integration_tests/string_121.f90
+++ b/integration_tests/string_121.f90
@@ -1,0 +1,32 @@
+program string_121
+! Constant substrings of non-parameter strings must use the current value,
+! not the initializer
+implicit none
+type :: t
+    character(len=4) :: s = "abcd"
+end type
+type(t) :: x
+character(len=4) :: local = "abcd"
+character(len=4), parameter :: c = "efgh"
+character(len=2), parameter :: c2 = c(2:3)
+integer :: i
+
+x%s = "_hid"
+local = "mnop"
+i = 1
+
+print *, x%s(1:1), x%s(i:i), x%s(2:3)
+if (x%s(1:1) /= "_") error stop
+if (x%s(i:i) /= "_") error stop
+if (x%s(2:3) /= "hi") error stop
+
+print *, local(1:1), local(3:4)
+if (local(1:1) /= "m") error stop
+if (local(3:4) /= "op") error stop
+if (len(local(3:1)) /= 0) error stop
+if (local(3:1) /= "") error stop
+
+print *, c(4:4), c2
+if (c(4:4) /= "h") error stop
+if (c2 /= "fg") error stop
+end program

--- a/src/lfortran/semantics/ast_common_visitor.h
+++ b/src/lfortran/semantics/ast_common_visitor.h
@@ -11301,7 +11301,9 @@ public:
                     }
                     if( end == -1 && !flag ) {
                         end = str_length;
-                    } else {
+                    } else if( var->m_storage == ASR::storage_typeType::Parameter ) {
+                        // Only a parameter's value is known at compile time; any
+                        // other variable may have been assigned since initialization.
                         // Substring bounds are character positions. For kind > 1
                         // the value holds UTF-8, so slice whole characters.
                         std::vector<std::string> characters =
@@ -11533,9 +11535,9 @@ public:
                         ASR::expr_t *a_len_expr = nullptr;
                         if (ASRUtils::is_value_constant(r) && 
                             ASRUtils::is_value_constant(l)) {
-                            int64_t a_len_value = ASR::down_cast<ASR::IntegerConstant_t>(ASRUtils::expr_value(r))->m_n -
-                                                  ASR::down_cast<ASR::IntegerConstant_t>(ASRUtils::expr_value(l))->m_n + 
-                                                  1;
+                            int64_t a_len_value = std::max<int64_t>(0,
+                                ASR::down_cast<ASR::IntegerConstant_t>(ASRUtils::expr_value(r))->m_n -
+                                ASR::down_cast<ASR::IntegerConstant_t>(ASRUtils::expr_value(l))->m_n + 1);
                             a_len_expr = ASRUtils::EXPR(ASR::make_IntegerConstant_t(al, loc, a_len_value, int_type));
                         } else {
                             ASRUtils::ASRBuilder b(al, loc);


### PR DESCRIPTION
## Summary

Fixes #12788.

A substring with constant bounds was folded at compile time from the
symbol's initializer whenever that initializer was a string constant. For a
derived type component with default initialization (`x%s(1:1)`), or a local
variable with an initializer that is later reassigned, the initializer is not
the current value, so the substring evaluated to the wrong characters:

```fortran
type :: t
  character(len=2) :: s = "ab"
end type
type(t) :: x
x%s = "xy"
print *, x%s(1:1)   ! printed "a", expected "x"
```

## Scope

- Only fold the substring when the variable is a `parameter`, since only then
  is its value known at compile time. The existing bounds diagnostics are
  unchanged, so no reference outputs change.
- Without the fold, an empty substring such as `s(1:-1)` gets its length from
  the bounds, which produced `-1` and failed ASR verification (`string_31`).
  This already failed on `main` for a variable without an initializer. The
  constant length is now clamped at zero, as the standard requires.

## Verification

- New integration test `string_121` (labels `gfortran llvm`) covers a
  default-initialized component, an initialized local (including an empty
  substring), and parameter substrings (including use in a constant
  expression).
- The test fails on `main` (`a_bc`, then `ERROR STOP`) and passes on this
  branch; output matches gfortran and flang.
- `./run_tests.py`: all reference tests pass, no reference changes.
- `integration_tests/run_tests.py -b llvm` and `-b llvm -f`: 100% tests
  passed, 0 failed out of 4148 in each.
